### PR TITLE
feat: Config-Server/Shard relation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Install tox & poetry
         run: |
           pipx install tox
-          pipx install poetry
+          pipx install "poetry<2.0"
       - name: Set up python environment
         uses: actions/setup-python@v5
         with:
@@ -36,9 +36,36 @@ jobs:
         run: |
           poetry run pre-commit run --all-files
 
-  lint:
-    name: Lint
-    uses: canonical/data-platform-workflows/.github/workflows/lint.yaml@v21.0.0
+  actionlint:
+    name: Lint .github/workflows/
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install actionlint
+        id: install
+        run: |
+          curl -O https://raw.githubusercontent.com/rhysd/actionlint/main/.github/actionlint-matcher.json
+          echo "::add-matcher::actionlint-matcher.json"
+          bash <(curl https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
+      - name: Run actionlint
+        run: |
+          '${{ steps.install.outputs.executable }}' -color
+
+  tox-lint:
+    name: tox run -e lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install tox & poetry
+        run: |
+          pipx install tox
+          pipx install "poetry<2.0"
+      - name: Run linters
+        run: tox run -e lint
 
   unit-test:
     name: Unit test charm
@@ -50,7 +77,7 @@ jobs:
       - name: Install tox & poetry
         run: |
           pipx install tox
-          pipx install poetry
+          pipx install "poetry<2.0"
       - name: Set up python environment
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Install poetry
-        run: pipx install poetry
+        run: pipx install "poetry<2.0"
       - name: Setup python
         uses: actions/setup-python@v5
         with:

--- a/poetry.lock
+++ b/poetry.lock
@@ -13,54 +13,54 @@ files = [
 
 [[package]]
 name = "anyio"
-version = "4.6.2.post1"
+version = "4.8.0"
 description = "High level compatibility layer for multiple asynchronous event loop implementations"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "anyio-4.6.2.post1-py3-none-any.whl", hash = "sha256:6d170c36fba3bdd840c73d3868c1e777e33676a69c3a72cf0a0d5d6d8009b61d"},
-    {file = "anyio-4.6.2.post1.tar.gz", hash = "sha256:4c8bc31ccdb51c7f7bd251f51c609e038d63e34219b44aa86e47576389880b4c"},
+    {file = "anyio-4.8.0-py3-none-any.whl", hash = "sha256:b5011f270ab5eb0abf13385f851315585cc37ef330dd88e27ec3d34d651fd47a"},
+    {file = "anyio-4.8.0.tar.gz", hash = "sha256:1d9fe889df5212298c0c0723fa20479d1b94883a2df44bd3897aa91083316f7a"},
 ]
 
 [package.dependencies]
 exceptiongroup = {version = ">=1.0.2", markers = "python_version < \"3.11\""}
 idna = ">=2.8"
 sniffio = ">=1.1"
-typing-extensions = {version = ">=4.1", markers = "python_version < \"3.11\""}
+typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 
 [package.extras]
-doc = ["Sphinx (>=7.4,<8.0)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx-rtd-theme"]
-test = ["anyio[trio]", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypothesis (>=4.0)", "psutil (>=5.9)", "pytest (>=7.0)", "pytest-mock (>=3.6.1)", "trustme", "truststore (>=0.9.1)", "uvloop (>=0.21.0b1)"]
+doc = ["Sphinx (>=7.4,<8.0)", "packaging", "sphinx-autodoc-typehints (>=1.2.0)", "sphinx_rtd_theme"]
+test = ["anyio[trio]", "coverage[toml] (>=7)", "exceptiongroup (>=1.2.0)", "hypothesis (>=4.0)", "psutil (>=5.9)", "pytest (>=7.0)", "trustme", "truststore (>=0.9.1)", "uvloop (>=0.21)"]
 trio = ["trio (>=0.26.1)"]
 
 [[package]]
 name = "attrs"
-version = "24.2.0"
+version = "24.3.0"
 description = "Classes Without Boilerplate"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 files = [
-    {file = "attrs-24.2.0-py3-none-any.whl", hash = "sha256:81921eb96de3191c8258c199618104dd27ac608d9366f5e35d011eae1867ede2"},
-    {file = "attrs-24.2.0.tar.gz", hash = "sha256:5cfb1b9148b5b086569baec03f20d7b6bf3bcacc9a42bebf87ffaaca362f6346"},
+    {file = "attrs-24.3.0-py3-none-any.whl", hash = "sha256:ac96cd038792094f438ad1f6ff80837353805ac950cd2aa0e0625ef19850c308"},
+    {file = "attrs-24.3.0.tar.gz", hash = "sha256:8f5c07333d543103541ba7be0e2ce16eeee8130cb0b3f9238ab904ce1e85baff"},
 ]
 
 [package.extras]
 benchmark = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4.3.0)", "pytest-codspeed", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
 cov = ["cloudpickle", "coverage[toml] (>=5.3)", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
-dev = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pre-commit", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
+dev = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pre-commit-uv", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
 docs = ["cogapp", "furo", "myst-parser", "sphinx", "sphinx-notfound-page", "sphinxcontrib-towncrier", "towncrier (<24.7)"]
 tests = ["cloudpickle", "hypothesis", "mypy (>=1.11.1)", "pympler", "pytest (>=4.3.0)", "pytest-mypy-plugins", "pytest-xdist[psutil]"]
 tests-mypy = ["mypy (>=1.11.1)", "pytest-mypy-plugins"]
 
 [[package]]
 name = "certifi"
-version = "2024.8.30"
+version = "2024.12.14"
 description = "Python package for providing Mozilla's CA Bundle."
 optional = false
 python-versions = ">=3.6"
 files = [
-    {file = "certifi-2024.8.30-py3-none-any.whl", hash = "sha256:922820b53db7a7257ffbda3f597266d435245903d80737e34f8a45ff3e3230d8"},
-    {file = "certifi-2024.8.30.tar.gz", hash = "sha256:bec941d2aa8195e248a60b31ff9f0558284cf01a52591ceda73ea9afffd69fd9"},
+    {file = "certifi-2024.12.14-py3-none-any.whl", hash = "sha256:1275f7a45be9464efc1173084eaa30f866fe2e47d389406136d332ed4967ec56"},
+    {file = "certifi-2024.12.14.tar.gz", hash = "sha256:b650d30f370c2b724812bee08008be0c4163b163ddaec3f2546c1caf65f191db"},
 ]
 
 [[package]]
@@ -183,73 +183,73 @@ files = [
 
 [[package]]
 name = "coverage"
-version = "7.6.8"
+version = "7.6.10"
 description = "Code coverage measurement for Python"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "coverage-7.6.8-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b39e6011cd06822eb964d038d5dff5da5d98652b81f5ecd439277b32361a3a50"},
-    {file = "coverage-7.6.8-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:63c19702db10ad79151a059d2d6336fe0c470f2e18d0d4d1a57f7f9713875dcf"},
-    {file = "coverage-7.6.8-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3985b9be361d8fb6b2d1adc9924d01dec575a1d7453a14cccd73225cb79243ee"},
-    {file = "coverage-7.6.8-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:644ec81edec0f4ad17d51c838a7d01e42811054543b76d4ba2c5d6af741ce2a6"},
-    {file = "coverage-7.6.8-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1f188a2402f8359cf0c4b1fe89eea40dc13b52e7b4fd4812450da9fcd210181d"},
-    {file = "coverage-7.6.8-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:e19122296822deafce89a0c5e8685704c067ae65d45e79718c92df7b3ec3d331"},
-    {file = "coverage-7.6.8-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:13618bed0c38acc418896005732e565b317aa9e98d855a0e9f211a7ffc2d6638"},
-    {file = "coverage-7.6.8-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:193e3bffca48ad74b8c764fb4492dd875038a2f9925530cb094db92bb5e47bed"},
-    {file = "coverage-7.6.8-cp310-cp310-win32.whl", hash = "sha256:3988665ee376abce49613701336544041f2117de7b7fbfe91b93d8ff8b151c8e"},
-    {file = "coverage-7.6.8-cp310-cp310-win_amd64.whl", hash = "sha256:f56f49b2553d7dd85fd86e029515a221e5c1f8cb3d9c38b470bc38bde7b8445a"},
-    {file = "coverage-7.6.8-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:86cffe9c6dfcfe22e28027069725c7f57f4b868a3f86e81d1c62462764dc46d4"},
-    {file = "coverage-7.6.8-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d82ab6816c3277dc962cfcdc85b1efa0e5f50fb2c449432deaf2398a2928ab94"},
-    {file = "coverage-7.6.8-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:13690e923a3932e4fad4c0ebfb9cb5988e03d9dcb4c5150b5fcbf58fd8bddfc4"},
-    {file = "coverage-7.6.8-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4be32da0c3827ac9132bb488d331cb32e8d9638dd41a0557c5569d57cf22c9c1"},
-    {file = "coverage-7.6.8-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:44e6c85bbdc809383b509d732b06419fb4544dca29ebe18480379633623baafb"},
-    {file = "coverage-7.6.8-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:768939f7c4353c0fac2f7c37897e10b1414b571fd85dd9fc49e6a87e37a2e0d8"},
-    {file = "coverage-7.6.8-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e44961e36cb13c495806d4cac67640ac2866cb99044e210895b506c26ee63d3a"},
-    {file = "coverage-7.6.8-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3ea8bb1ab9558374c0ab591783808511d135a833c3ca64a18ec927f20c4030f0"},
-    {file = "coverage-7.6.8-cp311-cp311-win32.whl", hash = "sha256:629a1ba2115dce8bf75a5cce9f2486ae483cb89c0145795603d6554bdc83e801"},
-    {file = "coverage-7.6.8-cp311-cp311-win_amd64.whl", hash = "sha256:fb9fc32399dca861584d96eccd6c980b69bbcd7c228d06fb74fe53e007aa8ef9"},
-    {file = "coverage-7.6.8-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:e683e6ecc587643f8cde8f5da6768e9d165cd31edf39ee90ed7034f9ca0eefee"},
-    {file = "coverage-7.6.8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1defe91d41ce1bd44b40fabf071e6a01a5aa14de4a31b986aa9dfd1b3e3e414a"},
-    {file = "coverage-7.6.8-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d7ad66e8e50225ebf4236368cc43c37f59d5e6728f15f6e258c8639fa0dd8e6d"},
-    {file = "coverage-7.6.8-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:3fe47da3e4fda5f1abb5709c156eca207eacf8007304ce3019eb001e7a7204cb"},
-    {file = "coverage-7.6.8-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:202a2d645c5a46b84992f55b0a3affe4f0ba6b4c611abec32ee88358db4bb649"},
-    {file = "coverage-7.6.8-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4674f0daa1823c295845b6a740d98a840d7a1c11df00d1fd62614545c1583787"},
-    {file = "coverage-7.6.8-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:74610105ebd6f33d7c10f8907afed696e79c59e3043c5f20eaa3a46fddf33b4c"},
-    {file = "coverage-7.6.8-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:37cda8712145917105e07aab96388ae76e787270ec04bcb9d5cc786d7cbb8443"},
-    {file = "coverage-7.6.8-cp312-cp312-win32.whl", hash = "sha256:9e89d5c8509fbd6c03d0dd1972925b22f50db0792ce06324ba069f10787429ad"},
-    {file = "coverage-7.6.8-cp312-cp312-win_amd64.whl", hash = "sha256:379c111d3558272a2cae3d8e57e6b6e6f4fe652905692d54bad5ea0ca37c5ad4"},
-    {file = "coverage-7.6.8-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0b0c69f4f724c64dfbfe79f5dfb503b42fe6127b8d479b2677f2b227478db2eb"},
-    {file = "coverage-7.6.8-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c15b32a7aca8038ed7644f854bf17b663bc38e1671b5d6f43f9a2b2bd0c46f63"},
-    {file = "coverage-7.6.8-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:63068a11171e4276f6ece913bde059e77c713b48c3a848814a6537f35afb8365"},
-    {file = "coverage-7.6.8-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6f4548c5ead23ad13fb7a2c8ea541357474ec13c2b736feb02e19a3085fac002"},
-    {file = "coverage-7.6.8-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3b4b4299dd0d2c67caaaf286d58aef5e75b125b95615dda4542561a5a566a1e3"},
-    {file = "coverage-7.6.8-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:c9ebfb2507751f7196995142f057d1324afdab56db1d9743aab7f50289abd022"},
-    {file = "coverage-7.6.8-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:c1b4474beee02ede1eef86c25ad4600a424fe36cff01a6103cb4533c6bf0169e"},
-    {file = "coverage-7.6.8-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d9fd2547e6decdbf985d579cf3fc78e4c1d662b9b0ff7cc7862baaab71c9cc5b"},
-    {file = "coverage-7.6.8-cp313-cp313-win32.whl", hash = "sha256:8aae5aea53cbfe024919715eca696b1a3201886ce83790537d1c3668459c7146"},
-    {file = "coverage-7.6.8-cp313-cp313-win_amd64.whl", hash = "sha256:ae270e79f7e169ccfe23284ff5ea2d52a6f401dc01b337efb54b3783e2ce3f28"},
-    {file = "coverage-7.6.8-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:de38add67a0af869b0d79c525d3e4588ac1ffa92f39116dbe0ed9753f26eba7d"},
-    {file = "coverage-7.6.8-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b07c25d52b1c16ce5de088046cd2432b30f9ad5e224ff17c8f496d9cb7d1d451"},
-    {file = "coverage-7.6.8-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:62a66ff235e4c2e37ed3b6104d8b478d767ff73838d1222132a7a026aa548764"},
-    {file = "coverage-7.6.8-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:09b9f848b28081e7b975a3626e9081574a7b9196cde26604540582da60235fdf"},
-    {file = "coverage-7.6.8-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:093896e530c38c8e9c996901858ac63f3d4171268db2c9c8b373a228f459bbc5"},
-    {file = "coverage-7.6.8-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9a7b8ac36fd688c8361cbc7bf1cb5866977ece6e0b17c34aa0df58bda4fa18a4"},
-    {file = "coverage-7.6.8-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:38c51297b35b3ed91670e1e4efb702b790002e3245a28c76e627478aa3c10d83"},
-    {file = "coverage-7.6.8-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:2e4e0f60cb4bd7396108823548e82fdab72d4d8a65e58e2c19bbbc2f1e2bfa4b"},
-    {file = "coverage-7.6.8-cp313-cp313t-win32.whl", hash = "sha256:6535d996f6537ecb298b4e287a855f37deaf64ff007162ec0afb9ab8ba3b8b71"},
-    {file = "coverage-7.6.8-cp313-cp313t-win_amd64.whl", hash = "sha256:c79c0685f142ca53256722a384540832420dff4ab15fec1863d7e5bc8691bdcc"},
-    {file = "coverage-7.6.8-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3ac47fa29d8d41059ea3df65bd3ade92f97ee4910ed638e87075b8e8ce69599e"},
-    {file = "coverage-7.6.8-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:24eda3a24a38157eee639ca9afe45eefa8d2420d49468819ac5f88b10de84f4c"},
-    {file = "coverage-7.6.8-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e4c81ed2820b9023a9a90717020315e63b17b18c274a332e3b6437d7ff70abe0"},
-    {file = "coverage-7.6.8-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:bd55f8fc8fa494958772a2a7302b0354ab16e0b9272b3c3d83cdb5bec5bd1779"},
-    {file = "coverage-7.6.8-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f39e2f3530ed1626c66e7493be7a8423b023ca852aacdc91fb30162c350d2a92"},
-    {file = "coverage-7.6.8-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:716a78a342679cd1177bc8c2fe957e0ab91405bd43a17094324845200b2fddf4"},
-    {file = "coverage-7.6.8-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:177f01eeaa3aee4a5ffb0d1439c5952b53d5010f86e9d2667963e632e30082cc"},
-    {file = "coverage-7.6.8-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:912e95017ff51dc3d7b6e2be158dedc889d9a5cc3382445589ce554f1a34c0ea"},
-    {file = "coverage-7.6.8-cp39-cp39-win32.whl", hash = "sha256:4db3ed6a907b555e57cc2e6f14dc3a4c2458cdad8919e40b5357ab9b6db6c43e"},
-    {file = "coverage-7.6.8-cp39-cp39-win_amd64.whl", hash = "sha256:428ac484592f780e8cd7b6b14eb568f7c85460c92e2a37cb0c0e5186e1a0d076"},
-    {file = "coverage-7.6.8-pp39.pp310-none-any.whl", hash = "sha256:5c52a036535d12590c32c49209e79cabaad9f9ad8aa4cbd875b68c4d67a9cbce"},
-    {file = "coverage-7.6.8.tar.gz", hash = "sha256:8b2b8503edb06822c86d82fa64a4a5cb0760bb8f31f26e138ec743f422f37cfc"},
+    {file = "coverage-7.6.10-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:5c912978f7fbf47ef99cec50c4401340436d200d41d714c7a4766f377c5b7b78"},
+    {file = "coverage-7.6.10-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a01ec4af7dfeb96ff0078ad9a48810bb0cc8abcb0115180c6013a6b26237626c"},
+    {file = "coverage-7.6.10-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a3b204c11e2b2d883946fe1d97f89403aa1811df28ce0447439178cc7463448a"},
+    {file = "coverage-7.6.10-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:32ee6d8491fcfc82652a37109f69dee9a830e9379166cb73c16d8dc5c2915165"},
+    {file = "coverage-7.6.10-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:675cefc4c06e3b4c876b85bfb7c59c5e2218167bbd4da5075cbe3b5790a28988"},
+    {file = "coverage-7.6.10-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:f4f620668dbc6f5e909a0946a877310fb3d57aea8198bde792aae369ee1c23b5"},
+    {file = "coverage-7.6.10-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:4eea95ef275de7abaef630c9b2c002ffbc01918b726a39f5a4353916ec72d2f3"},
+    {file = "coverage-7.6.10-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e2f0280519e42b0a17550072861e0bc8a80a0870de260f9796157d3fca2733c5"},
+    {file = "coverage-7.6.10-cp310-cp310-win32.whl", hash = "sha256:bc67deb76bc3717f22e765ab3e07ee9c7a5e26b9019ca19a3b063d9f4b874244"},
+    {file = "coverage-7.6.10-cp310-cp310-win_amd64.whl", hash = "sha256:0f460286cb94036455e703c66988851d970fdfd8acc2a1122ab7f4f904e4029e"},
+    {file = "coverage-7.6.10-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ea3c8f04b3e4af80e17bab607c386a830ffc2fb88a5484e1df756478cf70d1d3"},
+    {file = "coverage-7.6.10-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:507a20fc863cae1d5720797761b42d2d87a04b3e5aeb682ef3b7332e90598f43"},
+    {file = "coverage-7.6.10-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d37a84878285b903c0fe21ac8794c6dab58150e9359f1aaebbeddd6412d53132"},
+    {file = "coverage-7.6.10-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a534738b47b0de1995f85f582d983d94031dffb48ab86c95bdf88dc62212142f"},
+    {file = "coverage-7.6.10-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0d7a2bf79378d8fb8afaa994f91bfd8215134f8631d27eba3e0e2c13546ce994"},
+    {file = "coverage-7.6.10-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:6713ba4b4ebc330f3def51df1d5d38fad60b66720948112f114968feb52d3f99"},
+    {file = "coverage-7.6.10-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:ab32947f481f7e8c763fa2c92fd9f44eeb143e7610c4ca9ecd6a36adab4081bd"},
+    {file = "coverage-7.6.10-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:7bbd8c8f1b115b892e34ba66a097b915d3871db7ce0e6b9901f462ff3a975377"},
+    {file = "coverage-7.6.10-cp311-cp311-win32.whl", hash = "sha256:299e91b274c5c9cdb64cbdf1b3e4a8fe538a7a86acdd08fae52301b28ba297f8"},
+    {file = "coverage-7.6.10-cp311-cp311-win_amd64.whl", hash = "sha256:489a01f94aa581dbd961f306e37d75d4ba16104bbfa2b0edb21d29b73be83609"},
+    {file = "coverage-7.6.10-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:27c6e64726b307782fa5cbe531e7647aee385a29b2107cd87ba7c0105a5d3853"},
+    {file = "coverage-7.6.10-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c56e097019e72c373bae32d946ecf9858fda841e48d82df7e81c63ac25554078"},
+    {file = "coverage-7.6.10-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c7827a5bc7bdb197b9e066cdf650b2887597ad124dd99777332776f7b7c7d0d0"},
+    {file = "coverage-7.6.10-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:204a8238afe787323a8b47d8be4df89772d5c1e4651b9ffa808552bdf20e1d50"},
+    {file = "coverage-7.6.10-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e67926f51821b8e9deb6426ff3164870976fe414d033ad90ea75e7ed0c2e5022"},
+    {file = "coverage-7.6.10-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e78b270eadb5702938c3dbe9367f878249b5ef9a2fcc5360ac7bff694310d17b"},
+    {file = "coverage-7.6.10-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:714f942b9c15c3a7a5fe6876ce30af831c2ad4ce902410b7466b662358c852c0"},
+    {file = "coverage-7.6.10-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:abb02e2f5a3187b2ac4cd46b8ced85a0858230b577ccb2c62c81482ca7d18852"},
+    {file = "coverage-7.6.10-cp312-cp312-win32.whl", hash = "sha256:55b201b97286cf61f5e76063f9e2a1d8d2972fc2fcfd2c1272530172fd28c359"},
+    {file = "coverage-7.6.10-cp312-cp312-win_amd64.whl", hash = "sha256:e4ae5ac5e0d1e4edfc9b4b57b4cbecd5bc266a6915c500f358817a8496739247"},
+    {file = "coverage-7.6.10-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:05fca8ba6a87aabdd2d30d0b6c838b50510b56cdcfc604d40760dae7153b73d9"},
+    {file = "coverage-7.6.10-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9e80eba8801c386f72e0712a0453431259c45c3249f0009aff537a517b52942b"},
+    {file = "coverage-7.6.10-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a372c89c939d57abe09e08c0578c1d212e7a678135d53aa16eec4430adc5e690"},
+    {file = "coverage-7.6.10-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ec22b5e7fe7a0fa8509181c4aac1db48f3dd4d3a566131b313d1efc102892c18"},
+    {file = "coverage-7.6.10-cp313-cp313-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:26bcf5c4df41cad1b19c84af71c22cbc9ea9a547fc973f1f2cc9a290002c8b3c"},
+    {file = "coverage-7.6.10-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:4e4630c26b6084c9b3cb53b15bd488f30ceb50b73c35c5ad7871b869cb7365fd"},
+    {file = "coverage-7.6.10-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2396e8116db77789f819d2bc8a7e200232b7a282c66e0ae2d2cd84581a89757e"},
+    {file = "coverage-7.6.10-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:79109c70cc0882e4d2d002fe69a24aa504dec0cc17169b3c7f41a1d341a73694"},
+    {file = "coverage-7.6.10-cp313-cp313-win32.whl", hash = "sha256:9e1747bab246d6ff2c4f28b4d186b205adced9f7bd9dc362051cc37c4a0c7bd6"},
+    {file = "coverage-7.6.10-cp313-cp313-win_amd64.whl", hash = "sha256:254f1a3b1eef5f7ed23ef265eaa89c65c8c5b6b257327c149db1ca9d4a35f25e"},
+    {file = "coverage-7.6.10-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2ccf240eb719789cedbb9fd1338055de2761088202a9a0b73032857e53f612fe"},
+    {file = "coverage-7.6.10-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:0c807ca74d5a5e64427c8805de15b9ca140bba13572d6d74e262f46f50b13273"},
+    {file = "coverage-7.6.10-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2bcfa46d7709b5a7ffe089075799b902020b62e7ee56ebaed2f4bdac04c508d8"},
+    {file = "coverage-7.6.10-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4e0de1e902669dccbf80b0415fb6b43d27edca2fbd48c74da378923b05316098"},
+    {file = "coverage-7.6.10-cp313-cp313t-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3f7b444c42bbc533aaae6b5a2166fd1a797cdb5eb58ee51a92bee1eb94a1e1cb"},
+    {file = "coverage-7.6.10-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:b330368cb99ef72fcd2dc3ed260adf67b31499584dc8a20225e85bfe6f6cfed0"},
+    {file = "coverage-7.6.10-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:9a7cfb50515f87f7ed30bc882f68812fd98bc2852957df69f3003d22a2aa0abf"},
+    {file = "coverage-7.6.10-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:6f93531882a5f68c28090f901b1d135de61b56331bba82028489bc51bdd818d2"},
+    {file = "coverage-7.6.10-cp313-cp313t-win32.whl", hash = "sha256:89d76815a26197c858f53c7f6a656686ec392b25991f9e409bcef020cd532312"},
+    {file = "coverage-7.6.10-cp313-cp313t-win_amd64.whl", hash = "sha256:54a5f0f43950a36312155dae55c505a76cd7f2b12d26abeebbe7a0b36dbc868d"},
+    {file = "coverage-7.6.10-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:656c82b8a0ead8bba147de9a89bda95064874c91a3ed43a00e687f23cc19d53a"},
+    {file = "coverage-7.6.10-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:ccc2b70a7ed475c68ceb548bf69cec1e27305c1c2606a5eb7c3afff56a1b3b27"},
+    {file = "coverage-7.6.10-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a5e37dc41d57ceba70956fa2fc5b63c26dba863c946ace9705f8eca99daecdc4"},
+    {file = "coverage-7.6.10-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0aa9692b4fdd83a4647eeb7db46410ea1322b5ed94cd1715ef09d1d5922ba87f"},
+    {file = "coverage-7.6.10-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:aa744da1820678b475e4ba3dfd994c321c5b13381d1041fe9c608620e6676e25"},
+    {file = "coverage-7.6.10-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:c0b1818063dc9e9d838c09e3a473c1422f517889436dd980f5d721899e66f315"},
+    {file = "coverage-7.6.10-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:59af35558ba08b758aec4d56182b222976330ef8d2feacbb93964f576a7e7a90"},
+    {file = "coverage-7.6.10-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:7ed2f37cfce1ce101e6dffdfd1c99e729dd2ffc291d02d3e2d0af8b53d13840d"},
+    {file = "coverage-7.6.10-cp39-cp39-win32.whl", hash = "sha256:4bcc276261505d82f0ad426870c3b12cb177752834a633e737ec5ee79bbdff18"},
+    {file = "coverage-7.6.10-cp39-cp39-win_amd64.whl", hash = "sha256:457574f4599d2b00f7f637a0700a6422243b3565509457b2dbd3f50703e11f59"},
+    {file = "coverage-7.6.10-pp39.pp310-none-any.whl", hash = "sha256:fd34e7b3405f0cc7ab03d54a334c17a9e802897580d964bd8c2001f4b9fd488f"},
+    {file = "coverage-7.6.10.tar.gz", hash = "sha256:7fb105327c8f8f0682e29843e2ff96af9dcbe5bab8eeb4b398c6a33a16d80a23"},
 ]
 
 [package.dependencies]
@@ -390,13 +390,13 @@ doc = ["Sphinx", "sphinx-rtd-theme", "sphinxcontrib-spelling"]
 
 [[package]]
 name = "faker"
-version = "33.1.0"
+version = "33.3.0"
 description = "Faker is a Python package that generates fake data for you."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "Faker-33.1.0-py3-none-any.whl", hash = "sha256:d30c5f0e2796b8970de68978365247657486eb0311c5abe88d0b895b68dff05d"},
-    {file = "faker-33.1.0.tar.gz", hash = "sha256:1c925fc0e86a51fc46648b504078c88d0cd48da1da2595c4e712841cab43a1e4"},
+    {file = "Faker-33.3.0-py3-none-any.whl", hash = "sha256:ae074d9c7ef65817a93b448141a5531a16b2ea2e563dc5774578197c7c84060c"},
+    {file = "faker-33.3.0.tar.gz", hash = "sha256:2abb551a05b75d268780b6095100a48afc43c53e97422002efbfc1272ebf5f26"},
 ]
 
 [package.dependencies]
@@ -453,13 +453,13 @@ trio = ["trio (>=0.22.0,<1.0)"]
 
 [[package]]
 name = "httpx"
-version = "0.28.0"
+version = "0.28.1"
 description = "The next generation HTTP client."
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "httpx-0.28.0-py3-none-any.whl", hash = "sha256:dc0b419a0cfeb6e8b34e85167c0da2671206f5095f1baa9663d23bcfd6b535fc"},
-    {file = "httpx-0.28.0.tar.gz", hash = "sha256:0858d3bab51ba7e386637f22a61d8ccddaeec5f3fe4209da3a6168dbb91573e0"},
+    {file = "httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad"},
+    {file = "httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc"},
 ]
 
 [package.dependencies]
@@ -477,13 +477,13 @@ zstd = ["zstandard (>=0.18.0)"]
 
 [[package]]
 name = "identify"
-version = "2.6.3"
+version = "2.6.5"
 description = "File identification library for Python"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "identify-2.6.3-py2.py3-none-any.whl", hash = "sha256:9edba65473324c2ea9684b1f944fe3191db3345e50b6d04571d10ed164f8d7bd"},
-    {file = "identify-2.6.3.tar.gz", hash = "sha256:62f5dae9b5fef52c84cc188514e9ea4f3f636b1d8799ab5ebc475471f9e47a02"},
+    {file = "identify-2.6.5-py2.py3-none-any.whl", hash = "sha256:14181a47091eb75b337af4c23078c9d09225cd4c48929f521f3bf16b09d02566"},
+    {file = "identify-2.6.5.tar.gz", hash = "sha256:c10b33f250e5bba374fae86fb57f3adcebf1161bce7cdf92031915fd480c13bc"},
 ]
 
 [package.extras]
@@ -516,13 +516,13 @@ files = [
 
 [[package]]
 name = "jinja2"
-version = "3.1.4"
+version = "3.1.5"
 description = "A very fast and expressive template engine."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "jinja2-3.1.4-py3-none-any.whl", hash = "sha256:bc5dd2abb727a5319567b7a813e6a2e7318c39f4f487cfe6c89c6f9c7d25197d"},
-    {file = "jinja2-3.1.4.tar.gz", hash = "sha256:4a3aee7acbbe7303aede8e9648d13b8bf88a429282aa6122a993f0ac800cb369"},
+    {file = "jinja2-3.1.5-py3-none-any.whl", hash = "sha256:aba0f4dc9ed8013c424088f68a5c226f7d6097ed89b246d7749c2ec4175c6adb"},
+    {file = "jinja2-3.1.5.tar.gz", hash = "sha256:8fefff8dc3034e27bb80d67c671eb8a9bc424c0ef4c0826edbff304cceff43bb"},
 ]
 
 [package.dependencies]
@@ -568,32 +568,32 @@ referencing = ">=0.31.0"
 
 [[package]]
 name = "lightkube"
-version = "0.15.5"
+version = "0.16.2"
 description = "Lightweight kubernetes client library"
 optional = false
 python-versions = "*"
 files = [
-    {file = "lightkube-0.15.5-py3-none-any.whl", hash = "sha256:0d93be743cbeae022d18a1d3fbb45d1df58f9a603ea0061237842658f68d93fd"},
-    {file = "lightkube-0.15.5.tar.gz", hash = "sha256:5edbfd1aee83398374179f41f4897519e8f89dc9754c866d40bbdc68c49c033f"},
+    {file = "lightkube-0.16.2-py3-none-any.whl", hash = "sha256:61a1477eba728207f511febc27165d22e5cae34ff8cb342ae35360c969d02a59"},
+    {file = "lightkube-0.16.2.tar.gz", hash = "sha256:f6807fe72cee1a82788f0e066b5b2ef28be32756eded68421a785401c39236f1"},
 ]
 
 [package.dependencies]
-httpx = ">=0.24.0"
+httpx = ">=0.24.0,<1.0.0"
 lightkube-models = ">=1.15.12.0"
 PyYAML = "*"
 
 [package.extras]
-dev = ["pytest", "pytest-asyncio (<0.17.0)", "respx"]
+dev = ["pytest", "pytest-asyncio", "respx"]
 
 [[package]]
 name = "lightkube-models"
-version = "1.31.1.8"
+version = "1.32.0.8"
 description = "Models and Resources for lightkube module"
 optional = false
 python-versions = "*"
 files = [
-    {file = "lightkube-models-1.31.1.8.tar.gz", hash = "sha256:14fbfa990b4d3393fa4ac3e9e46d67514c4d659508e296b30f1a5d254eecc097"},
-    {file = "lightkube_models-1.31.1.8-py3-none-any.whl", hash = "sha256:50c0e2dd2c125cd9b50e93269e2d212bcbec19f7b00de91aa66a5ec320772fae"},
+    {file = "lightkube-models-1.32.0.8.tar.gz", hash = "sha256:97f6c2ab554a23a69554dd56ffbd94173fb416af6490c3a21b1e0b8e13a2bafe"},
+    {file = "lightkube_models-1.32.0.8-py3-none-any.whl", hash = "sha256:73786dac63085521f4c88aa69d86bfdc76a67da997c1770e5bdcef8482e4b2a0"},
 ]
 
 [[package]]
@@ -688,49 +688,55 @@ pymongo = ["pymongo"]
 
 [[package]]
 name = "mypy"
-version = "1.13.0"
+version = "1.14.1"
 description = "Optional static typing for Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "mypy-1.13.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:6607e0f1dd1fb7f0aca14d936d13fd19eba5e17e1cd2a14f808fa5f8f6d8f60a"},
-    {file = "mypy-1.13.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:8a21be69bd26fa81b1f80a61ee7ab05b076c674d9b18fb56239d72e21d9f4c80"},
-    {file = "mypy-1.13.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b2353a44d2179846a096e25691d54d59904559f4232519d420d64da6828a3a7"},
-    {file = "mypy-1.13.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:0730d1c6a2739d4511dc4253f8274cdd140c55c32dfb0a4cf8b7a43f40abfa6f"},
-    {file = "mypy-1.13.0-cp310-cp310-win_amd64.whl", hash = "sha256:c5fc54dbb712ff5e5a0fca797e6e0aa25726c7e72c6a5850cfd2adbc1eb0a372"},
-    {file = "mypy-1.13.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:581665e6f3a8a9078f28d5502f4c334c0c8d802ef55ea0e7276a6e409bc0d82d"},
-    {file = "mypy-1.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:3ddb5b9bf82e05cc9a627e84707b528e5c7caaa1c55c69e175abb15a761cec2d"},
-    {file = "mypy-1.13.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:20c7ee0bc0d5a9595c46f38beb04201f2620065a93755704e141fcac9f59db2b"},
-    {file = "mypy-1.13.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:3790ded76f0b34bc9c8ba4def8f919dd6a46db0f5a6610fb994fe8efdd447f73"},
-    {file = "mypy-1.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:51f869f4b6b538229c1d1bcc1dd7d119817206e2bc54e8e374b3dfa202defcca"},
-    {file = "mypy-1.13.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:5c7051a3461ae84dfb5dd15eff5094640c61c5f22257c8b766794e6dd85e72d5"},
-    {file = "mypy-1.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:39bb21c69a5d6342f4ce526e4584bc5c197fd20a60d14a8624d8743fffb9472e"},
-    {file = "mypy-1.13.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:164f28cb9d6367439031f4c81e84d3ccaa1e19232d9d05d37cb0bd880d3f93c2"},
-    {file = "mypy-1.13.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:a4c1bfcdbce96ff5d96fc9b08e3831acb30dc44ab02671eca5953eadad07d6d0"},
-    {file = "mypy-1.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:a0affb3a79a256b4183ba09811e3577c5163ed06685e4d4b46429a271ba174d2"},
-    {file = "mypy-1.13.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a7b44178c9760ce1a43f544e595d35ed61ac2c3de306599fa59b38a6048e1aa7"},
-    {file = "mypy-1.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5d5092efb8516d08440e36626f0153b5006d4088c1d663d88bf79625af3d1d62"},
-    {file = "mypy-1.13.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:de2904956dac40ced10931ac967ae63c5089bd498542194b436eb097a9f77bc8"},
-    {file = "mypy-1.13.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:7bfd8836970d33c2105562650656b6846149374dc8ed77d98424b40b09340ba7"},
-    {file = "mypy-1.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:9f73dba9ec77acb86457a8fc04b5239822df0c14a082564737833d2963677dbc"},
-    {file = "mypy-1.13.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:100fac22ce82925f676a734af0db922ecfea991e1d7ec0ceb1e115ebe501301a"},
-    {file = "mypy-1.13.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7bcb0bb7f42a978bb323a7c88f1081d1b5dee77ca86f4100735a6f541299d8fb"},
-    {file = "mypy-1.13.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bde31fc887c213e223bbfc34328070996061b0833b0a4cfec53745ed61f3519b"},
-    {file = "mypy-1.13.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:07de989f89786f62b937851295ed62e51774722e5444a27cecca993fc3f9cd74"},
-    {file = "mypy-1.13.0-cp38-cp38-win_amd64.whl", hash = "sha256:4bde84334fbe19bad704b3f5b78c4abd35ff1026f8ba72b29de70dda0916beb6"},
-    {file = "mypy-1.13.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:0246bcb1b5de7f08f2826451abd947bf656945209b140d16ed317f65a17dc7dc"},
-    {file = "mypy-1.13.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7f5b7deae912cf8b77e990b9280f170381fdfbddf61b4ef80927edd813163732"},
-    {file = "mypy-1.13.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7029881ec6ffb8bc233a4fa364736789582c738217b133f1b55967115288a2bc"},
-    {file = "mypy-1.13.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:3e38b980e5681f28f033f3be86b099a247b13c491f14bb8b1e1e134d23bb599d"},
-    {file = "mypy-1.13.0-cp39-cp39-win_amd64.whl", hash = "sha256:a6789be98a2017c912ae6ccb77ea553bbaf13d27605d2ca20a76dfbced631b24"},
-    {file = "mypy-1.13.0-py3-none-any.whl", hash = "sha256:9c250883f9fd81d212e0952c92dbfcc96fc237f4b7c92f56ac81fd48460b3e5a"},
-    {file = "mypy-1.13.0.tar.gz", hash = "sha256:0291a61b6fbf3e6673e3405cfcc0e7650bebc7939659fdca2702958038bd835e"},
+    {file = "mypy-1.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:52686e37cf13d559f668aa398dd7ddf1f92c5d613e4f8cb262be2fb4fedb0fcb"},
+    {file = "mypy-1.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:1fb545ca340537d4b45d3eecdb3def05e913299ca72c290326be19b3804b39c0"},
+    {file = "mypy-1.14.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:90716d8b2d1f4cd503309788e51366f07c56635a3309b0f6a32547eaaa36a64d"},
+    {file = "mypy-1.14.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2ae753f5c9fef278bcf12e1a564351764f2a6da579d4a81347e1d5a15819997b"},
+    {file = "mypy-1.14.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e0fe0f5feaafcb04505bcf439e991c6d8f1bf8b15f12b05feeed96e9e7bf1427"},
+    {file = "mypy-1.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:7d54bd85b925e501c555a3227f3ec0cfc54ee8b6930bd6141ec872d1c572f81f"},
+    {file = "mypy-1.14.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f995e511de847791c3b11ed90084a7a0aafdc074ab88c5a9711622fe4751138c"},
+    {file = "mypy-1.14.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:d64169ec3b8461311f8ce2fd2eb5d33e2d0f2c7b49116259c51d0d96edee48d1"},
+    {file = "mypy-1.14.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba24549de7b89b6381b91fbc068d798192b1b5201987070319889e93038967a8"},
+    {file = "mypy-1.14.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:183cf0a45457d28ff9d758730cd0210419ac27d4d3f285beda038c9083363b1f"},
+    {file = "mypy-1.14.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:f2a0ecc86378f45347f586e4163d1769dd81c5a223d577fe351f26b179e148b1"},
+    {file = "mypy-1.14.1-cp311-cp311-win_amd64.whl", hash = "sha256:ad3301ebebec9e8ee7135d8e3109ca76c23752bac1e717bc84cd3836b4bf3eae"},
+    {file = "mypy-1.14.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:30ff5ef8519bbc2e18b3b54521ec319513a26f1bba19a7582e7b1f58a6e69f14"},
+    {file = "mypy-1.14.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:cb9f255c18052343c70234907e2e532bc7e55a62565d64536dbc7706a20b78b9"},
+    {file = "mypy-1.14.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b4e3413e0bddea671012b063e27591b953d653209e7a4fa5e48759cda77ca11"},
+    {file = "mypy-1.14.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:553c293b1fbdebb6c3c4030589dab9fafb6dfa768995a453d8a5d3b23784af2e"},
+    {file = "mypy-1.14.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fad79bfe3b65fe6a1efaed97b445c3d37f7be9fdc348bdb2d7cac75579607c89"},
+    {file = "mypy-1.14.1-cp312-cp312-win_amd64.whl", hash = "sha256:8fa2220e54d2946e94ab6dbb3ba0a992795bd68b16dc852db33028df2b00191b"},
+    {file = "mypy-1.14.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:92c3ed5afb06c3a8e188cb5da4984cab9ec9a77ba956ee419c68a388b4595255"},
+    {file = "mypy-1.14.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:dbec574648b3e25f43d23577309b16534431db4ddc09fda50841f1e34e64ed34"},
+    {file = "mypy-1.14.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8c6d94b16d62eb3e947281aa7347d78236688e21081f11de976376cf010eb31a"},
+    {file = "mypy-1.14.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d4b19b03fdf54f3c5b2fa474c56b4c13c9dbfb9a2db4370ede7ec11a2c5927d9"},
+    {file = "mypy-1.14.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0c911fde686394753fff899c409fd4e16e9b294c24bfd5e1ea4675deae1ac6fd"},
+    {file = "mypy-1.14.1-cp313-cp313-win_amd64.whl", hash = "sha256:8b21525cb51671219f5307be85f7e646a153e5acc656e5cebf64bfa076c50107"},
+    {file = "mypy-1.14.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:7084fb8f1128c76cd9cf68fe5971b37072598e7c31b2f9f95586b65c741a9d31"},
+    {file = "mypy-1.14.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:8f845a00b4f420f693f870eaee5f3e2692fa84cc8514496114649cfa8fd5e2c6"},
+    {file = "mypy-1.14.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:44bf464499f0e3a2d14d58b54674dee25c031703b2ffc35064bd0df2e0fac319"},
+    {file = "mypy-1.14.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c99f27732c0b7dc847adb21c9d47ce57eb48fa33a17bc6d7d5c5e9f9e7ae5bac"},
+    {file = "mypy-1.14.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:bce23c7377b43602baa0bd22ea3265c49b9ff0b76eb315d6c34721af4cdf1d9b"},
+    {file = "mypy-1.14.1-cp38-cp38-win_amd64.whl", hash = "sha256:8edc07eeade7ebc771ff9cf6b211b9a7d93687ff892150cb5692e4f4272b0837"},
+    {file = "mypy-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3888a1816d69f7ab92092f785a462944b3ca16d7c470d564165fe703b0970c35"},
+    {file = "mypy-1.14.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:46c756a444117c43ee984bd055db99e498bc613a70bbbc120272bd13ca579fbc"},
+    {file = "mypy-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:27fc248022907e72abfd8e22ab1f10e903915ff69961174784a3900a8cba9ad9"},
+    {file = "mypy-1.14.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:499d6a72fb7e5de92218db961f1a66d5f11783f9ae549d214617edab5d4dbdbb"},
+    {file = "mypy-1.14.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:57961db9795eb566dc1d1b4e9139ebc4c6b0cb6e7254ecde69d1552bf7613f60"},
+    {file = "mypy-1.14.1-cp39-cp39-win_amd64.whl", hash = "sha256:07ba89fdcc9451f2ebb02853deb6aaaa3d2239a236669a63ab3801bbf923ef5c"},
+    {file = "mypy-1.14.1-py3-none-any.whl", hash = "sha256:b66a60cc4073aeb8ae00057f9c1f64d49e90f918fbcef9a977eb121da8b8f1d1"},
+    {file = "mypy-1.14.1.tar.gz", hash = "sha256:7ec88144fe9b510e8475ec2f5f251992690fcf89ccb4500b214b4226abcd32d6"},
 ]
 
 [package.dependencies]
-mypy-extensions = ">=1.0.0"
+mypy_extensions = ">=1.0.0"
 tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
-typing-extensions = ">=4.6.0"
+typing_extensions = ">=4.6.0"
 
 [package.extras]
 dmypy = ["psutil (>=4.0)"]
@@ -1012,13 +1018,13 @@ typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
 name = "pydantic-settings"
-version = "2.6.1"
+version = "2.7.1"
 description = "Settings management using Pydantic"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pydantic_settings-2.6.1-py3-none-any.whl", hash = "sha256:7fb0637c786a558d3103436278a7c4f1cfd29ba8973238a50c5bb9a55387da87"},
-    {file = "pydantic_settings-2.6.1.tar.gz", hash = "sha256:e0f92546d8a9923cb8941689abf85d6601a8c19a23e97a34b2964a2e3f813ca0"},
+    {file = "pydantic_settings-2.7.1-py3-none-any.whl", hash = "sha256:590be9e6e24d06db33a4262829edef682500ef008565a969c73d39d5f8bfb3fd"},
+    {file = "pydantic_settings-2.7.1.tar.gz", hash = "sha256:10c9caad35e64bfb3c2fbf70a078c0e25cc92499782e5200747f942a065dec93"},
 ]
 
 [package.dependencies]
@@ -1131,13 +1137,13 @@ test = ["pretend", "pytest (>=3.0.1)", "pytest-rerunfailures"]
 
 [[package]]
 name = "pytest"
-version = "8.3.3"
+version = "8.3.4"
 description = "pytest: simple powerful testing with Python"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "pytest-8.3.3-py3-none-any.whl", hash = "sha256:a6853c7375b2663155079443d2e45de913a911a11d669df02a50814944db57b2"},
-    {file = "pytest-8.3.3.tar.gz", hash = "sha256:70b98107bd648308a7952b06e6ca9a50bc660be218d53c257cc1fc94fda10181"},
+    {file = "pytest-8.3.4-py3-none-any.whl", hash = "sha256:50e16d954148559c9a74109af1eaf0c945ba2d8f30f0a3d3335edde19788b6f6"},
+    {file = "pytest-8.3.4.tar.gz", hash = "sha256:965370d062bce11e73868e0335abac31b4d3de0e82f4007408d242b4f8610761"},
 ]
 
 [package.dependencies]
@@ -1286,101 +1292,114 @@ rpds-py = ">=0.7.0"
 
 [[package]]
 name = "rpds-py"
-version = "0.21.0"
+version = "0.22.3"
 description = "Python bindings to Rust's persistent data structures (rpds)"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "rpds_py-0.21.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:a017f813f24b9df929674d0332a374d40d7f0162b326562daae8066b502d0590"},
-    {file = "rpds_py-0.21.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:20cc1ed0bcc86d8e1a7e968cce15be45178fd16e2ff656a243145e0b439bd250"},
-    {file = "rpds_py-0.21.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad116dda078d0bc4886cb7840e19811562acdc7a8e296ea6ec37e70326c1b41c"},
-    {file = "rpds_py-0.21.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:808f1ac7cf3b44f81c9475475ceb221f982ef548e44e024ad5f9e7060649540e"},
-    {file = "rpds_py-0.21.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de552f4a1916e520f2703ec474d2b4d3f86d41f353e7680b597512ffe7eac5d0"},
-    {file = "rpds_py-0.21.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:efec946f331349dfc4ae9d0e034c263ddde19414fe5128580f512619abed05f1"},
-    {file = "rpds_py-0.21.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b80b4690bbff51a034bfde9c9f6bf9357f0a8c61f548942b80f7b66356508bf5"},
-    {file = "rpds_py-0.21.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:085ed25baac88953d4283e5b5bd094b155075bb40d07c29c4f073e10623f9f2e"},
-    {file = "rpds_py-0.21.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:daa8efac2a1273eed2354397a51216ae1e198ecbce9036fba4e7610b308b6153"},
-    {file = "rpds_py-0.21.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:95a5bad1ac8a5c77b4e658671642e4af3707f095d2b78a1fdd08af0dfb647624"},
-    {file = "rpds_py-0.21.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:3e53861b29a13d5b70116ea4230b5f0f3547b2c222c5daa090eb7c9c82d7f664"},
-    {file = "rpds_py-0.21.0-cp310-none-win32.whl", hash = "sha256:ea3a6ac4d74820c98fcc9da4a57847ad2cc36475a8bd9683f32ab6d47a2bd682"},
-    {file = "rpds_py-0.21.0-cp310-none-win_amd64.whl", hash = "sha256:b8f107395f2f1d151181880b69a2869c69e87ec079c49c0016ab96860b6acbe5"},
-    {file = "rpds_py-0.21.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:5555db3e618a77034954b9dc547eae94166391a98eb867905ec8fcbce1308d95"},
-    {file = "rpds_py-0.21.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:97ef67d9bbc3e15584c2f3c74bcf064af36336c10d2e21a2131e123ce0f924c9"},
-    {file = "rpds_py-0.21.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4ab2c2a26d2f69cdf833174f4d9d86118edc781ad9a8fa13970b527bf8236027"},
-    {file = "rpds_py-0.21.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4e8921a259f54bfbc755c5bbd60c82bb2339ae0324163f32868f63f0ebb873d9"},
-    {file = "rpds_py-0.21.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8a7ff941004d74d55a47f916afc38494bd1cfd4b53c482b77c03147c91ac0ac3"},
-    {file = "rpds_py-0.21.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5145282a7cd2ac16ea0dc46b82167754d5e103a05614b724457cffe614f25bd8"},
-    {file = "rpds_py-0.21.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de609a6f1b682f70bb7163da745ee815d8f230d97276db049ab447767466a09d"},
-    {file = "rpds_py-0.21.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:40c91c6e34cf016fa8e6b59d75e3dbe354830777fcfd74c58b279dceb7975b75"},
-    {file = "rpds_py-0.21.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d2132377f9deef0c4db89e65e8bb28644ff75a18df5293e132a8d67748397b9f"},
-    {file = "rpds_py-0.21.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:0a9e0759e7be10109645a9fddaaad0619d58c9bf30a3f248a2ea57a7c417173a"},
-    {file = "rpds_py-0.21.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9e20da3957bdf7824afdd4b6eeb29510e83e026473e04952dca565170cd1ecc8"},
-    {file = "rpds_py-0.21.0-cp311-none-win32.whl", hash = "sha256:f71009b0d5e94c0e86533c0b27ed7cacc1239cb51c178fd239c3cfefefb0400a"},
-    {file = "rpds_py-0.21.0-cp311-none-win_amd64.whl", hash = "sha256:e168afe6bf6ab7ab46c8c375606298784ecbe3ba31c0980b7dcbb9631dcba97e"},
-    {file = "rpds_py-0.21.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:30b912c965b2aa76ba5168fd610087bad7fcde47f0a8367ee8f1876086ee6d1d"},
-    {file = "rpds_py-0.21.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ca9989d5d9b1b300bc18e1801c67b9f6d2c66b8fd9621b36072ed1df2c977f72"},
-    {file = "rpds_py-0.21.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6f54e7106f0001244a5f4cf810ba8d3f9c542e2730821b16e969d6887b664266"},
-    {file = "rpds_py-0.21.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fed5dfefdf384d6fe975cc026886aece4f292feaf69d0eeb716cfd3c5a4dd8be"},
-    {file = "rpds_py-0.21.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:590ef88db231c9c1eece44dcfefd7515d8bf0d986d64d0caf06a81998a9e8cab"},
-    {file = "rpds_py-0.21.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f983e4c2f603c95dde63df633eec42955508eefd8d0f0e6d236d31a044c882d7"},
-    {file = "rpds_py-0.21.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b229ce052ddf1a01c67d68166c19cb004fb3612424921b81c46e7ea7ccf7c3bf"},
-    {file = "rpds_py-0.21.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ebf64e281a06c904a7636781d2e973d1f0926a5b8b480ac658dc0f556e7779f4"},
-    {file = "rpds_py-0.21.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:998a8080c4495e4f72132f3d66ff91f5997d799e86cec6ee05342f8f3cda7dca"},
-    {file = "rpds_py-0.21.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:98486337f7b4f3c324ab402e83453e25bb844f44418c066623db88e4c56b7c7b"},
-    {file = "rpds_py-0.21.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a78d8b634c9df7f8d175451cfeac3810a702ccb85f98ec95797fa98b942cea11"},
-    {file = "rpds_py-0.21.0-cp312-none-win32.whl", hash = "sha256:a58ce66847711c4aa2ecfcfaff04cb0327f907fead8945ffc47d9407f41ff952"},
-    {file = "rpds_py-0.21.0-cp312-none-win_amd64.whl", hash = "sha256:e860f065cc4ea6f256d6f411aba4b1251255366e48e972f8a347cf88077b24fd"},
-    {file = "rpds_py-0.21.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:ee4eafd77cc98d355a0d02f263efc0d3ae3ce4a7c24740010a8b4012bbb24937"},
-    {file = "rpds_py-0.21.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:688c93b77e468d72579351a84b95f976bd7b3e84aa6686be6497045ba84be560"},
-    {file = "rpds_py-0.21.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c38dbf31c57032667dd5a2f0568ccde66e868e8f78d5a0d27dcc56d70f3fcd3b"},
-    {file = "rpds_py-0.21.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2d6129137f43f7fa02d41542ffff4871d4aefa724a5fe38e2c31a4e0fd343fb0"},
-    {file = "rpds_py-0.21.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:520ed8b99b0bf86a176271f6fe23024323862ac674b1ce5b02a72bfeff3fff44"},
-    {file = "rpds_py-0.21.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:aaeb25ccfb9b9014a10eaf70904ebf3f79faaa8e60e99e19eef9f478651b9b74"},
-    {file = "rpds_py-0.21.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:af04ac89c738e0f0f1b913918024c3eab6e3ace989518ea838807177d38a2e94"},
-    {file = "rpds_py-0.21.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b9b76e2afd585803c53c5b29e992ecd183f68285b62fe2668383a18e74abe7a3"},
-    {file = "rpds_py-0.21.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5afb5efde74c54724e1a01118c6e5c15e54e642c42a1ba588ab1f03544ac8c7a"},
-    {file = "rpds_py-0.21.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:52c041802a6efa625ea18027a0723676a778869481d16803481ef6cc02ea8cb3"},
-    {file = "rpds_py-0.21.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ee1e4fc267b437bb89990b2f2abf6c25765b89b72dd4a11e21934df449e0c976"},
-    {file = "rpds_py-0.21.0-cp313-none-win32.whl", hash = "sha256:0c025820b78817db6a76413fff6866790786c38f95ea3f3d3c93dbb73b632202"},
-    {file = "rpds_py-0.21.0-cp313-none-win_amd64.whl", hash = "sha256:320c808df533695326610a1b6a0a6e98f033e49de55d7dc36a13c8a30cfa756e"},
-    {file = "rpds_py-0.21.0-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:2c51d99c30091f72a3c5d126fad26236c3f75716b8b5e5cf8effb18889ced928"},
-    {file = "rpds_py-0.21.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:cbd7504a10b0955ea287114f003b7ad62330c9e65ba012c6223dba646f6ffd05"},
-    {file = "rpds_py-0.21.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6dcc4949be728ede49e6244eabd04064336012b37f5c2200e8ec8eb2988b209c"},
-    {file = "rpds_py-0.21.0-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f414da5c51bf350e4b7960644617c130140423882305f7574b6cf65a3081cecb"},
-    {file = "rpds_py-0.21.0-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9afe42102b40007f588666bc7de82451e10c6788f6f70984629db193849dced1"},
-    {file = "rpds_py-0.21.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3b929c2bb6e29ab31f12a1117c39f7e6d6450419ab7464a4ea9b0b417174f044"},
-    {file = "rpds_py-0.21.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8404b3717da03cbf773a1d275d01fec84ea007754ed380f63dfc24fb76ce4592"},
-    {file = "rpds_py-0.21.0-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e12bb09678f38b7597b8346983d2323a6482dcd59e423d9448108c1be37cac9d"},
-    {file = "rpds_py-0.21.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:58a0e345be4b18e6b8501d3b0aa540dad90caeed814c515e5206bb2ec26736fd"},
-    {file = "rpds_py-0.21.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:c3761f62fcfccf0864cc4665b6e7c3f0c626f0380b41b8bd1ce322103fa3ef87"},
-    {file = "rpds_py-0.21.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:c2b2f71c6ad6c2e4fc9ed9401080badd1469fa9889657ec3abea42a3d6b2e1ed"},
-    {file = "rpds_py-0.21.0-cp39-none-win32.whl", hash = "sha256:b21747f79f360e790525e6f6438c7569ddbfb1b3197b9e65043f25c3c9b489d8"},
-    {file = "rpds_py-0.21.0-cp39-none-win_amd64.whl", hash = "sha256:0626238a43152918f9e72ede9a3b6ccc9e299adc8ade0d67c5e142d564c9a83d"},
-    {file = "rpds_py-0.21.0-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:6b4ef7725386dc0762857097f6b7266a6cdd62bfd209664da6712cb26acef035"},
-    {file = "rpds_py-0.21.0-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:6bc0e697d4d79ab1aacbf20ee5f0df80359ecf55db33ff41481cf3e24f206919"},
-    {file = "rpds_py-0.21.0-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:da52d62a96e61c1c444f3998c434e8b263c384f6d68aca8274d2e08d1906325c"},
-    {file = "rpds_py-0.21.0-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:98e4fe5db40db87ce1c65031463a760ec7906ab230ad2249b4572c2fc3ef1f9f"},
-    {file = "rpds_py-0.21.0-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:30bdc973f10d28e0337f71d202ff29345320f8bc49a31c90e6c257e1ccef4333"},
-    {file = "rpds_py-0.21.0-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:faa5e8496c530f9c71f2b4e1c49758b06e5f4055e17144906245c99fa6d45356"},
-    {file = "rpds_py-0.21.0-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:32eb88c30b6a4f0605508023b7141d043a79b14acb3b969aa0b4f99b25bc7d4a"},
-    {file = "rpds_py-0.21.0-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a89a8ce9e4e75aeb7fa5d8ad0f3fecdee813802592f4f46a15754dcb2fd6b061"},
-    {file = "rpds_py-0.21.0-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:241e6c125568493f553c3d0fdbb38c74babf54b45cef86439d4cd97ff8feb34d"},
-    {file = "rpds_py-0.21.0-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:3b766a9f57663396e4f34f5140b3595b233a7b146e94777b97a8413a1da1be18"},
-    {file = "rpds_py-0.21.0-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:af4a644bf890f56e41e74be7d34e9511e4954894d544ec6b8efe1e21a1a8da6c"},
-    {file = "rpds_py-0.21.0-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:3e30a69a706e8ea20444b98a49f386c17b26f860aa9245329bab0851ed100677"},
-    {file = "rpds_py-0.21.0-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:031819f906bb146561af051c7cef4ba2003d28cff07efacef59da973ff7969ba"},
-    {file = "rpds_py-0.21.0-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:b876f2bc27ab5954e2fd88890c071bd0ed18b9c50f6ec3de3c50a5ece612f7a6"},
-    {file = "rpds_py-0.21.0-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dc5695c321e518d9f03b7ea6abb5ea3af4567766f9852ad1560f501b17588c7b"},
-    {file = "rpds_py-0.21.0-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b4de1da871b5c0fd5537b26a6fc6814c3cc05cabe0c941db6e9044ffbb12f04a"},
-    {file = "rpds_py-0.21.0-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:878f6fea96621fda5303a2867887686d7a198d9e0f8a40be100a63f5d60c88c9"},
-    {file = "rpds_py-0.21.0-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a8eeec67590e94189f434c6d11c426892e396ae59e4801d17a93ac96b8c02a6c"},
-    {file = "rpds_py-0.21.0-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1ff2eba7f6c0cb523d7e9cff0903f2fe1feff8f0b2ceb6bd71c0e20a4dcee271"},
-    {file = "rpds_py-0.21.0-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a429b99337062877d7875e4ff1a51fe788424d522bd64a8c0a20ef3021fdb6ed"},
-    {file = "rpds_py-0.21.0-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:d167e4dbbdac48bd58893c7e446684ad5d425b407f9336e04ab52e8b9194e2ed"},
-    {file = "rpds_py-0.21.0-pp39-pypy39_pp73-musllinux_1_2_i686.whl", hash = "sha256:4eb2de8a147ffe0626bfdc275fc6563aa7bf4b6db59cf0d44f0ccd6ca625a24e"},
-    {file = "rpds_py-0.21.0-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:e78868e98f34f34a88e23ee9ccaeeec460e4eaf6db16d51d7a9b883e5e785a5e"},
-    {file = "rpds_py-0.21.0-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:4991ca61656e3160cdaca4851151fd3f4a92e9eba5c7a530ab030d6aee96ec89"},
-    {file = "rpds_py-0.21.0.tar.gz", hash = "sha256:ed6378c9d66d0de903763e7706383d60c33829581f0adff47b6535f1802fa6db"},
+    {file = "rpds_py-0.22.3-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:6c7b99ca52c2c1752b544e310101b98a659b720b21db00e65edca34483259967"},
+    {file = "rpds_py-0.22.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:be2eb3f2495ba669d2a985f9b426c1797b7d48d6963899276d22f23e33d47e37"},
+    {file = "rpds_py-0.22.3-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:70eb60b3ae9245ddea20f8a4190bd79c705a22f8028aaf8bbdebe4716c3fab24"},
+    {file = "rpds_py-0.22.3-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:4041711832360a9b75cfb11b25a6a97c8fb49c07b8bd43d0d02b45d0b499a4ff"},
+    {file = "rpds_py-0.22.3-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:64607d4cbf1b7e3c3c8a14948b99345eda0e161b852e122c6bb71aab6d1d798c"},
+    {file = "rpds_py-0.22.3-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:81e69b0a0e2537f26d73b4e43ad7bc8c8efb39621639b4434b76a3de50c6966e"},
+    {file = "rpds_py-0.22.3-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc27863442d388870c1809a87507727b799c8460573cfbb6dc0eeaef5a11b5ec"},
+    {file = "rpds_py-0.22.3-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e79dd39f1e8c3504be0607e5fc6e86bb60fe3584bec8b782578c3b0fde8d932c"},
+    {file = "rpds_py-0.22.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:e0fa2d4ec53dc51cf7d3bb22e0aa0143966119f42a0c3e4998293a3dd2856b09"},
+    {file = "rpds_py-0.22.3-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:fda7cb070f442bf80b642cd56483b5548e43d366fe3f39b98e67cce780cded00"},
+    {file = "rpds_py-0.22.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:cff63a0272fcd259dcc3be1657b07c929c466b067ceb1c20060e8d10af56f5bf"},
+    {file = "rpds_py-0.22.3-cp310-cp310-win32.whl", hash = "sha256:9bd7228827ec7bb817089e2eb301d907c0d9827a9e558f22f762bb690b131652"},
+    {file = "rpds_py-0.22.3-cp310-cp310-win_amd64.whl", hash = "sha256:9beeb01d8c190d7581a4d59522cd3d4b6887040dcfc744af99aa59fef3e041a8"},
+    {file = "rpds_py-0.22.3-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:d20cfb4e099748ea39e6f7b16c91ab057989712d31761d3300d43134e26e165f"},
+    {file = "rpds_py-0.22.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:68049202f67380ff9aa52f12e92b1c30115f32e6895cd7198fa2a7961621fc5a"},
+    {file = "rpds_py-0.22.3-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fb4f868f712b2dd4bcc538b0a0c1f63a2b1d584c925e69a224d759e7070a12d5"},
+    {file = "rpds_py-0.22.3-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:bc51abd01f08117283c5ebf64844a35144a0843ff7b2983e0648e4d3d9f10dbb"},
+    {file = "rpds_py-0.22.3-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0f3cec041684de9a4684b1572fe28c7267410e02450f4561700ca5a3bc6695a2"},
+    {file = "rpds_py-0.22.3-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7ef9d9da710be50ff6809fed8f1963fecdfecc8b86656cadfca3bc24289414b0"},
+    {file = "rpds_py-0.22.3-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:59f4a79c19232a5774aee369a0c296712ad0e77f24e62cad53160312b1c1eaa1"},
+    {file = "rpds_py-0.22.3-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a60bce91f81ddaac922a40bbb571a12c1070cb20ebd6d49c48e0b101d87300d"},
+    {file = "rpds_py-0.22.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e89391e6d60251560f0a8f4bd32137b077a80d9b7dbe6d5cab1cd80d2746f648"},
+    {file = "rpds_py-0.22.3-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e3fb866d9932a3d7d0c82da76d816996d1667c44891bd861a0f97ba27e84fc74"},
+    {file = "rpds_py-0.22.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1352ae4f7c717ae8cba93421a63373e582d19d55d2ee2cbb184344c82d2ae55a"},
+    {file = "rpds_py-0.22.3-cp311-cp311-win32.whl", hash = "sha256:b0b4136a252cadfa1adb705bb81524eee47d9f6aab4f2ee4fa1e9d3cd4581f64"},
+    {file = "rpds_py-0.22.3-cp311-cp311-win_amd64.whl", hash = "sha256:8bd7c8cfc0b8247c8799080fbff54e0b9619e17cdfeb0478ba7295d43f635d7c"},
+    {file = "rpds_py-0.22.3-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:27e98004595899949bd7a7b34e91fa7c44d7a97c40fcaf1d874168bb652ec67e"},
+    {file = "rpds_py-0.22.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1978d0021e943aae58b9b0b196fb4895a25cc53d3956b8e35e0b7682eefb6d56"},
+    {file = "rpds_py-0.22.3-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:655ca44a831ecb238d124e0402d98f6212ac527a0ba6c55ca26f616604e60a45"},
+    {file = "rpds_py-0.22.3-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:feea821ee2a9273771bae61194004ee2fc33f8ec7db08117ef9147d4bbcbca8e"},
+    {file = "rpds_py-0.22.3-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:22bebe05a9ffc70ebfa127efbc429bc26ec9e9b4ee4d15a740033efda515cf3d"},
+    {file = "rpds_py-0.22.3-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3af6e48651c4e0d2d166dc1b033b7042ea3f871504b6805ba5f4fe31581d8d38"},
+    {file = "rpds_py-0.22.3-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e67ba3c290821343c192f7eae1d8fd5999ca2dc99994114643e2f2d3e6138b15"},
+    {file = "rpds_py-0.22.3-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:02fbb9c288ae08bcb34fb41d516d5eeb0455ac35b5512d03181d755d80810059"},
+    {file = "rpds_py-0.22.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f56a6b404f74ab372da986d240e2e002769a7d7102cc73eb238a4f72eec5284e"},
+    {file = "rpds_py-0.22.3-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:0a0461200769ab3b9ab7e513f6013b7a97fdeee41c29b9db343f3c5a8e2b9e61"},
+    {file = "rpds_py-0.22.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8633e471c6207a039eff6aa116e35f69f3156b3989ea3e2d755f7bc41754a4a7"},
+    {file = "rpds_py-0.22.3-cp312-cp312-win32.whl", hash = "sha256:593eba61ba0c3baae5bc9be2f5232430453fb4432048de28399ca7376de9c627"},
+    {file = "rpds_py-0.22.3-cp312-cp312-win_amd64.whl", hash = "sha256:d115bffdd417c6d806ea9069237a4ae02f513b778e3789a359bc5856e0404cc4"},
+    {file = "rpds_py-0.22.3-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:ea7433ce7e4bfc3a85654aeb6747babe3f66eaf9a1d0c1e7a4435bbdf27fea84"},
+    {file = "rpds_py-0.22.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:6dd9412824c4ce1aca56c47b0991e65bebb7ac3f4edccfd3f156150c96a7bf25"},
+    {file = "rpds_py-0.22.3-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:20070c65396f7373f5df4005862fa162db5d25d56150bddd0b3e8214e8ef45b4"},
+    {file = "rpds_py-0.22.3-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0b09865a9abc0ddff4e50b5ef65467cd94176bf1e0004184eb915cbc10fc05c5"},
+    {file = "rpds_py-0.22.3-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3453e8d41fe5f17d1f8e9c383a7473cd46a63661628ec58e07777c2fff7196dc"},
+    {file = "rpds_py-0.22.3-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f5d36399a1b96e1a5fdc91e0522544580dbebeb1f77f27b2b0ab25559e103b8b"},
+    {file = "rpds_py-0.22.3-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:009de23c9c9ee54bf11303a966edf4d9087cd43a6003672e6aa7def643d06518"},
+    {file = "rpds_py-0.22.3-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1aef18820ef3e4587ebe8b3bc9ba6e55892a6d7b93bac6d29d9f631a3b4befbd"},
+    {file = "rpds_py-0.22.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f60bd8423be1d9d833f230fdbccf8f57af322d96bcad6599e5a771b151398eb2"},
+    {file = "rpds_py-0.22.3-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:62d9cfcf4948683a18a9aff0ab7e1474d407b7bab2ca03116109f8464698ab16"},
+    {file = "rpds_py-0.22.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9253fc214112405f0afa7db88739294295f0e08466987f1d70e29930262b4c8f"},
+    {file = "rpds_py-0.22.3-cp313-cp313-win32.whl", hash = "sha256:fb0ba113b4983beac1a2eb16faffd76cb41e176bf58c4afe3e14b9c681f702de"},
+    {file = "rpds_py-0.22.3-cp313-cp313-win_amd64.whl", hash = "sha256:c58e2339def52ef6b71b8f36d13c3688ea23fa093353f3a4fee2556e62086ec9"},
+    {file = "rpds_py-0.22.3-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:f82a116a1d03628a8ace4859556fb39fd1424c933341a08ea3ed6de1edb0283b"},
+    {file = "rpds_py-0.22.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3dfcbc95bd7992b16f3f7ba05af8a64ca694331bd24f9157b49dadeeb287493b"},
+    {file = "rpds_py-0.22.3-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:59259dc58e57b10e7e18ce02c311804c10c5a793e6568f8af4dead03264584d1"},
+    {file = "rpds_py-0.22.3-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5725dd9cc02068996d4438d397e255dcb1df776b7ceea3b9cb972bdb11260a83"},
+    {file = "rpds_py-0.22.3-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:99b37292234e61325e7a5bb9689e55e48c3f5f603af88b1642666277a81f1fbd"},
+    {file = "rpds_py-0.22.3-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:27b1d3b3915a99208fee9ab092b8184c420f2905b7d7feb4aeb5e4a9c509b8a1"},
+    {file = "rpds_py-0.22.3-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f612463ac081803f243ff13cccc648578e2279295048f2a8d5eb430af2bae6e3"},
+    {file = "rpds_py-0.22.3-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f73d3fef726b3243a811121de45193c0ca75f6407fe66f3f4e183c983573e130"},
+    {file = "rpds_py-0.22.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:3f21f0495edea7fdbaaa87e633a8689cd285f8f4af5c869f27bc8074638ad69c"},
+    {file = "rpds_py-0.22.3-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:1e9663daaf7a63ceccbbb8e3808fe90415b0757e2abddbfc2e06c857bf8c5e2b"},
+    {file = "rpds_py-0.22.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a76e42402542b1fae59798fab64432b2d015ab9d0c8c47ba7addddbaf7952333"},
+    {file = "rpds_py-0.22.3-cp313-cp313t-win32.whl", hash = "sha256:69803198097467ee7282750acb507fba35ca22cc3b85f16cf45fb01cb9097730"},
+    {file = "rpds_py-0.22.3-cp313-cp313t-win_amd64.whl", hash = "sha256:f5cf2a0c2bdadf3791b5c205d55a37a54025c6e18a71c71f82bb536cf9a454bf"},
+    {file = "rpds_py-0.22.3-cp39-cp39-macosx_10_12_x86_64.whl", hash = "sha256:378753b4a4de2a7b34063d6f95ae81bfa7b15f2c1a04a9518e8644e81807ebea"},
+    {file = "rpds_py-0.22.3-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3445e07bf2e8ecfeef6ef67ac83de670358abf2996916039b16a218e3d95e97e"},
+    {file = "rpds_py-0.22.3-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b2513ba235829860b13faa931f3b6846548021846ac808455301c23a101689d"},
+    {file = "rpds_py-0.22.3-cp39-cp39-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:eaf16ae9ae519a0e237a0f528fd9f0197b9bb70f40263ee57ae53c2b8d48aeb3"},
+    {file = "rpds_py-0.22.3-cp39-cp39-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:583f6a1993ca3369e0f80ba99d796d8e6b1a3a2a442dd4e1a79e652116413091"},
+    {file = "rpds_py-0.22.3-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4617e1915a539a0d9a9567795023de41a87106522ff83fbfaf1f6baf8e85437e"},
+    {file = "rpds_py-0.22.3-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c150c7a61ed4a4f4955a96626574e9baf1adf772c2fb61ef6a5027e52803543"},
+    {file = "rpds_py-0.22.3-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2fa4331c200c2521512595253f5bb70858b90f750d39b8cbfd67465f8d1b596d"},
+    {file = "rpds_py-0.22.3-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:214b7a953d73b5e87f0ebece4a32a5bd83c60a3ecc9d4ec8f1dca968a2d91e99"},
+    {file = "rpds_py-0.22.3-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:f47ad3d5f3258bd7058d2d506852217865afefe6153a36eb4b6928758041d831"},
+    {file = "rpds_py-0.22.3-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:f276b245347e6e36526cbd4a266a417796fc531ddf391e43574cf6466c492520"},
+    {file = "rpds_py-0.22.3-cp39-cp39-win32.whl", hash = "sha256:bbb232860e3d03d544bc03ac57855cd82ddf19c7a07651a7c0fdb95e9efea8b9"},
+    {file = "rpds_py-0.22.3-cp39-cp39-win_amd64.whl", hash = "sha256:cfbc454a2880389dbb9b5b398e50d439e2e58669160f27b60e5eca11f68ae17c"},
+    {file = "rpds_py-0.22.3-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:d48424e39c2611ee1b84ad0f44fb3b2b53d473e65de061e3f460fc0be5f1939d"},
+    {file = "rpds_py-0.22.3-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:24e8abb5878e250f2eb0d7859a8e561846f98910326d06c0d51381fed59357bd"},
+    {file = "rpds_py-0.22.3-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4b232061ca880db21fa14defe219840ad9b74b6158adb52ddf0e87bead9e8493"},
+    {file = "rpds_py-0.22.3-pp310-pypy310_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac0a03221cdb5058ce0167ecc92a8c89e8d0decdc9e99a2ec23380793c4dcb96"},
+    {file = "rpds_py-0.22.3-pp310-pypy310_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:eb0c341fa71df5a4595f9501df4ac5abfb5a09580081dffbd1ddd4654e6e9123"},
+    {file = "rpds_py-0.22.3-pp310-pypy310_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bf9db5488121b596dbfc6718c76092fda77b703c1f7533a226a5a9f65248f8ad"},
+    {file = "rpds_py-0.22.3-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b8db6b5b2d4491ad5b6bdc2bc7c017eec108acbf4e6785f42a9eb0ba234f4c9"},
+    {file = "rpds_py-0.22.3-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b3d504047aba448d70cf6fa22e06cb09f7cbd761939fdd47604f5e007675c24e"},
+    {file = "rpds_py-0.22.3-pp310-pypy310_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:e61b02c3f7a1e0b75e20c3978f7135fd13cb6cf551bf4a6d29b999a88830a338"},
+    {file = "rpds_py-0.22.3-pp310-pypy310_pp73-musllinux_1_2_i686.whl", hash = "sha256:e35ba67d65d49080e8e5a1dd40101fccdd9798adb9b050ff670b7d74fa41c566"},
+    {file = "rpds_py-0.22.3-pp310-pypy310_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:26fd7cac7dd51011a245f29a2cc6489c4608b5a8ce8d75661bb4a1066c52dfbe"},
+    {file = "rpds_py-0.22.3-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:177c7c0fce2855833819c98e43c262007f42ce86651ffbb84f37883308cb0e7d"},
+    {file = "rpds_py-0.22.3-pp39-pypy39_pp73-macosx_10_12_x86_64.whl", hash = "sha256:bb47271f60660803ad11f4c61b42242b8c1312a31c98c578f79ef9387bbde21c"},
+    {file = "rpds_py-0.22.3-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:70fb28128acbfd264eda9bf47015537ba3fe86e40d046eb2963d75024be4d055"},
+    {file = "rpds_py-0.22.3-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:44d61b4b7d0c2c9ac019c314e52d7cbda0ae31078aabd0f22e583af3e0d79723"},
+    {file = "rpds_py-0.22.3-pp39-pypy39_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5f0e260eaf54380380ac3808aa4ebe2d8ca28b9087cf411649f96bad6900c728"},
+    {file = "rpds_py-0.22.3-pp39-pypy39_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b25bc607423935079e05619d7de556c91fb6adeae9d5f80868dde3468657994b"},
+    {file = "rpds_py-0.22.3-pp39-pypy39_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:fb6116dfb8d1925cbdb52595560584db42a7f664617a1f7d7f6e32f138cdf37d"},
+    {file = "rpds_py-0.22.3-pp39-pypy39_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a63cbdd98acef6570c62b92a1e43266f9e8b21e699c363c0fef13bd530799c11"},
+    {file = "rpds_py-0.22.3-pp39-pypy39_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2b8f60e1b739a74bab7e01fcbe3dddd4657ec685caa04681df9d562ef15b625f"},
+    {file = "rpds_py-0.22.3-pp39-pypy39_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:2e8b55d8517a2fda8d95cb45d62a5a8bbf9dd0ad39c5b25c8833efea07b880ca"},
+    {file = "rpds_py-0.22.3-pp39-pypy39_pp73-musllinux_1_2_i686.whl", hash = "sha256:2de29005e11637e7a2361fa151f780ff8eb2543a0da1413bb951e9f14b699ef3"},
+    {file = "rpds_py-0.22.3-pp39-pypy39_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:666ecce376999bf619756a24ce15bb14c5bfaf04bf00abc7e663ce17c3f34fe7"},
+    {file = "rpds_py-0.22.3-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:5246b14ca64a8675e0a7161f7af68fe3e910e6b90542b4bfb5439ba752191df6"},
+    {file = "rpds_py-0.22.3.tar.gz", hash = "sha256:e32fee8ab45d3c2db6da19a5323bc3362237c8b653c70194414b892fd06a080d"},
 ]
 
 [[package]]
@@ -1436,13 +1455,13 @@ files = [
 
 [[package]]
 name = "six"
-version = "1.16.0"
+version = "1.17.0"
 description = "Python 2 and 3 compatibility utilities"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
 files = [
-    {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},
-    {file = "six-1.16.0.tar.gz", hash = "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926"},
+    {file = "six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"},
+    {file = "six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"},
 ]
 
 [[package]]
@@ -1514,13 +1533,13 @@ files = [
 
 [[package]]
 name = "types-pyyaml"
-version = "6.0.12.20240917"
+version = "6.0.12.20241230"
 description = "Typing stubs for PyYAML"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "types-PyYAML-6.0.12.20240917.tar.gz", hash = "sha256:d1405a86f9576682234ef83bcb4e6fff7c9305c8b1fbad5e0bcd4f7dbdc9c587"},
-    {file = "types_PyYAML-6.0.12.20240917-py3-none-any.whl", hash = "sha256:392b267f1c0fe6022952462bf5d6523f31e37f6cea49b14cee7ad634b6301570"},
+    {file = "types_PyYAML-6.0.12.20241230-py3-none-any.whl", hash = "sha256:fa4d32565219b68e6dee5f67534c722e53c00d1cfc09c435ef04d7353e1e96e6"},
+    {file = "types_pyyaml-6.0.12.20241230.tar.gz", hash = "sha256:7f07622dbd34bb9c8b264fe860a17e0efcad00d50b5f27e93984909d9363498c"},
 ]
 
 [[package]]
@@ -1536,13 +1555,13 @@ files = [
 
 [[package]]
 name = "virtualenv"
-version = "20.28.0"
+version = "20.28.1"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.8"
 files = [
-    {file = "virtualenv-20.28.0-py3-none-any.whl", hash = "sha256:23eae1b4516ecd610481eda647f3a7c09aea295055337331bb4e6892ecce47b0"},
-    {file = "virtualenv-20.28.0.tar.gz", hash = "sha256:2c9c3262bb8e7b87ea801d715fae4495e6032450c71d2309be9550e7364049aa"},
+    {file = "virtualenv-20.28.1-py3-none-any.whl", hash = "sha256:412773c85d4dab0409b83ec36f7a6499e72eaf08c80e81e9576bca61831c71cb"},
+    {file = "virtualenv-20.28.1.tar.gz", hash = "sha256:5d34ab240fdb5d21549b76f9e8ff3af28252f5499fb6d6f031adac4e5a8c5329"},
 ]
 
 [package.dependencies]
@@ -1573,4 +1592,4 @@ test = ["websockets"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "d7fedd12872bc4c933294a2c364c8edaf6986ef6fec1bb1a13e57303b23ee247"
+content-hash = "33d67bafd6040b556cf13b6b245f226609427bc54dac104fead9d9942d4d14f7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.10"
-poetry-core = "^1.9.0"
+poetry-core = "<2.0"
 ops = "~2.15.0"
 overrides = "^7.7.0"
 pydantic = "~2.9.0"
@@ -44,7 +44,7 @@ dacite = "^1.8.0"
 
 
 [build-system]
-requires = ["poetry-core>=1.9.0"]
+requires = ["poetry-core<2.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.group.charm-libs.dependencies]

--- a/single_kernel_mongo/abstract_charm.py
+++ b/single_kernel_mongo/abstract_charm.py
@@ -31,7 +31,7 @@ from ops.charm import CharmBase
 from single_kernel_mongo.config.literals import Substrates
 from single_kernel_mongo.config.relations import PeerRelationNames
 from single_kernel_mongo.core.operator import OperatorProtocol
-from single_kernel_mongo.core.structured_config import MongoConfigModel
+from single_kernel_mongo.core.structured_config import MongoConfigModel, MongoDBRoles
 from single_kernel_mongo.events.lifecycle import LifecycleEventsHandler
 from single_kernel_mongo.status import StatusManager
 
@@ -97,7 +97,6 @@ class AbstractMongoCharm(Generic[T, U], CharmBase):
 
     def on_leader_elected(self, _):
         """First leader elected handler."""
-        # FIXME: Check role status in databag first.
-
         # Sets the role in the databag.
-        self.operator.state.app_peer_data.role = self.parsed_config.role
+        if self.operator.state.app_peer_data.role == MongoDBRoles.UNKNOWN:
+            self.operator.state.app_peer_data.role = self.parsed_config.role

--- a/single_kernel_mongo/abstract_charm.py
+++ b/single_kernel_mongo/abstract_charm.py
@@ -97,6 +97,8 @@ class AbstractMongoCharm(Generic[T, U], CharmBase):
 
     def on_leader_elected(self, _):
         """First leader elected handler."""
-        # Sets the role in the databag.
+        # Sets the role in the databag: when the charm is first created, its
+        # role won't exist in the databag. We save it in the databag because we
+        # don't allow role changing yet.
         if self.operator.state.app_peer_data.role == MongoDBRoles.UNKNOWN:
             self.operator.state.app_peer_data.role = self.parsed_config.role

--- a/single_kernel_mongo/config/literals.py
+++ b/single_kernel_mongo/config/literals.py
@@ -96,3 +96,5 @@ ENVIRONMENT_FILE = Path("/etc/environment")
 SECRETS_UNIT: list[str] = []
 
 MAX_PASSWORD_LENGTH = 4096
+
+PBM_RESTART_DELAY = 5

--- a/single_kernel_mongo/core/vm_workload.py
+++ b/single_kernel_mongo/core/vm_workload.py
@@ -60,7 +60,8 @@ class VMWorkload(WorkloadBase):
     @override
     def update_env(self, parameters: chain[str]) -> None:
         content = " ".join(parameters)
-        self.mongod_snap.set({self.snap_param: content})
+        if content != "":
+            self.mongod_snap.set({self.snap_param: content})
 
     @override
     def stop(self) -> None:

--- a/single_kernel_mongo/core/vm_workload.py
+++ b/single_kernel_mongo/core/vm_workload.py
@@ -58,10 +58,14 @@ class VMWorkload(WorkloadBase):
         return {self.env_var: self.mongod_snap.get(self.snap_param)}
 
     @override
-    def update_env(self, parameters: chain[str]) -> None:
-        content = " ".join(parameters)
-        if content != "":
-            self.mongod_snap.set({self.snap_param: content})
+    def update_env(self, parameters: chain[str]):
+        try:
+            content = " ".join(parameters)
+            if content != "":
+                self.mongod_snap.set({self.snap_param: content})
+        except snap.SnapError as e:
+            logger.exception(str(e))
+            raise WorkloadServiceError(str(e)) from e
 
     @override
     def stop(self) -> None:

--- a/single_kernel_mongo/events/sharding.py
+++ b/single_kernel_mongo/events/sharding.py
@@ -22,6 +22,7 @@ from single_kernel_mongo.exceptions import (
     DeferrableFailedHookChecksError,
     FailedToUpdateCredentialsError,
     NonDeferrableFailedHookChecksError,
+    ShardAuthError,
     WaitingForCertificatesError,
     WaitingForSecretsError,
 )
@@ -75,7 +76,7 @@ class ConfigServerEventHandler(Object):
         is_leaving = isinstance(event, RelationBrokenEvent)
         try:
             self.manager.on_relation_event(event.relation, is_leaving)
-        except (DeferrableFailedHookChecksError, ServerSelectionTimeoutError) as e:
+        except (DeferrableFailedHookChecksError, ServerSelectionTimeoutError, ShardAuthError) as e:
             defer_event_with_info_log(logger, event, str(type(event)), str(e))
         except NonDeferrableFailedHookChecksError as e:
             logger.info(f"Skipping {str(type(event))}: {str(e)}")

--- a/single_kernel_mongo/events/sharding.py
+++ b/single_kernel_mongo/events/sharding.py
@@ -138,6 +138,7 @@ class ShardEventHandler(Object):
             DeferrableFailedHookChecksError,
             WaitingForSecretsError,
             WaitingForCertificatesError,
+            NotReadyError,
         ) as e:
             defer_event_with_info_log(logger, event, str(type(event)), str(e))
         except NonDeferrableFailedHookChecksError as e:

--- a/single_kernel_mongo/events/sharding.py
+++ b/single_kernel_mongo/events/sharding.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Manager for sharding and config server events."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from ops.charm import (
+    RelationBrokenEvent,
+    RelationChangedEvent,
+    RelationCreatedEvent,
+    RelationJoinedEvent,
+    SecretChangedEvent,
+)
+from ops.framework import Object
+
+from single_kernel_mongo.exceptions import (
+    DeferrableFailedHookChecksError,
+    FailedToUpdateCredentialsError,
+    NonDeferrableFailedHookChecksError,
+    WaitingForSecretsError,
+)
+from single_kernel_mongo.lib.charms.data_platform_libs.v0.data_interfaces import (
+    DatabaseProviderEventHandlers,
+    DatabaseRequirerEventHandlers,
+)
+from single_kernel_mongo.utils.event_helpers import defer_event_with_info_log
+from single_kernel_mongo.utils.mongo_connection import NotReadyError
+
+if TYPE_CHECKING:
+    from single_kernel_mongo.managers.mongodb_operator import MongoDBOperator
+
+
+logger = logging.getLogger(__name__)
+
+logger = logging.getLogger(__name__)
+
+
+class ConfigServerEventHandler(Object):
+    """Event Handler for managing config server side events."""
+
+    def __init__(self, dependent: MongoDBOperator):
+        self.dependent = dependent
+        self.charm = self.dependent.charm
+        self.manager = self.dependent.config_server_manager
+        self.relation_name = self.manager.relation_name
+        super().__init__(parent=self.manager, key=dependent.config_server_manager.relation_name)
+
+        self.database_provider_events = DatabaseProviderEventHandlers(
+            self.charm, self.manager.data_interface
+        )
+        self.framework.observe(
+            self.charm.on[self.relation_name].relation_joined, self._on_relation_joined
+        )
+        self.framework.observe(
+            self.charm.on[self.relation_name].relation_departed,
+            self.dependent.check_relation_broken_or_scale_down,
+        )
+        self.framework.observe(
+            self.charm.on[self.relation_name].relation_changed, self._on_relation_event
+        )
+        self.framework.observe(
+            self.charm.on[self.relation_name].relation_broken, self._on_relation_event
+        )
+
+    def _on_relation_event(self, event: RelationChangedEvent):
+        """Handle relation changed and relation broken events."""
+        is_leaving = isinstance(event, RelationBrokenEvent)
+        try:
+            self.manager.on_relation_event(event.relation, is_leaving)
+        except DeferrableFailedHookChecksError as e:
+            defer_event_with_info_log(logger, event, str(type(event)), str(e))
+        except NonDeferrableFailedHookChecksError as e:
+            logger.info(f"Skipping {str(type(event))}: {str(e)}")
+
+    def _on_relation_joined(self, event: RelationJoinedEvent):
+        """Relation joined events."""
+        try:
+            self.manager.on_relation_joined(event.relation)
+        except DeferrableFailedHookChecksError as e:
+            defer_event_with_info_log(logger, event, str(type(event)), str(e))
+        except NonDeferrableFailedHookChecksError as e:
+            logger.info(f"Skipping {str(type(event))}: {str(e)}")
+
+
+class ShardEventHandler(Object):
+    """Event Handler for managing shard side events."""
+
+    def __init__(self, dependent: MongoDBOperator):
+        self.dependent = dependent
+        self.charm = self.dependent.charm
+        self.manager = self.dependent.shard_manager
+        self.relation_name = self.manager.relation_name
+        super().__init__(parent=self.manager, key=dependent.shard_manager.relation_name)
+
+        self.database_require_events = DatabaseRequirerEventHandlers(
+            self.charm, self.manager.data_requirer
+        )
+
+        self.framework.observe(
+            self.charm.on[self.relation_name].relation_created, self._on_relation_created
+        )
+        self.framework.observe(
+            self.charm.on[self.relation_name].relation_changed, self._on_relation_changed
+        )
+
+        self.framework.observe(
+            getattr(self.charm.on, "secret_changed"), self._handle_changed_secrets
+        )
+
+        self.framework.observe(
+            self.charm.on[self.relation_name].relation_departed,
+            self.dependent.check_relation_broken_or_scale_down,
+        )
+
+        self.framework.observe(
+            self.charm.on[self.relation_name].relation_broken, self._on_relation_broken
+        )
+
+    def _on_relation_created(self, event: RelationCreatedEvent):
+        self.manager.relation_created()
+
+    def _on_relation_changed(self, event: RelationChangedEvent):
+        try:
+            self.manager.relation_changed(event.relation)
+        except DeferrableFailedHookChecksError as e:
+            defer_event_with_info_log(logger, event, str(type(event)), str(e))
+        except NonDeferrableFailedHookChecksError as e:
+            logger.info(f"Skipping {str(type(event))}: {str(e)}")
+
+    def _handle_changed_secrets(self, event: SecretChangedEvent):
+        try:
+            self.manager.handle_secret_changed(event.secret.label or "")
+        except (NotReadyError, FailedToUpdateCredentialsError):
+            event.defer()
+        except WaitingForSecretsError:
+            logger.info("Missing secrets, ignoring")
+
+    def _on_relation_broken(self, event: RelationBrokenEvent):
+        try:
+            self.manager.relation_broken(event.relation)
+        except DeferrableFailedHookChecksError as e:
+            defer_event_with_info_log(logger, event, str(type(event)), str(e))
+        except NonDeferrableFailedHookChecksError as e:
+            logger.info(f"Skipping {str(type(event))}: {str(e)}")

--- a/single_kernel_mongo/events/sharding.py
+++ b/single_kernel_mongo/events/sharding.py
@@ -41,8 +41,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-logger = logging.getLogger(__name__)
-
 
 class ConfigServerEventHandler(Object):
     """Event Handler for managing config server side events."""
@@ -110,10 +108,7 @@ class ShardEventHandler(Object):
             self.charm.on[self.relation_name].relation_created, self._on_relation_created
         )
         self.framework.observe(
-            self.database_require_events.on.database_created, self._on_relation_changed
-        )
-        self.framework.observe(
-            self.charm.on[self.relation_name].relation_changed, self._on_relation_changed
+            self.database_require_events.on.database_created, self._on_database_created
         )
 
         self.framework.observe(
@@ -132,9 +127,9 @@ class ShardEventHandler(Object):
     def _on_relation_created(self, event: RelationCreatedEvent):
         self.manager.relation_created()
 
-    def _on_relation_changed(self, event: RelationChangedEvent | DatabaseCreatedEvent):
+    def _on_database_created(self, event: DatabaseCreatedEvent):
         try:
-            self.manager.relation_changed(event.relation)
+            self.manager.on_database_created(event.relation)
         except (
             DeferrableFailedHookChecksError,
             WaitingForSecretsError,

--- a/single_kernel_mongo/events/sharding.py
+++ b/single_kernel_mongo/events/sharding.py
@@ -16,6 +16,7 @@ from ops.charm import (
     SecretChangedEvent,
 )
 from ops.framework import Object
+from pymongo.errors import ServerSelectionTimeoutError
 
 from single_kernel_mongo.exceptions import (
     DeferrableFailedHookChecksError,
@@ -74,7 +75,7 @@ class ConfigServerEventHandler(Object):
         is_leaving = isinstance(event, RelationBrokenEvent)
         try:
             self.manager.on_relation_event(event.relation, is_leaving)
-        except DeferrableFailedHookChecksError as e:
+        except (DeferrableFailedHookChecksError, ServerSelectionTimeoutError) as e:
             defer_event_with_info_log(logger, event, str(type(event)), str(e))
         except NonDeferrableFailedHookChecksError as e:
             logger.info(f"Skipping {str(type(event))}: {str(e)}")

--- a/single_kernel_mongo/events/sharding.py
+++ b/single_kernel_mongo/events/sharding.py
@@ -125,9 +125,11 @@ class ShardEventHandler(Object):
         )
 
     def _on_relation_created(self, event: RelationCreatedEvent):
+        """Prepare to add the shard."""
         self.manager.prepare_to_add_shard()
 
     def _on_database_created(self, event: DatabaseCreatedEvent):
+        """When we receive a database created event, we synchronize the cluster secrets locally."""
         try:
             self.manager.synchronise_cluster_secrets(event.relation)
         except (
@@ -141,6 +143,7 @@ class ShardEventHandler(Object):
             logger.info(f"Skipping {str(type(event))}: {str(e)}")
 
     def _handle_changed_secrets(self, event: SecretChangedEvent):
+        """SecretChanged event handler, which is used to propagate the updated passwords."""
         try:
             self.manager.handle_secret_changed(event.secret.label or "")
         except (NotReadyError, FailedToUpdateCredentialsError):
@@ -149,6 +152,7 @@ class ShardEventHandler(Object):
             logger.info("Missing secrets, ignoring")
 
     def _on_relation_broken(self, event: RelationBrokenEvent):
+        """On relation broken, we drain the shard before allowing it to disconnect."""
         try:
             self.manager.drain_shard_from_cluster(event.relation)
         except DeferrableFailedHookChecksError as e:

--- a/single_kernel_mongo/exceptions.py
+++ b/single_kernel_mongo/exceptions.py
@@ -122,6 +122,49 @@ class DatabaseRequestedHasNotRunYetError(Exception):
     """Raised when the database event has not run yet."""
 
 
+class ShardAuthError(Exception):
+    """Raised when a shard doesn't have the same auth as the config server."""
+
+    def __init__(self, shard: str):
+        self.shard = shard
+
+
+class RemoveLastShardError(Exception):
+    """Raised when there is an attempt to remove the last shard in the cluster."""
+
+
+class NotEnoughSpaceError(Exception):
+    """Raised when there isn't enough space to movePrimary."""
+
+
+class ShardNotInClusterError(Exception):
+    """Raised when shard is not present in cluster, but it is expected to be."""
+
+
+class ShardNotPlannedForRemovalError(Exception):
+    """Raised when it is expected that a shard is planned for removal, but it is not."""
+
+
+class NotDrainedError(Exception):
+    """Raised when a shard is still being drained."""
+
+
+class BalancerNotEnabledError(Exception):
+    """Raised when balancer process is not enabled."""
+
+
+class WaitingForSecretsError(Exception):
+    """Raised when we are still waiting for secrets."""
+
+
+class WaitingForCertificatesError(Exception):
+    """Raised when we are waiting for certificates."""
+
+
+class FailedToUpdateCredentialsError(Exception):
+    """Raised when we failed to update credentials."""
+
+
 class DeferrableFailedHookChecksError(Exception):
     """Raised when we failed to pass hook checks and we should defer."""
 

--- a/single_kernel_mongo/exceptions.py
+++ b/single_kernel_mongo/exceptions.py
@@ -171,3 +171,7 @@ class DeferrableFailedHookChecksError(Exception):
 
 class NonDeferrableFailedHookChecksError(Exception):
     """Raised when we failed to pass hook checks and we should skip."""
+
+
+class EarlyRemovalOfConfigServerError(Exception):
+    """Raised when we try to remove config server while it still has shards."""

--- a/single_kernel_mongo/lib/charms/operator_libs_linux/v2/snap.py
+++ b/single_kernel_mongo/lib/charms/operator_libs_linux/v2/snap.py
@@ -84,7 +84,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 8
+LIBPATCH = 9
 
 
 # Regex to locate 7-bit C1 ANSI sequences
@@ -787,7 +787,7 @@ class SnapClient:
             status = response["status"]
             if status == "Done":
                 return response.get("data")
-            if status == "Doing":
+            if status == "Doing" or status == "Do":
                 time.sleep(0.1)
                 continue
             if status == "Wait":

--- a/single_kernel_mongo/managers/config.py
+++ b/single_kernel_mongo/managers/config.py
@@ -100,7 +100,7 @@ class BackupConfigManager(CommonConfigManager):
                 self.workload.stop()
                 self.set_environment()
                 # Avoid restart errors on PBM.
-                time.sleep(2)
+                time.sleep(5)
                 self.workload.start()
             except WorkloadServiceError as e:
                 logger.error(f"Failed to restart {self.workload.service}: {e}")

--- a/single_kernel_mongo/managers/config.py
+++ b/single_kernel_mongo/managers/config.py
@@ -282,7 +282,10 @@ class MongoDBConfigManager(MongoConfigManager):
     @property
     def role_parameter(self) -> list[str]:
         """The role parameter."""
-        match self.state.app_peer_data.role:
+        role = self.state.app_peer_data.role
+        if role == MongoDBRoles.UNKNOWN:  # First install we don't have the role in databag yet.
+            role = self.state.config.role
+        match role:
             case MongoDBRoles.CONFIG_SERVER:
                 return ["--configsvr"]
             case MongoDBRoles.SHARD:

--- a/single_kernel_mongo/managers/config.py
+++ b/single_kernel_mongo/managers/config.py
@@ -184,6 +184,8 @@ class MongoDBExporterConfigManager(CommonConfigManager):
 class MongoConfigManager(CommonConfigManager, ABC):
     """The common configuration manager for both MongoDB and Mongos."""
 
+    auth: bool
+
     @override
     def build_parameters(self) -> list[list[str]]:
         return [
@@ -236,16 +238,15 @@ class MongoConfigManager(CommonConfigManager, ABC):
     @property
     def auth_parameter(self) -> list[str]:
         """The auth mode."""
+        cmd = ["--auth"] if self.auth else []
         if self.state.tls.internal_enabled and self.state.tls.external_enabled:
-            return [
-                "--auth",
+            return cmd + [
                 "--clusterAuthMode=x509",
                 "--tlsAllowInvalidCertificates",
                 f"--tlsClusterCAFile={self.workload.paths.int_ca_file}",
                 f"--tlsClusterFile={self.workload.paths.int_pem_file}",
             ]
-        return [
-            "--auth",
+        return cmd + [
             "--clusterAuthMode=keyFile",
             f"--keyFile={self.workload.paths.keyfile}",
         ]
@@ -271,6 +272,7 @@ class MongoDBConfigManager(MongoConfigManager):
         self.state = state
         self.workload = workload
         self.config = config
+        self.auth = True
 
     @property
     def db_path_argument(self) -> list[str]:
@@ -315,6 +317,7 @@ class MongosConfigManager(MongoConfigManager):
         self.state = state
         self.workload = workload
         self.config = config
+        self.auth = False
 
     @property
     def config_server_db_parameter(self) -> list[str]:

--- a/single_kernel_mongo/managers/config.py
+++ b/single_kernel_mongo/managers/config.py
@@ -14,6 +14,7 @@ from typing_extensions import override
 
 from single_kernel_mongo.config.literals import (
     LOCALHOST,
+    PBM_RESTART_DELAY,
     KindEnum,
     MongoPorts,
     Substrates,
@@ -100,7 +101,7 @@ class BackupConfigManager(CommonConfigManager):
                 self.workload.stop()
                 self.set_environment()
                 # Avoid restart errors on PBM.
-                time.sleep(5)
+                time.sleep(PBM_RESTART_DELAY)
                 self.workload.start()
             except WorkloadServiceError as e:
                 logger.error(f"Failed to restart {self.workload.service}: {e}")
@@ -282,10 +283,7 @@ class MongoDBConfigManager(MongoConfigManager):
     @property
     def role_parameter(self) -> list[str]:
         """The role parameter."""
-        role = self.state.app_peer_data.role
-        if role == MongoDBRoles.UNKNOWN:  # First install we don't have the role in databag yet.
-            role = self.state.config.role
-        match role:
+        match self.state.app_peer_data.role:
             case MongoDBRoles.CONFIG_SERVER:
                 return ["--configsvr"]
             case MongoDBRoles.SHARD:

--- a/single_kernel_mongo/managers/k8s.py
+++ b/single_kernel_mongo/managers/k8s.py
@@ -109,7 +109,7 @@ class K8sManager:
     def build_node_port_services(self, port: str) -> Service:
         """Builds a ClusterIP service for initial client connection."""
         pod = self.get_pod(pod_name=self.pod_name)
-        if not pod.metadata or not pod.apiVersion or not pod.kind or not pod.uid:
+        if not pod.metadata or not pod.apiVersion or not pod.kind or not pod.metadata.uid:
             raise Exception(f"Could not find metadata for {pod}")
 
         return Service(

--- a/single_kernel_mongo/managers/k8s.py
+++ b/single_kernel_mongo/managers/k8s.py
@@ -109,7 +109,7 @@ class K8sManager:
     def build_node_port_services(self, port: str) -> Service:
         """Builds a ClusterIP service for initial client connection."""
         pod = self.get_pod(pod_name=self.pod_name)
-        if not pod.metadata:
+        if not pod.metadata or not pod.apiVersion or not pod.kind or not pod.uid:
             raise Exception(f"Could not find metadata for {pod}")
 
         return Service(
@@ -137,8 +137,8 @@ class K8sManager:
                 ports=[
                     ServicePort(
                         protocol="TCP",
-                        port=port,
-                        targetPort=port,
+                        port=int(port),
+                        targetPort=int(port),
                         name=f"{self.pod_name}-port",
                     )
                 ],

--- a/single_kernel_mongo/managers/mongo.py
+++ b/single_kernel_mongo/managers/mongo.py
@@ -409,6 +409,18 @@ class MongoManager(Object):
                     raise NotReadyError
                 mongo.add_replset_member(member)
 
+    def get_draining_shards(self, config: MongoConfiguration | None = None) -> list[str]:
+        """Returns the shard that is currently draining."""
+        with MongoConnection(config or self.state.mongos_config) as mongo:
+            draining_shards = mongo.get_draining_shards()
+
+            # in theory, this should always be a list of one. But if something has gone wrong we
+            # should take note and log it
+            if len(draining_shards) > 1:
+                logger.error("Multiple shards draining at the same time.")
+
+            return draining_shards
+
     # Keep for memory for now.
     # def get_relation_name(self):
     #    """Returns the name of the relation to use."""

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -806,5 +806,5 @@ class MongoDBOperator(OperatorProtocol, Object):
 
         if self.state.is_scaling_down(relation.id):
             raise NonDeferrableFailedHookChecksError(
-                "Relation broken event occurring during scale down, do not proceed to remove users."
+                "Relation broken event occurring during scale down, no need to proceed with broken event."
             )

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -33,6 +33,7 @@ from single_kernel_mongo.events.backups import INVALID_S3_INTEGRATION_STATUS, Ba
 from single_kernel_mongo.events.database import DatabaseEventsHandler
 from single_kernel_mongo.events.password_actions import PasswordActionEvents
 from single_kernel_mongo.events.primary_action import PrimaryActionHandler
+from single_kernel_mongo.events.sharding import ConfigServerEventHandler, ShardEventHandler
 from single_kernel_mongo.events.tls import TLSEventsHandler
 from single_kernel_mongo.exceptions import (
     ContainerNotReadyError,
@@ -144,6 +145,8 @@ class MongoDBOperator(OperatorProtocol, Object):
         self.tls_events = TLSEventsHandler(self)
         self.primary_events = PrimaryActionHandler(self)
         self.client_events = DatabaseEventsHandler(self, RelationNames.DATABASE)
+        self.config_server_events = ConfigServerEventHandler(self)
+        self.sharding_event_handlers = ShardEventHandler(self)
 
     @property
     def config(self):

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -605,7 +605,7 @@ class MongoDBOperator(OperatorProtocol, Object):
         """Retrieves the primary unit with the primary replica."""
         with MongoConnection(self.state.mongo_config) as connection:
             try:
-                primary_ip = connection.primary
+                primary_ip = connection.primary()
             except Exception as e:
                 logger.error(f"Unable to get primary: {e}")
                 return None

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -53,6 +53,7 @@ from single_kernel_mongo.managers.config import (
     MongosConfigManager,
 )
 from single_kernel_mongo.managers.mongo import MongoManager
+from single_kernel_mongo.managers.sharding import ConfigServerManager, ShardManager
 from single_kernel_mongo.managers.tls import TLSManager
 from single_kernel_mongo.state.charm_state import CharmState
 from single_kernel_mongo.utils.mongo_connection import MongoConnection, NotReadyError
@@ -121,6 +122,20 @@ class MongoDBOperator(OperatorProtocol, Object):
             self.workload,
             self.state,
             self.substrate,
+        )
+        self.config_server_manager = ConfigServerManager(
+            self,
+            self.workload,
+            self.state,
+            self.substrate,
+            RelationNames.CONFIG_SERVER,
+        )
+        self.shard_manager = ShardManager(
+            self,
+            self.workload,
+            self.state,
+            self.substrate,
+            RelationNames.SHARDING,
         )
 
         # Event Handlers

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -528,9 +528,11 @@ class MongoDBOperator(OperatorProtocol, Object):
         if user == MonitorUser:
             # Update and restart mongodb exporter.
             self.mongodb_exporter_config_manager.configure_and_restart()
-        # TODO: Rotate password.
-        if user in (OperatorUser, BackupUser):
-            pass
+        if user in (OperatorUser, BackupUser) and self.state.is_role(MongoDBRoles.CONFIG_SERVER):
+            self.config_server_manager.update_credentials(
+                user.password_key_name,
+                new_password,
+            )
 
         return new_password, secret_id
 

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -448,7 +448,7 @@ class MongoDBOperator(OperatorProtocol, Object):
                 current_shards = [
                     relation.app.name for relation in self.state.config_server_relation
                 ]
-                early_removal_message = f"Cannot remoe config-server, still related to shards {', '.join(current_shards)}"
+                early_removal_message = f"Cannot remove config-server, still related to shards {', '.join(current_shards)}"
                 logger.error(early_removal_message)
                 raise EarlyRemovalOfConfigServerError(early_removal_message)
             if self.state.is_role(MongoDBRoles.SHARD) and self.state.shard_relation is not None:

--- a/single_kernel_mongo/managers/sharding.py
+++ b/single_kernel_mongo/managers/sharding.py
@@ -402,7 +402,7 @@ class ShardManager(Object):
             self.model,
             relation_name=self.relation_name,
             additional_secret_fields=SECRETS_FIELDS,
-            database_name="",  # Needed for relation events
+            database_name="unused",  # Needed for relation events
         )
 
     def assert_pass_sanity_hook_checks(self):

--- a/single_kernel_mongo/managers/sharding.py
+++ b/single_kernel_mongo/managers/sharding.py
@@ -1,0 +1,570 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""In this class, we implement managers for config-servers and shards.
+
+This class handles the sharing of secrets between sharded components, adding shards, and removing
+shards.
+"""
+
+import json
+from logging import getLogger
+from typing import TYPE_CHECKING
+
+from ops import StatusBase
+from ops.framework import Object
+from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, Relation, WaitingStatus
+from pymongo.errors import OperationFailure, PyMongoError, ServerSelectionTimeoutError
+from tenacity import Retrying, stop_after_delay, wait_fixed
+
+from single_kernel_mongo.config.literals import Substrates
+from single_kernel_mongo.config.relations import RelationNames
+from single_kernel_mongo.core.structured_config import MongoDBRoles
+from single_kernel_mongo.exceptions import (
+    BalancerNotEnabledError,
+    DeferrableFailedHookChecksError,
+    FailedToUpdateCredentialsError,
+    NonDeferrableFailedHookChecksError,
+    NotDrainedError,
+    RemoveLastShardError,
+    ShardAuthError,
+    ShardNotInClusterError,
+    WaitingForCertificatesError,
+    WaitingForSecretsError,
+)
+from single_kernel_mongo.lib.charms.data_platform_libs.v0.data_interfaces import (
+    DatabaseProviderData,
+    DatabaseRequirerData,
+)
+from single_kernel_mongo.state.charm_state import CharmState
+from single_kernel_mongo.state.config_server_state import ConfigServerKeys
+from single_kernel_mongo.state.tls_state import SECRET_CA_LABEL
+from single_kernel_mongo.utils.mongo_connection import MongoConnection, NotReadyError
+from single_kernel_mongo.utils.mongodb_users import BackupUser, MongoDBUser, OperatorUser
+from single_kernel_mongo.workload.mongodb_workload import MongoDBWorkload
+
+if TYPE_CHECKING:
+    from single_kernel_mongo.managers.mongodb_operator import MongoDBOperator
+
+logger = getLogger(__name__)
+
+
+class ConfigServerManager(Object):
+    """Manage relations between the config server and the shard, on the config-server's side."""
+
+    def __init__(
+        self,
+        dependent: MongoDBOperator,
+        workload: MongoDBWorkload,
+        state: CharmState,
+        substrate: Substrates,
+        relation_name: RelationNames = RelationNames.CONFIG_SERVER,
+    ):
+        self.dependent = dependent
+        self.charm = dependent.charm
+        self.state = state
+        self.workload = workload
+        self.substrate = substrate
+        self.relation_name = relation_name
+
+    def on_relation_joined(self, relation: Relation):
+        """Relation joined event."""
+        relation_data = {
+            ConfigServerKeys.operator_password.value: self.state.get_user_password(OperatorUser),
+            ConfigServerKeys.backup_password.value: self.state.get_user_password(BackupUser),
+            ConfigServerKeys.key_file.value: self.state.get_keyfile(),
+            ConfigServerKeys.host.value: json.dumps(sorted(self.state.app_hosts)),
+        }
+        data_interface = DatabaseProviderData(self.model, relation_name=self.relation_name.value)
+
+        int_tls_ca = self.state.tls.get_secret(internal=True, label_name=SECRET_CA_LABEL)
+        if int_tls_ca:
+            relation_data[f"int-{SECRET_CA_LABEL}"] = int_tls_ca
+
+        data_interface.update_relation_data(relation.id, relation_data)
+
+    def on_relation_event(self, relation: Relation, is_leaving: bool = False):
+        """Handles adding and removing shards.
+
+        Updating of shards is done automatically via MongoDB change-streams.
+        """
+        # TODO: Hook checks
+        try:
+            logger.info("Adding/Removing shards not present in cluster.")
+            match is_leaving:
+                case False:
+                    self.add_shard(relation)
+                case True:
+                    self.remove_shards(relation)
+        except NotDrainedError:
+            # it is necessary to removeShard multiple times for the shard to be removed.
+            logger.info(
+                "Shard is still present in the cluster after removal, will defer and remove again."
+            )
+            raise
+        except OperationFailure as e:
+            if e.code == 20:
+                # TODO Future PR, allow removal of last shards that have no data. This will be
+                # tricky since we are not allowed to update the mongos config in this way.
+                logger.error(
+                    "Cannot not remove the last shard from cluster, this is forbidden by mongos."
+                )
+                # we should not lose connection with the shard, prevent other hooks from executing.
+                raise RemoveLastShardError
+
+            logger.error("Deferring _on_relation_event for shards interface since: error=%r", e)
+            raise
+        except (PyMongoError, NotReadyError, BalancerNotEnabledError) as e:
+            logger.error(f"Deferring _on_relation_event for shards interface since: error={e}")
+            raise
+
+    def update_credentials(self, key: str, value: str) -> None:
+        """Sends new credentials for a new key value pair across all shards."""
+        data_interface = DatabaseProviderData(self.model, self.relation_name.value)
+        for relation in self.state.config_server_relation:
+            data_interface.update_relation_data(relation.id, {key: value})
+
+    def update_mongos_hosts(self):
+        """Updates the hosts for mongos on the relation data."""
+        data_interface = DatabaseProviderData(self.model, self.relation_name.value)
+        for relation in self.state.config_server_relation:
+            data_interface.update_relation_data(
+                relation.id, {ConfigServerKeys.host.value: sorted(self.state.app_hosts)}
+            )
+
+    def update_ca_secret(self, new_ca: str | None) -> None:
+        """Updates the new CA for all related shards."""
+        data_interface = DatabaseProviderData(self.model, self.relation_name.value)
+        for relation in self.state.config_server_relation:
+            if new_ca is None:
+                data_interface.delete_relation_data(
+                    relation.id, [ConfigServerKeys.int_ca_secret.value]
+                )
+            else:
+                data_interface.update_relation_data(
+                    relation.id, {ConfigServerKeys.int_ca_secret.value: new_ca}
+                )
+
+    def skip_config_server_status(self) -> bool:
+        """Returns true if the status check should be skipped."""
+        if self.state.is_role(MongoDBRoles.SHARD):
+            logger.info("skipping config server status check, charm is  running as a shard")
+            return True
+
+        if not self.state.db_initialised:
+            logger.info("No status for shard to report, waiting for db to be initialised.")
+            return True
+
+        return False
+
+    def get_status(self) -> StatusBase | None:
+        """Returns the current status of the config-server."""
+        if self.skip_config_server_status():
+            return None
+
+        if self.state.is_role(MongoDBRoles.REPLICATION) and self.state.config_server_relation:
+            return BlockedStatus("sharding interface cannot be used by replicas")
+
+        if self.state.client_relations:
+            return BlockedStatus(
+                f"Sharding roles do not support {RelationNames.DATABASE.value} interface."
+            )
+
+        uri = f"mongodb://{','.join(self.state.app_hosts)}"
+        if not self.dependent.mongo_manager.mongod_ready(uri):
+            return BlockedStatus("Internal mongos is not running.")
+
+        if not self.cluster_password_synced():
+            return WaitingStatus("Waiting to sync passwords across the cluster")
+
+        shard_draining = self.get_draining_shards()
+        if shard_draining:
+            draining = ",".join(shard_draining)
+            return MaintenanceStatus(f"Draining shard {draining}")
+
+        if not self.state.config_server_relation:
+            return BlockedStatus("missing relation to shard(s)")
+
+        unreachable_shards = self.get_unreachable_shards()
+
+        if unreachable_shards:
+            unreachable = ", ".join(unreachable_shards)
+            return BlockedStatus(f"shards {unreachable} are unreachable.")
+
+        return ActiveStatus()
+
+    def add_shard(self, relation: Relation):
+        """Adds a shard to the cluster."""
+        shard_name = relation.app.name
+
+        hosts = []
+        for unit in relation.units:
+            if self.substrate == "k8s":
+                unit_name = unit.name.split("/")[0]
+                unit_id = unit.name.split("/")[1]
+                host_name = f"{unit_name}-{unit_id}.{unit_name}-endpoints"
+                hosts.append(host_name)
+            else:
+                if not (address := relation.data[unit].get("private-address")):
+                    raise Exception("Missing host")
+                hosts.append(address)
+        if not len(hosts):
+            logger.info(f"host info for shard {shard_name} not yet added, skipping")
+            return
+
+        self.charm.status_manager.to_maintenance(f"Adding shard {shard_name} to config-server")
+        with MongoConnection(self.state.mongos_config) as mongo:
+            try:
+                mongo.add_shard(shard_name, hosts)
+            except OperationFailure as e:
+                if e.code == 18:
+                    logger.error(
+                        f"{shard_name} shard does not have the same auth as the config server."
+                    )
+                    raise ShardAuthError(shard_name)
+            except PyMongoError as e:
+                logger.error(f"Failed to add {shard_name} to cluster")
+                raise e
+        self.charm.status_manager.to_active(None)
+
+    def remove_shards(self, relation: Relation):
+        """Removes a shard from the cluster."""
+        shard_name = relation.app.name
+
+        with MongoConnection(self.state.mongos_config) as mongo:
+            try:
+                self.charm.status_manager.to_maintenance(f"Draining shard {shard_name}")
+                logger.info("Attempting to removing shard: %s", shard_name)
+                mongo.pre_remove_checks(shard_name)
+                mongo.remove_shard(shard_name)
+                mongo.move_primary_after_draining_shard(shard_name)
+            except NotReadyError:
+                logger.info("Unable to remove shard: %s another shard is draining", shard_name)
+                # to guarantee that shard that the currently draining shard, gets re-processed,
+                # do not raise immediately, instead at the end of removal processing.
+                raise ShardNotInClusterError
+            except ShardNotInClusterError:
+                logger.info(
+                    "Shard to remove is not in sharded cluster. It has been successfully removed."
+                )
+
+    def cluster_password_synced(self) -> bool:
+        """Returns True if the cluster password is synced."""
+        # base case: not config-server
+        if not self.state.is_role(MongoDBRoles.CONFIG_SERVER):
+            return True
+
+        try:
+            # check our ability to use connect to mongos
+            with MongoConnection(self.state.mongos_config) as mongos:
+                mongos.get_shard_members()
+            # check our ability to use connect to mongod
+            with MongoConnection(self.state.mongo_config) as mongod:
+                mongod.get_replset_status()
+        except OperationFailure as e:
+            if e.code in [13, 18]:
+                return False
+            raise
+        except ServerSelectionTimeoutError:
+            # Connection refused, - this occurs when internal membership is not in sync across the
+            # cluster (i.e. TLS + KeyFile).
+            return False
+
+        return True
+
+    def get_draining_shards(self) -> list[str]:
+        """Returns the shard that is currently draining."""
+        with MongoConnection(self.state.mongos_config) as mongo:
+            draining_shards = mongo.get_draining_shards()
+
+            # in theory, this should always be a list of one. But if something has gone wrong we
+            # should take note and log it
+            if len(draining_shards) > 1:
+                logger.error("Multiple shards draining at the same time.")
+
+            return draining_shards
+
+    def get_unreachable_shards(self) -> list[str]:
+        """Returns a list of unreable shard hosts."""
+        unreachable_hosts: list[str] = []
+        if not self.model.relations[self.relation_name]:
+            logger.info("shards are not reachable, none related to config-sever")
+            return unreachable_hosts
+
+        for relation in self.state.config_server_relation:
+            shard_name = relation.app.name
+            hosts = []
+            for unit in relation.units:
+                if self.substrate == "k8s":
+                    unit_name = unit.name.split("/")[0]
+                    unit_id = unit.name.split("/")[1]
+                    host_name = f"{unit_name}-{unit_id}.{unit_name}-endpoints"
+                    hosts.append(host_name)
+                else:
+                    if not (address := relation.data[unit].get("private-address")):
+                        raise Exception("Missing host")
+                    hosts.append(address)
+            if not hosts:
+                return unreachable_hosts
+
+            # use a URI that is not dependent on the operator password, as we are not guaranteed
+            # that the shard has received the password yet.
+            uri = f"mongodb://{','.join(hosts)}"
+            if not self.dependent.mongo_manager.mongod_ready(uri):
+                unreachable_hosts.append(shard_name)
+
+        return unreachable_hosts
+
+
+class ShardManager(Object):
+    """Manage relations between the config server and the shard, on the shard's side."""
+
+    def __init__(
+        self,
+        dependent: MongoDBOperator,
+        workload: MongoDBWorkload,
+        state: CharmState,
+        substrate: Substrates,
+        relation_name: RelationNames = RelationNames.SHARDING,
+    ):
+        super().__init__(dependent, relation_name)
+        self.dependent = dependent
+        self.charm = dependent.charm
+        self.state = state
+        self.workload = workload
+        self.substrate = substrate
+        self.relation_name = relation_name
+        self.data_requirer = DatabaseRequirerData(
+            self.model,
+            relation_name=self.relation_name,
+            additional_secret_fields=[
+                ConfigServerKeys.operator_password,
+                ConfigServerKeys.backup_password,
+                ConfigServerKeys.key_file,
+                ConfigServerKeys.int_ca_secret,
+            ],
+            database_name="",
+        )
+
+    def assert_pass_sanity_hook_checks(self):
+        """Returns True if all the sanity hook checks for sharding pass."""
+        if not self.state.db_initialised:
+            raise DeferrableFailedHookChecksError("db is not initialised.")
+        if not self.dependent.is_relation_feasible(self.relation_name):
+            raise NonDeferrableFailedHookChecksError("relation is not feasible")
+        # TODO: revision checks.
+        if not self.state.is_role(MongoDBRoles.SHARD):
+            raise NonDeferrableFailedHookChecksError("is only executed by shards")
+
+    def assert_pass_hook_checks(self, relation: Relation, leaving: bool = False):
+        """Runs the pre-hooks checks, returns True if all pass."""
+        self.assert_pass_sanity_hook_checks()
+
+        # Edge case for DPE-4998
+        # TODO: Remove this when https://github.com/canonical/operator/issues/1306 is fixed.
+        if relation.app is None:
+            raise NonDeferrableFailedHookChecksError("Missing app information in event, skipping.")
+
+        mongos_hosts = self.state.shard_state.mongos_hosts
+
+        if leaving and not mongos_hosts:
+            raise NonDeferrableFailedHookChecksError(
+                "Config-server never set up, no need to process broken event."
+            )
+
+        if self.state.upgrade_in_progress:
+            logger.warning(
+                "Adding/Removing shards is not supported during an upgrade. The charm may be in a broken, unrecoverable state"
+            )
+            if not leaving:
+                raise DeferrableFailedHookChecksError
+
+        shard_has_tls, config_server_has_tls = self.tls_status()
+        match (shard_has_tls, config_server_has_tls):
+            case False, True:
+                raise DeferrableFailedHookChecksError(
+                    "Config-Server uses TLS but shard does not. Please synchronise encryption method."
+                )
+            case True, False:
+                raise DeferrableFailedHookChecksError(
+                    "Shard uses TLS but config-server does not. Please synchronise encryption method."
+                )
+            case _:
+                pass
+
+        if not self.is_ca_compatible():
+            raise DeferrableFailedHookChecksError(
+                "Shard is integrated to a different CA than the config server. Please use the same CA for all cluster components.",
+            )
+
+    def relation_created(self):
+        """Sets status and flags in relation data relevant to sharding."""
+        # if re-using an old shard, re-set flags.
+        self.state.unit_peer_data["drained"] = json.dumps(False)
+        self.charm.status_manager.to_maintenance("Adding shard to config-server")
+
+    def relation_changed(self, relation: Relation):
+        """Retrieves secrets from config-server and updates them within the shard."""
+        try:
+            self.assert_pass_hook_checks(relation)
+        except:
+            logger.info("Skipping relation changed event: hook checks did not pass.")
+            raise
+
+        keyfile = self.state.shard_state.keyfile
+        tls_ca = self.state.shard_state.internal_ca_secret
+
+        if keyfile is None and tls_ca is None:
+            logger.info("Waiting for secrets from config-server")
+            raise WaitingForSecretsError
+
+        self.update_member_auth(keyfile, tls_ca)
+
+        if tls_ca is not None and self.dependent.tls_manager.is_waiting_for_both_certs():
+            logger.info("Waiting for requested certs before restarting and adding to cluster.")
+            raise WaitingForCertificatesError
+
+        if not self.dependent.mongo_manager.mongod_ready():
+            raise NotReadyError
+
+        if not self.charm.unit.is_leader():
+            return
+
+        operator_password = self.state.shard_state.operator_password
+        backup_password = self.state.shard_state.backup_password
+        if not operator_password or not backup_password:
+            raise WaitingForSecretsError
+
+        self.sync_cluster_passwords(operator_password, backup_password)
+
+        self.state.app_peer_data.mongos_hosts = self.state.shard_state.mongos_hosts
+
+    def handle_secret_changed(self, secret_label: str | None):
+        """Update operator and backup user passwords when rotation occurs.
+
+        Changes in secrets do not re-trigger a relation changed event, so it is necessary to listen
+        to secret changes events.
+        """
+        if not self.charm.unit.is_leader():
+            return
+        if not secret_label:
+            return
+        if not (relation := self.state.shard_relation):
+            return
+
+        # many secret changed events occur, only listen to those related to our interface with the
+        # config-server
+        sharding_secretes_label = f"{self.relation_name}.{relation.id}.extra.secret"
+        if secret_label != sharding_secretes_label:
+            logger.info(
+                f"Secret unrelated to this sharding relation {relation.id} is changing, ignoring event."
+            )
+            return
+
+        operator_password = self.state.shard_state.operator_password
+        backup_password = self.state.shard_state.backup_password
+
+        if not operator_password or not backup_password:
+            raise WaitingForSecretsError
+        self.sync_cluster_passwords(operator_password, backup_password)
+
+    def update_member_auth(self, keyfile: str | None, tls_ca: str | None):
+        """Updates the shard to have the same membership auth as the config-server."""
+        cluster_auth_tls = tls_ca is not None
+        cluster_auth_keyfile = keyfile is not None
+        tls_integrated = self.state.tls_relation is not None
+
+        # Edge case: shard has TLS enabled before having connected to the config-server. For TLS in
+        # sharded MongoDB clusters it is necessary that the subject and organisation name are the
+        # same in their CSRs. Re-requesting a cert after integrated with the config-server
+        # regenerates the cert with the appropriate configurations needed for sharding.
+        if cluster_auth_tls and tls_integrated and self._should_request_new_certs():
+            logger.info("Cluster implements internal membership auth via certificates")
+            self.dependent.tls_manager.generate_certificate_request(param=None, internal=True)
+            self.dependent.tls_manager.generate_certificate_request(param=None, internal=False)
+        elif cluster_auth_keyfile and not cluster_auth_tls and not tls_integrated:
+            logger.info("Cluster implements internal membership auth via keyFile")
+
+        # Copy over keyfile regardless of whether the cluster uses TLS or or KeyFile for internal
+        # membership authentication. If TLS is disabled on the cluster this enables the cluster to
+        # have the correct cluster KeyFile readily available.
+        if keyfile:
+            self.workload.write(path=self.workload.paths.keyfile, content=keyfile)
+
+    def sync_cluster_passwords(self, operator_password: str, backup_password: str) -> None:
+        """Update shared cluster passwords."""
+        if self.dependent.primary is None:
+            logger.info(
+                "Replica set has not elected a primary after restarting, cannot update passwords."
+            )
+            raise NotReadyError
+
+        try:
+            self.update_password(user=OperatorUser, new_password=operator_password)
+            self.update_password(user=BackupUser, new_password=backup_password)
+        except (NotReadyError, PyMongoError, ServerSelectionTimeoutError):
+            # RelationChangedEvents will only update passwords when the relation is first joined,
+            # otherwise all other password changes result in a Secret Changed Event.
+            logger.error(
+                "Failed to sync cluster passwords from config-server to shard. Deferring event and retrying."
+            )
+            raise FailedToUpdateCredentialsError
+        # after updating the password of the backup user, restart pbm with correct password
+        self.dependent.backup_manager.connect()
+
+    def update_password(self, user: MongoDBUser, new_password: str):
+        """Updates the password for the given user."""
+        if not new_password or not self.charm.unit.is_leader():
+            return
+
+        current_password = self.state.get_user_password(user)
+
+        if new_password == current_password:
+            return
+
+        # updating operator password, usually comes after keyfile was updated, hence, the mongodb
+        # service was restarted. Sometimes this requires units getting insync again.
+        for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(3), reraise=True):
+            with attempt:
+                # TODO, in the future use set_password from src/charm.py - this will require adding
+                # a library, for exceptions used in both charm code and lib code.
+                with MongoConnection(self.state.mongo_config) as mongo:
+                    try:
+                        mongo.set_user_password(user.username, new_password)
+                    except NotReadyError:
+                        logger.error(
+                            "Failed changing the password: Not all members healthy or finished initial sync."
+                        )
+                        raise
+                    except PyMongoError as e:
+                        logger.error(f"Failed changing the password: {e}")
+                        raise
+        self.state.set_user_password(user, new_password)
+
+    def _should_request_new_certs(self) -> bool:
+        """Returns if the shard has already requested the certificates for internal-membership."""
+        int_subject = self.state.unit_peer_data.get("int_certs_subject") or None
+        ext_subject = self.state.unit_peer_data.get("ext_certs_subject") or None
+        return {int_subject, ext_subject} != {self.state.config_server_name}
+
+    def tls_status(self) -> tuple[bool, bool]:
+        """Returns the TLS integration status for shard and config-server."""
+        shard_relation = self.state.shard_relation
+        if shard_relation:
+            shard_has_tls = self.state.tls_relation is not None
+            config_server_has_tls = self.state.shard_state.internal_ca_secret is not None
+            return shard_has_tls, config_server_has_tls
+
+        return False, False
+
+    def is_ca_compatible(self) -> bool:
+        """Returns true if both the shard and the config server use the same CA."""
+        shard_relation = self.state.shard_relation
+        if not shard_relation:
+            return True
+        config_server_tls_ca = self.state.shard_state.internal_ca_secret
+        shard_tls_ca = self.state.tls.get_secret(internal=True, label_name=SECRET_CA_LABEL)
+        if not config_server_tls_ca or not shard_tls_ca:
+            return True
+
+        return config_server_tls_ca == shard_tls_ca

--- a/single_kernel_mongo/managers/sharding.py
+++ b/single_kernel_mongo/managers/sharding.py
@@ -461,7 +461,6 @@ class ShardManager(Object):
         # if re-using an old shard, re-set flags.
         self.state.unit_peer_data.drained = False
         self.charm.status_manager.to_maintenance("Adding shard to config-server")
-        self.data_requirer._on_relation_created_event
 
     def relation_changed(self, relation: Relation, leaving: bool = False):
         """Retrieves secrets from config-server and updates them within the shard."""

--- a/single_kernel_mongo/managers/sharding.py
+++ b/single_kernel_mongo/managers/sharding.py
@@ -612,8 +612,6 @@ class ShardManager(Object):
         # service was restarted. Sometimes this requires units getting insync again.
         for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(3), reraise=True):
             with attempt:
-                # TODO, in the future use set_password from src/charm.py - this will require adding
-                # a library, for exceptions used in both charm code and lib code.
                 with MongoConnection(self.state.mongo_config) as mongo:
                     try:
                         mongo.set_user_password(user.username, new_password)

--- a/single_kernel_mongo/managers/sharding.py
+++ b/single_kernel_mongo/managers/sharding.py
@@ -102,6 +102,12 @@ class ConfigServerManager(Object):
         Updating of shards is done automatically via MongoDB change-streams.
         """
         self.assert_pass_hook_checks(relation, is_leaving)
+
+        if self.data_interface.fetch_relation_field(relation.id, "database") is None:
+            raise DeferrableFailedHookChecksError(
+                f"Database Requested event has not run yet for relation {relation.id}"
+            )
+
         try:
             logger.info("Adding/Removing shards not present in cluster.")
             match is_leaving:

--- a/single_kernel_mongo/managers/sharding.py
+++ b/single_kernel_mongo/managers/sharding.py
@@ -396,7 +396,7 @@ class ShardManager(Object):
             self.model,
             relation_name=self.relation_name,
             additional_secret_fields=SECRETS_FIELDS,
-            database_name="",
+            database_name="unused",  # Needed for relation events
         )
 
     def assert_pass_sanity_hook_checks(self):
@@ -455,6 +455,7 @@ class ShardManager(Object):
         # if re-using an old shard, re-set flags.
         self.state.unit_peer_data.drained = False
         self.charm.status_manager.to_maintenance("Adding shard to config-server")
+        self.data_requirer._on_relation_created_event
 
     def relation_changed(self, relation: Relation, leaving: bool = False):
         """Retrieves secrets from config-server and updates them within the shard."""

--- a/single_kernel_mongo/managers/sharding.py
+++ b/single_kernel_mongo/managers/sharding.py
@@ -402,7 +402,7 @@ class ShardManager(Object):
             self.model,
             relation_name=self.relation_name,
             additional_secret_fields=SECRETS_FIELDS,
-            database_name="unused",  # Needed for relation events
+            database_name="",  # Needed for relation events
         )
 
     def assert_pass_sanity_hook_checks(self):

--- a/single_kernel_mongo/managers/sharding.py
+++ b/single_kernel_mongo/managers/sharding.py
@@ -75,11 +75,13 @@ class ConfigServerManager(Object):
             self.model, relation_name=self.relation_name.value
         )
 
-    def on_relation_joined(self, relation: Relation):
+    def on_database_requested(self, relation: Relation):
         """Relation joined event."""
+        self.assert_pass_hook_checks(relation)
+
         if self.data_interface.fetch_relation_field(relation.id, "database") is None:
             raise DeferrableFailedHookChecksError(
-                "Database Requested event has not run yet for relation {relation.id}"
+                f"Database Requested event has not run yet for relation {relation.id}"
             )
         relation_data = {
             ConfigServerKeys.operator_password.value: self.state.get_user_password(OperatorUser),
@@ -99,7 +101,7 @@ class ConfigServerManager(Object):
 
         Updating of shards is done automatically via MongoDB change-streams.
         """
-        # TODO: Hook checks
+        self.assert_pass_hook_checks(relation, is_leaving)
         try:
             logger.info("Adding/Removing shards not present in cluster.")
             match is_leaving:

--- a/single_kernel_mongo/managers/sharding.py
+++ b/single_kernel_mongo/managers/sharding.py
@@ -596,7 +596,7 @@ class ShardManager(Object):
             )
             raise FailedToUpdateCredentialsError
         # after updating the password of the backup user, restart pbm with correct password
-        self.dependent.backup_manager.connect()
+        self.dependent.backup_manager.configure_and_restart()
 
     def update_password(self, user: MongoDBUser, new_password: str):
         """Updates the password for the given user."""

--- a/single_kernel_mongo/managers/sharding.py
+++ b/single_kernel_mongo/managers/sharding.py
@@ -75,7 +75,7 @@ class ConfigServerManager(Object):
             self.model, relation_name=self.relation_name.value
         )
 
-    def prepare_sharding_config(self, relation: Relation):
+    def prepare_sharding_config(self, relation: Relation) -> None:
         """Handles the database requested event.
 
         It shares the different credentials and necessary files with the shard.
@@ -101,12 +101,11 @@ class ConfigServerManager(Object):
             relation.id, "unused", "unused"
         )  # Triggers the database created event
 
-    def reconcile_shards_for_relation(self, relation: Relation, is_leaving: bool = False):
+    def reconcile_shards_for_relation(self, relation: Relation, is_leaving: bool = False) -> None:
         """Handles adding and removing shards.
 
         Updating of shards is done automatically via MongoDB change-streams.
         """
-        logger.info("Running Relation Changed hook.")
         self.assert_pass_hook_checks(relation, is_leaving)
 
         if self.data_interface.fetch_relation_field(relation.id, "database") is None:
@@ -195,7 +194,7 @@ class ConfigServerManager(Object):
                 continue
             self.data_interface.update_relation_data(relation.id, {key: value})
 
-    def update_mongos_hosts(self):
+    def update_mongos_hosts(self) -> None:
         """Updates the hosts for mongos on the relation data."""
         for relation in self.state.config_server_relation:
             self.data_interface.update_relation_data(
@@ -262,7 +261,7 @@ class ConfigServerManager(Object):
 
         return ActiveStatus()
 
-    def add_shard(self, relation: Relation):
+    def add_shard(self, relation: Relation) -> None:
         """Adds a shard to the cluster."""
         shard_name = relation.app.name
 
@@ -293,7 +292,7 @@ class ConfigServerManager(Object):
                 raise e
         self.charm.status_manager.to_active(None)
 
-    def remove_shards(self, relation: Relation):
+    def remove_shards(self, relation: Relation) -> None:
         """Removes a shard from the cluster."""
         shard_name = relation.app.name
 
@@ -610,7 +609,10 @@ class ShardManager(Object):
         self.state.set_user_password(user, new_password)
 
     def _should_request_new_certs(self) -> bool:
-        """Returns if the shard has already requested the certificates for internal-membership."""
+        """Returns if the shard has already requested the certificates for internal-membership.
+
+        Sharded components must have the same subject names in their certs.
+        """
         int_subject = self.state.unit_peer_data.get("int_certs_subject") or None
         ext_subject = self.state.unit_peer_data.get("ext_certs_subject") or None
         return {int_subject, ext_subject} != {self.state.config_server_name}

--- a/single_kernel_mongo/managers/sharding.py
+++ b/single_kernel_mongo/managers/sharding.py
@@ -180,7 +180,7 @@ class ConfigServerManager(Object):
                 "Adding/Removing shards is not supported during an upgrade. The charm may be in a broken, unrecoverable state"
             )
             if not leaving:
-                raise DeferrableFailedHookChecksError
+                raise DeferrableFailedHookChecksError("Upgrade is in progress")
             if self.state.has_departed_run(relation.id):
                 raise DeferrableFailedHookChecksError(
                     "must wait for relation departed hook to decide if relation should be removed"
@@ -268,15 +268,8 @@ class ConfigServerManager(Object):
 
         hosts = []
         for unit in relation.units:
-            if self.substrate == "k8s":
-                unit_name = unit.name.split("/")[0]
-                unit_id = unit.name.split("/")[1]
-                host_name = f"{unit_name}-{unit_id}.{unit_name}-endpoints"
-                hosts.append(host_name)
-            else:
-                if not (address := relation.data[unit].get("private-address")):
-                    raise Exception("Missing host")
-                hosts.append(address)
+            unit_state = self.state.unit_peer_data_for(unit, relation)
+            hosts.append(unit_state.internal_address)
         if not len(hosts):
             logger.info(f"host info for shard {shard_name} not yet added, skipping")
             return
@@ -345,6 +338,7 @@ class ConfigServerManager(Object):
         except OperationFailure as e:
             if e.code in [13, 18]:  # Unauthorized, Auth Failed
                 return False
+            logger.error(f"Invalid operation failure when checking if cluster password synced: {e}")
             raise
         except ServerSelectionTimeoutError:
             # Connection refused, - this occurs when internal membership is not in sync across the

--- a/single_kernel_mongo/managers/sharding.py
+++ b/single_kernel_mongo/managers/sharding.py
@@ -93,8 +93,7 @@ class ConfigServerManager(Object):
             ConfigServerKeys.host.value: json.dumps(sorted(self.state.app_hosts)),
         }
 
-        int_tls_ca = self.state.tls.get_secret(internal=True, label_name=SECRET_CA_LABEL)
-        if int_tls_ca:
+        if int_tls_ca := self.state.tls.get_secret(internal=True, label_name=SECRET_CA_LABEL):
             relation_data[ConfigServerKeys.int_ca_secret.value] = int_tls_ca
 
         self.data_interface.update_relation_data(relation.id, relation_data)
@@ -120,11 +119,10 @@ class ConfigServerManager(Object):
 
         try:
             logger.info("Adding/Removing shards not present in cluster.")
-            match is_leaving:
-                case False:
-                    self.add_shard(relation)
-                case True:
-                    self.remove_shards(relation)
+            if is_leaving:
+                self.remove_shards(relation)
+            else:
+                self.add_shard(relation)
         except NotDrainedError:
             # it is necessary to removeShard multiple times for the shard to be removed.
             logger.info(
@@ -251,17 +249,14 @@ class ConfigServerManager(Object):
         if not self.cluster_password_synced():
             return WaitingStatus("Waiting to sync passwords across the cluster")
 
-        shard_draining = self.dependent.mongo_manager.get_draining_shards()
-        if shard_draining:
+        if shard_draining := self.dependent.mongo_manager.get_draining_shards():
             draining = ",".join(shard_draining)
             return MaintenanceStatus(f"Draining shard {draining}")
 
         if not self.state.config_server_relation:
             return BlockedStatus("missing relation to shard(s)")
 
-        unreachable_shards = self.get_unreachable_shards()
-
-        if unreachable_shards:
+        if unreachable_shards := self.get_unreachable_shards():
             unreachable = ", ".join(unreachable_shards)
             return BlockedStatus(f"shards {unreachable} are unreachable.")
 
@@ -317,7 +312,7 @@ class ConfigServerManager(Object):
             try:
                 self.charm.status_manager.to_maintenance(f"Draining shard {shard_name}")
                 logger.info("Attempting to removing shard: %s", shard_name)
-                mongo.pre_remove_checks(shard_name)
+                mongo.pre_remove_shard_checks(shard_name)
                 mongo.remove_shard(shard_name)
                 mongo.move_primary_after_draining_shard(shard_name)
             except NotReadyError:
@@ -348,7 +343,7 @@ class ConfigServerManager(Object):
             with MongoConnection(self.state.mongo_config) as mongod:
                 mongod.get_replset_status()
         except OperationFailure as e:
-            if e.code in [13, 18]:
+            if e.code in [13, 18]:  # Unauthorized, Auth Failed
                 return False
             raise
         except ServerSelectionTimeoutError:
@@ -408,7 +403,7 @@ class ShardManager(Object):
             database_name="unused",  # Needed for relation events
         )
 
-    def assert_pass_sanity_hook_checks(self):
+    def assert_pass_sanity_hook_checks(self) -> None:
         """Returns True if all the sanity hook checks for sharding pass."""
         if not self.state.db_initialised:
             raise DeferrableFailedHookChecksError("db is not initialised.")
@@ -418,7 +413,7 @@ class ShardManager(Object):
         if not self.state.is_role(MongoDBRoles.SHARD):
             raise NonDeferrableFailedHookChecksError("is only executed by shards")
 
-    def assert_pass_hook_checks(self, relation: Relation, is_leaving: bool = False):
+    def assert_pass_hook_checks(self, relation: Relation, is_leaving: bool = False) -> None:
         """Runs the pre-hooks checks, returns True if all pass."""
         self.assert_pass_sanity_hook_checks()
 
@@ -459,13 +454,13 @@ class ShardManager(Object):
                 "Shard is integrated to a different CA than the config server. Please use the same CA for all cluster components.",
             )
 
-    def prepare_to_add_shard(self):
+    def prepare_to_add_shard(self) -> None:
         """Sets status and flags in relation data relevant to sharding."""
         # if re-using an old shard, re-set flags.
         self.state.unit_peer_data.drained = False
         self.charm.status_manager.to_maintenance("Adding shard to config-server")
 
-    def synchronise_cluster_secrets(self, relation: Relation, leaving: bool = False):
+    def synchronise_cluster_secrets(self, relation: Relation, leaving: bool = False) -> None:
         """Retrieves secrets from config-server and updates them within the shard."""
         try:
             self.assert_pass_hook_checks(relation=relation, is_leaving=leaving)
@@ -503,7 +498,7 @@ class ShardManager(Object):
         self.data_requirer.update_relation_data(relation.id, {"auth-updated": "true"})
         self.state.app_peer_data.mongos_hosts = self.state.shard_state.mongos_hosts
 
-    def handle_secret_changed(self, secret_label: str | None):
+    def handle_secret_changed(self, secret_label: str | None) -> None:
         """Update operator and backup user passwords when rotation occurs.
 
         Changes in secrets do not re-trigger a relation changed event, so it is necessary to listen
@@ -546,7 +541,7 @@ class ShardManager(Object):
 
         self.charm.status_manager.to_active("Shard drained from cluster, ready for removal")
 
-    def update_member_auth(self, keyfile: str, tls_ca: str | None):
+    def update_member_auth(self, keyfile: str, tls_ca: str | None) -> None:
         """Updates the shard to have the same membership auth as the config-server."""
         cluster_auth_tls = tls_ca is not None
         tls_integrated = self.state.tls_relation is not None
@@ -593,7 +588,7 @@ class ShardManager(Object):
         # after updating the password of the backup user, restart pbm with correct password
         self.dependent.backup_manager.configure_and_restart()
 
-    def update_password(self, user: MongoDBUser, new_password: str):
+    def update_password(self, user: MongoDBUser, new_password: str) -> None:
         """Updates the password for the given user."""
         if not new_password or not self.charm.unit.is_leader():
             return
@@ -648,10 +643,11 @@ class ShardManager(Object):
 
         return config_server_tls_ca == shard_tls_ca
 
-    def wait_for_draining(self, mongos_hosts: list[str]):
+    def wait_for_draining(self, mongos_hosts: list[str]) -> None:
         """Waits for shards to be drained from sharded cluster."""
         drained = False
 
+        self.charm.status_manager.to_maintenance("Draining shard from cluster.")
         while not drained:
             try:
                 # no need to continuously check and abuse resources while shard is draining
@@ -677,7 +673,7 @@ class ShardManager(Object):
                 self.state.unit_peer_data.drained = True
                 break
 
-    def drained(self, mongos_hosts: list[str], shard_name: str):
+    def drained(self, mongos_hosts: list[str], shard_name: str) -> bool:
         """Returns whether a shard has been drained from the cluster or not.
 
         Raises:

--- a/single_kernel_mongo/managers/sharding.py
+++ b/single_kernel_mongo/managers/sharding.py
@@ -467,7 +467,7 @@ class ShardManager(Object):
 
         if keyfile is None:
             logger.info("Waiting for secrets from config-server")
-            raise WaitingForSecretsError
+            raise WaitingForSecretsError("Missing keyfile")
 
         self.update_member_auth(keyfile, tls_ca)
 
@@ -484,7 +484,7 @@ class ShardManager(Object):
         operator_password = self.state.shard_state.operator_password
         backup_password = self.state.shard_state.backup_password
         if not operator_password or not backup_password:
-            raise WaitingForSecretsError
+            raise WaitingForSecretsError("Missing operator password or backup password")
 
         self.sync_cluster_passwords(operator_password, backup_password)
 
@@ -520,7 +520,7 @@ class ShardManager(Object):
         backup_password = self.state.shard_state.backup_password
 
         if not operator_password or not backup_password:
-            raise WaitingForSecretsError
+            raise WaitingForSecretsError("Missing operator password or backup password")
         self.sync_cluster_passwords(operator_password, backup_password)
 
     def drain_shard_from_cluster(self, relation: Relation) -> None:

--- a/single_kernel_mongo/state/app_peer_state.py
+++ b/single_kernel_mongo/state/app_peer_state.py
@@ -24,6 +24,7 @@ class AppPeerDataKeys(str, Enum):
     role = "role"
     keyfile = "keyfile"
     external_connectivity = "external-connectivity"
+    mongos_hosts = "mongos_hosts"
 
 
 class AppPeerReplicaSet(AbstractRelationState[DataPeerData]):
@@ -120,6 +121,19 @@ class AppPeerReplicaSet(AbstractRelationState[DataPeerData]):
     def keyfile(self, keyfile: str):
         """Stores the keyfile in the app databag."""
         self.update({AppPeerDataKeys.keyfile.value: keyfile})
+
+    @property
+    def mongos_hosts(self) -> list[str]:
+        """Gets the mongos hosts from the databag."""
+        if not self.relation:
+            return []
+
+        return json.loads(self.relation_data.get(AppPeerDataKeys.mongos_hosts.value, "[]"))
+
+    @mongos_hosts.setter
+    def mongos_hosts(self, value: list[str]):
+        """Stores the mongos hosts in the databag."""
+        self.update({AppPeerDataKeys.mongos_hosts.value: json.dumps(sorted(value))})
 
     def set_user_created(self, user: str):
         """Stores the flag stating if user was created."""

--- a/single_kernel_mongo/state/app_peer_state.py
+++ b/single_kernel_mongo/state/app_peer_state.py
@@ -65,8 +65,10 @@ class AppPeerReplicaSet(AbstractRelationState[DataPeerData]):
 
         Either from the app databag or from the default from config.
         """
-        databag_role: str = str(self.relation_data.get(AppPeerDataKeys.role.value))
-        if not self.relation or not databag_role:
+        databag_role: str | None = self.relation_data.get(AppPeerDataKeys.role.value)
+        if not databag_role:
+            return MongoDBRoles.UNKNOWN
+        if not self.relation:
             return self._role
         return MongoDBRoles(databag_role)
 

--- a/single_kernel_mongo/state/app_peer_state.py
+++ b/single_kernel_mongo/state/app_peer_state.py
@@ -65,8 +65,7 @@ class AppPeerReplicaSet(AbstractRelationState[DataPeerData]):
 
         Either from the app databag or from the default from config.
         """
-        databag_role: str | None = self.relation_data.get(AppPeerDataKeys.role.value)
-        if not databag_role:
+        if not (databag_role := self.relation_data.get(AppPeerDataKeys.role.value)):
             return MongoDBRoles.UNKNOWN
         if not self.relation:
             return self._role

--- a/single_kernel_mongo/state/charm_state.py
+++ b/single_kernel_mongo/state/charm_state.py
@@ -42,7 +42,7 @@ from single_kernel_mongo.state.app_peer_state import (
 from single_kernel_mongo.state.cluster_state import ClusterState
 from single_kernel_mongo.state.config_server_state import (
     SECRETS_FIELDS,
-    ConfigServerState,
+    ShardingComponentState,
 )
 from single_kernel_mongo.state.models import ClusterData
 from single_kernel_mongo.state.tls_state import TLSState
@@ -176,6 +176,20 @@ class CharmState(Object):
             bind_address=str(self.bind_address),
         )
 
+    def unit_peer_data_for(self, unit: Unit, relation: Relation) -> UnitPeerReplicaSet:
+        """The provided unit peer relation data."""
+        data_interface = DataPeerOtherUnitData(
+            model=self.model,
+            unit=unit,
+            relation=relation,
+        )
+        return UnitPeerReplicaSet(
+            relation=relation,
+            data_interface=data_interface,
+            component=unit,
+            substrate=self.substrate,
+        )
+
     @property
     def units(self) -> set[UnitPeerReplicaSet]:
         """Grabs all units in the current peer relation, including this unit.
@@ -298,12 +312,15 @@ class CharmState(Object):
         return MongoPorts.MONGODB_PORT
 
     @property
-    def shard_state(self):
+    def shard_state(self) -> ShardingComponentState:
         """The shard state."""
-        return ConfigServerState(
+        return ShardingComponentState(
             relation=self.shard_relation,
             data_interface=DatabaseRequirerData(
-                self.model, RelationNames.SHARDING, "", additional_secret_fields=SECRETS_FIELDS
+                self.model,
+                RelationNames.SHARDING,
+                "unused",
+                additional_secret_fields=SECRETS_FIELDS,
             ),
             component=self.model.app,
         )

--- a/single_kernel_mongo/state/charm_state.py
+++ b/single_kernel_mongo/state/charm_state.py
@@ -30,6 +30,7 @@ from single_kernel_mongo.config.relations import (
 from single_kernel_mongo.core.secrets import SecretCache
 from single_kernel_mongo.core.structured_config import MongoConfigModel, MongoDBRoles
 from single_kernel_mongo.lib.charms.data_platform_libs.v0.data_interfaces import (
+    DatabaseRequirerData,
     DataPeerData,
     DataPeerOtherUnitData,
     DataPeerUnitData,
@@ -39,6 +40,10 @@ from single_kernel_mongo.state.app_peer_state import (
     AppPeerReplicaSet,
 )
 from single_kernel_mongo.state.cluster_state import ClusterState
+from single_kernel_mongo.state.config_server_state import (
+    SECRETS_FIELDS,
+    ConfigServerState,
+)
 from single_kernel_mongo.state.models import ClusterData
 from single_kernel_mongo.state.tls_state import TLSState
 from single_kernel_mongo.state.unit_peer_state import (
@@ -135,6 +140,11 @@ class CharmState(Object):
     def config_server_relation(self) -> set[Relation]:
         """The config-server relation if it exists."""
         return set(self.model.relations[RelationNames.CONFIG_SERVER.value])
+
+    @property
+    def tls_relation(self) -> Relation | None:
+        """The TLS relation."""
+        return self.model.get_relation(ExternalRequirerRelations.TLS.value)
 
     @property
     def s3_relation(self) -> Relation | None:
@@ -286,6 +296,17 @@ class CharmState(Object):
                 return self.unit_peer_data.node_port
             return MongoPorts.MONGOS_PORT
         return MongoPorts.MONGODB_PORT
+
+    @property
+    def shard_state(self):
+        """The shard state."""
+        return ConfigServerState(
+            relation=self.shard_relation,
+            data_interface=DatabaseRequirerData(
+                self.model, RelationNames.SHARDING, "", additional_secret_fields=SECRETS_FIELDS
+            ),
+            component=self.model.app,
+        )
 
     @property
     def config_server_name(self) -> str | None:

--- a/single_kernel_mongo/state/charm_state.py
+++ b/single_kernel_mongo/state/charm_state.py
@@ -181,7 +181,7 @@ class CharmState(Object):
         data_interface = DataPeerOtherUnitData(
             model=self.model,
             unit=unit,
-            relation=relation,
+            relation_name=relation.name,
         )
         return UnitPeerReplicaSet(
             relation=relation,

--- a/single_kernel_mongo/state/config_server_state.py
+++ b/single_kernel_mongo/state/config_server_state.py
@@ -4,6 +4,7 @@
 
 """The Cluster state."""
 
+import json
 from enum import Enum
 
 from ops import Application
@@ -17,6 +18,14 @@ class ConfigServerKeys(str, Enum):
     """Cluster State Model."""
 
     database = "database"
+    operator_password = "operator-password"
+    backup_password = "backup-password"
+    host = "host"
+    key_file = "key-file"
+    int_ca_secret = "int-ca-secret"
+
+
+SECRETS_FIELDS = ["operator-password", "backup-password", "key-file", "int-ca-secret"]
 
 
 class ConfigServerState(AbstractRelationState[Data]):
@@ -27,3 +36,42 @@ class ConfigServerState(AbstractRelationState[Data]):
     def __init__(self, relation: Relation | None, data_interface: Data, component: Application):
         super().__init__(relation, data_interface=data_interface, component=component)
         self.data_interface = data_interface
+
+    @property
+    def mongos_hosts(self) -> list[str]:
+        """The mongos hosts in the relation."""
+        if not self.relation:
+            return []
+        return json.loads(self.relation_data.get(ConfigServerKeys, "[]"))
+
+    @mongos_hosts.setter
+    def mongos_hosts(self, value: list[str]):
+        self.update({ConfigServerKeys.host.value: json.dumps(sorted(value))})
+
+    @property
+    def internal_ca_secret(self) -> str | None:
+        """Returns the internal CA secret."""
+        if not self.relation:
+            return None
+        return self.relation_data.get(ConfigServerKeys.int_ca_secret.value, None)
+
+    @property
+    def keyfile(self) -> str | None:
+        """Returns the keyfile."""
+        if not self.relation:
+            return None
+        return self.relation_data.get(ConfigServerKeys.key_file.value, None)
+
+    @property
+    def operator_password(self) -> str | None:
+        """Returns the operator password."""
+        if not self.relation:
+            return None
+        return self.relation_data.get(ConfigServerKeys.operator_password.value, None)
+
+    @property
+    def backup_password(self) -> str | None:
+        """Returns the operator password."""
+        if not self.relation:
+            return None
+        return self.relation_data.get(ConfigServerKeys.backup_password.value, None)

--- a/single_kernel_mongo/state/config_server_state.py
+++ b/single_kernel_mongo/state/config_server_state.py
@@ -28,7 +28,7 @@ class ConfigServerKeys(str, Enum):
 SECRETS_FIELDS = ["operator-password", "backup-password", "key-file", "int-ca-secret"]
 
 
-class ConfigServerState(AbstractRelationState[Data]):
+class ShardingComponentState(AbstractRelationState[Data]):
     """The stored state for the ConfigServer Relation."""
 
     component: Application

--- a/single_kernel_mongo/state/tls_state.py
+++ b/single_kernel_mongo/state/tls_state.py
@@ -52,3 +52,18 @@ class TLSState:
                 return self.internal_enabled
             case False:
                 return self.external_enabled
+
+    def set_secret(self, internal: bool, label_name: str, contents: str | None) -> None:
+        """Sets TLS secret, based on whether or not it is related to internal connections."""
+        scope = "int" if internal else "ext"
+        label_name = f"{scope}-{label_name}"
+        if not contents:
+            self.secrets.remove(Scope.UNIT, label_name)
+            return
+        self.secrets.set(label_name, contents, Scope.UNIT)
+
+    def get_secret(self, internal: bool, label_name: str) -> str | None:
+        """Gets TLS secret, based on whether or not it is related to internal connections."""
+        scope = "int" if internal else "ext"
+        label_name = f"{scope}-{label_name}"
+        return self.secrets.get_for_key(Scope.UNIT, label_name)

--- a/single_kernel_mongo/state/unit_peer_state.py
+++ b/single_kernel_mongo/state/unit_peer_state.py
@@ -2,6 +2,7 @@
 # See LICENSE file for licensing details.
 """The peer unit relation databag."""
 
+import json
 from enum import Enum
 from functools import cached_property
 
@@ -99,3 +100,14 @@ class UnitPeerReplicaSet(AbstractRelationState[DataPeerUnitData]):
         K8s-only.
         """
         return self.k8s.get_node_port(MongoPorts.MONGOS_PORT)
+
+    @property
+    def drained(self) -> bool:
+        """Is the shard drained."""
+        return json.loads(self.relation_data.get("drained", "true"))
+
+    @drained.setter
+    def drained(self, value: bool):
+        if not isinstance(value, bool):
+            raise ValueError(f"drained value is not boolean but {value}")
+        self.update({"drained": json.dumps(value)})

--- a/single_kernel_mongo/state/unit_peer_state.py
+++ b/single_kernel_mongo/state/unit_peer_state.py
@@ -103,7 +103,14 @@ class UnitPeerReplicaSet(AbstractRelationState[DataPeerUnitData]):
 
     @property
     def drained(self) -> bool:
-        """Is the shard drained."""
+        """Returns True if the shard is drained.
+
+        We check the unit databag rather than the app databag since a draining
+        operation blocks all events from occurring. The unit databag allows us
+        to update and check our draining status in the same event as the
+        draining. Unlike the app databag which triggers requires a
+        RelationChangedEvent to propagate.
+        """
         return json.loads(self.relation_data.get("drained", "true"))
 
     @drained.setter

--- a/single_kernel_mongo/utils/mongo_connection.py
+++ b/single_kernel_mongo/utils/mongo_connection.py
@@ -536,7 +536,7 @@ class MongoConnection:
             NotEnoughSpaceError, ConfigurationError, OperationFailure
         """
         for database_name in databases_to_move:
-            db_size = self.get_db_size(database_name, old_primary)
+            db_size = self.get_db_size_on_primary_shard(database_name, old_primary)
             new_shard, avail_space = self.get_shard_with_most_available_space(
                 shard_to_ignore=old_primary
             )
@@ -551,7 +551,7 @@ class MongoConnection:
             # From MongoDB Docs: After starting movePrimary, do not perform any read or write
             # operations against any unsharded collection in that database until the command
             # completes.
-            logger.info(
+            logger.warning(
                 "Moving primary on %s database to new primary: %s. Do NOT write to %s database.",
                 database_name,
                 new_shard,
@@ -566,7 +566,7 @@ class MongoConnection:
                 new_shard,
             )
 
-    def get_db_size(self, database_name, primary_shard) -> int:
+    def get_db_size_on_primary_shard(self, database_name: str, primary_shard: str) -> int:
         """Returns the size of a DB on a given shard in bytes."""
         database = self.client[database_name]
         db_stats = database.command("dbStats")
@@ -583,7 +583,7 @@ class MongoConnection:
 
         return 0
 
-    def get_shard_with_most_available_space(self, shard_to_ignore) -> tuple[str, int]:
+    def get_shard_with_most_available_space(self, shard_to_ignore: str) -> tuple[str, int]:
         """Returns the shard in the cluster with the most available space and the space in bytes.
 
         Algorithm used was similar to that used in mongo in `selectShardForNewDatabase`:

--- a/single_kernel_mongo/utils/mongo_connection.py
+++ b/single_kernel_mongo/utils/mongo_connection.py
@@ -385,7 +385,7 @@ class MongoConnection:
         logger.info("Adding shard %s", shard_name)
         self.client.admin.command("addShard", shard_url)
 
-    def pre_remove_shard_checks(self, shard_name: str):
+    def pre_remove_shard_checks(self, shard_name: str) -> None:
         """Performs a series of checks for removing a shard from the cluster.
 
         Raises:
@@ -446,7 +446,7 @@ class MongoConnection:
                 if balancer_state["mode"] == "off":
                     raise BalancerNotEnabledError("balancer is not enabled.")
 
-    def remove_shard(self, shard_name: str):
+    def remove_shard(self, shard_name: str) -> None:
         """Removes shard from the cluster.
 
         Raises:
@@ -462,7 +462,7 @@ class MongoConnection:
             logger.info("Waiting for all chunks to be drained from %s.", shard_name)
             raise NotDrainedError
 
-    def move_primary_after_draining_shard(self, shard_name: str):
+    def move_primary_after_draining_shard(self, shard_name: str) -> None:
         """Move primary after the shard was drained and removed from the cluster."""
         # MongoDB docs says to movePrimary only after all chunks have been drained from the shard.
         logger.info("All chunks drained from shard: %s", shard_name)
@@ -484,7 +484,7 @@ class MongoConnection:
             logger.info("Shard %s is still present in sharded cluster.", shard_name)
             raise NotDrainedError()
 
-    def _log_removal_info(self, removal_info, shard_name, remaining_chunks):
+    def _log_removal_info(self, removal_info, shard_name, remaining_chunks) -> None:
         """Logs removal information for a shard removal."""
         dbs_to_move = (
             removal_info["dbsToMove"]

--- a/single_kernel_mongo/utils/mongo_connection.py
+++ b/single_kernel_mongo/utils/mongo_connection.py
@@ -385,7 +385,7 @@ class MongoConnection:
         logger.info("Adding shard %s", shard_name)
         self.client.admin.command("addShard", shard_url)
 
-    def pre_remove_checks(self, shard_name: str):
+    def pre_remove_shard_checks(self, shard_name: str):
         """Performs a series of checks for removing a shard from the cluster.
 
         Raises:
@@ -398,7 +398,7 @@ class MongoConnection:
 
         # It is necessary to call removeShard multiple times on a shard to guarantee removal.
         # Allow re-removal of shards that are currently draining.
-        if self.is_any_draining(ignore_shard=shard_name):
+        if self.is_any_shard_draining(ignore_shard=shard_name):
             cannot_remove_shard = (
                 f"cannot remove shard {shard_name} from cluster, another shard is draining"
             )
@@ -415,7 +415,7 @@ class MongoConnection:
         logger.info("Balancer process is not running, enabling it.")
         self.start_and_wait_for_balancer()
 
-    def is_any_draining(self, ignore_shard: str = "") -> bool:
+    def is_any_shard_draining(self, ignore_shard: str = "") -> bool:
         """Returns true if any shard members is draining.
 
         Checks if any members in sharded cluster are draining data.
@@ -437,7 +437,7 @@ class MongoConnection:
         Starting the balancer doesn't guarantee that is is running, wait until it starts up.
 
         Raises:
-            BalancerNotEnabledError
+            BalancerNotEnabledError, ConfigurationError, OperationFailure
         """
         self.client.admin.command("balancerStart")
         for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(3), reraise=True):
@@ -466,8 +466,7 @@ class MongoConnection:
         """Move primary after the shard was drained and removed from the cluster."""
         # MongoDB docs says to movePrimary only after all chunks have been drained from the shard.
         logger.info("All chunks drained from shard: %s", shard_name)
-        databases_using_shard_as_primary = self.get_databases_for_shard(shard_name)
-        if databases_using_shard_as_primary:
+        if databases_using_shard_as_primary := self.get_databases_for_shard(shard_name):
             logger.info(
                 "These databases: %s use Shard %s is a primary shard, moving primary.",
                 ", ".join(databases_using_shard_as_primary),
@@ -536,6 +535,9 @@ class MongoConnection:
             NotEnoughSpaceError, ConfigurationError, OperationFailure
         """
         for database_name in databases_to_move:
+            # we try to find the shard that has the most available space and if
+            # it's still to small, we raise an error so the user can act
+            # accordingly.
             db_size = self.get_db_size_on_primary_shard(database_name, old_primary)
             new_shard, avail_space = self.get_shard_with_most_available_space(
                 shard_to_ignore=old_primary
@@ -567,7 +569,11 @@ class MongoConnection:
             )
 
     def get_db_size_on_primary_shard(self, database_name: str, primary_shard: str) -> int:
-        """Returns the size of a DB on a given shard in bytes."""
+        """Returns the size of a DB on a given shard in bytes.
+
+        We need to find the amount of storage used because we cannot move
+        primary to a shard that doesn't have enough available space.
+        """
         database = self.client[database_name]
         db_stats = database.command("dbStats")
 

--- a/tests/unit/mongodb_test_charm/requirements.txt
+++ b/tests/unit/mongodb_test_charm/requirements.txt
@@ -1,2 +1,2 @@
 ops~=2.15.0
-git+https://github.com/Canonical/mongo-single-kernel-library.git@feat/architecture-and-first-handlers#egg=mongo-charms-single-kernel
+git+https://github.com/Canonical/mongo-single-kernel-library.git@feat/config-server-and-shard#egg=mongo-charms-single-kernel

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -424,7 +424,6 @@ def test_primary(harness: Harness[MongoTestCharm], mocker):
     harness.charm.operator.state.db_initialised = True
     mocker.patch(
         "single_kernel_mongo.utils.mongo_connection.MongoConnection.primary",
-        new_callable=mocker.PropertyMock,
         return_value="1.1.1.1",
     )
     output = harness.run_action("get-primary")
@@ -448,7 +447,6 @@ def test_primary_other_unit(harness: Harness[MongoTestCharm], mocker):
     harness.charm.operator.state.db_initialised = True
     mocker.patch(
         "single_kernel_mongo.utils.mongo_connection.MongoConnection.primary",
-        new_callable=mocker.PropertyMock,
         return_value=PEER_ADDR["private-address"],
     )
     rel = harness.charm.operator.state.peer_relation

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -148,7 +148,6 @@ def test_mongos_config_manager(mocker):
         f"--auditPath={VM_PATH['mongod']['LOGS']}/audit.log",
     ]
     assert auth_parameter == [
-        "--auth",
         "--clusterAuthMode=keyFile",
         f"--keyFile={VM_PATH['mongod']['CONF']}/keyFile",
     ]

--- a/tests/unit/test_sharding.py
+++ b/tests/unit/test_sharding.py
@@ -1,0 +1,358 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import pytest
+from ops.model import MaintenanceStatus, Relation
+from ops.testing import Harness
+from pymongo.errors import OperationFailure, ServerSelectionTimeoutError
+
+from single_kernel_mongo.config.relations import RelationNames
+from single_kernel_mongo.core.structured_config import MongoDBRoles
+from single_kernel_mongo.exceptions import (
+    DeferrableFailedHookChecksError,
+    NonDeferrableFailedHookChecksError,
+)
+
+from .helpers import patch_network_get
+from .mongodb_test_charm.src.charm import MongoTestCharm
+
+############################
+# Config Server Side tests #
+############################
+
+
+@patch_network_get(private_address="1.1.1.1")
+def test_config_server_database_requested(harness: Harness[MongoTestCharm]):
+    manager = harness.charm.operator.config_server_manager
+
+    harness.set_leader(True)
+
+    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.CONFIG_SERVER.value
+    harness.charm.operator.state.db_initialised = True
+
+    rel_id = harness.add_relation(RelationNames.CONFIG_SERVER.value, "shard0")
+
+    harness.update_relation_data(rel_id, "shard0", {"database": "unused"})
+
+    data = manager.data_interface.as_dict(rel_id)
+
+    assert len(data.get("key-file", "")) == 1024
+    assert data.get("database") == "unused"
+    assert data.get("username") == "unused"
+    assert data.get("password") == "unused"
+    assert data.get("operator-password") is not None
+    assert data.get("backup-password") is not None
+    assert data.get("host") == '["1.1.1.1"]'
+
+
+@patch_network_get(private_address="1.1.1.1")
+def test_config_server_database_requested_failed_db_not_initialised(
+    harness: Harness[MongoTestCharm],
+):
+    manager = harness.charm.operator.config_server_manager
+
+    harness.set_leader(True)
+    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.CONFIG_SERVER.value
+    harness.charm.operator.state.db_initialised = False
+
+    rel_id = harness.add_relation(RelationNames.CONFIG_SERVER.value, "shard0")
+
+    relation: Relation = harness.charm.model.get_relation(RelationNames.CONFIG_SERVER.value, rel_id)  # type: ignore[assignment]
+
+    with pytest.raises(DeferrableFailedHookChecksError) as err:
+        manager.prepare_sharding_config(relation)
+
+    assert err.value.args[0] == "db is not initialised."
+
+
+@patch_network_get(private_address="1.1.1.1")
+def test_config_server_database_requested_failed_role_invalid(
+    harness: Harness[MongoTestCharm],
+):
+    manager = harness.charm.operator.config_server_manager
+
+    harness.set_leader(True)
+    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION.value
+    harness.charm.operator.state.db_initialised = True
+
+    rel_id = harness.add_relation(RelationNames.CONFIG_SERVER.value, "shard0")
+
+    relation: Relation = harness.charm.model.get_relation(RelationNames.CONFIG_SERVER.value, rel_id)  # type: ignore[assignment]
+
+    with pytest.raises(NonDeferrableFailedHookChecksError) as err:
+        manager.prepare_sharding_config(relation)
+
+    assert err.value.args[0] == "is only executed by config-server"
+
+
+@patch_network_get(private_address="1.1.1.1")
+def test_config_server_database_requested_failed_not_leader(
+    harness: Harness[MongoTestCharm],
+):
+    manager = harness.charm.operator.config_server_manager
+
+    harness.set_leader(True)
+    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.CONFIG_SERVER.value
+    harness.charm.operator.state.db_initialised = True
+
+    rel_id = harness.add_relation(RelationNames.CONFIG_SERVER.value, "shard0")
+
+    relation: Relation = harness.charm.model.get_relation(RelationNames.CONFIG_SERVER.value, rel_id)  # type: ignore[assignment]
+
+    harness.set_leader(False)
+
+    with pytest.raises(NonDeferrableFailedHookChecksError) as err:
+        manager.prepare_sharding_config(relation)
+
+    assert err.value.args == ()
+
+
+@patch_network_get(private_address="1.1.1.1")
+def test_config_server_database_requested_failed_wrong_pbm_status(
+    harness: Harness[MongoTestCharm], mocker
+):
+    manager = harness.charm.operator.config_server_manager
+
+    harness.set_leader(True)
+    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.CONFIG_SERVER.value
+    harness.charm.operator.state.db_initialised = True
+
+    mocker.patch(
+        "single_kernel_mongo.managers.backups.BackupManager.get_status",
+        return_value=MaintenanceStatus(""),
+    )
+
+    rel_id = harness.add_relation(RelationNames.CONFIG_SERVER.value, "shard0")
+
+    relation: Relation = harness.charm.model.get_relation(RelationNames.CONFIG_SERVER.value, rel_id)  # type: ignore[assignment]
+
+    with pytest.raises(DeferrableFailedHookChecksError) as err:
+        manager.prepare_sharding_config(relation)
+
+    assert err.value.args[0] == "Cannot add/remove shards while a backup/restore is in progress."
+
+
+@patch_network_get(private_address="1.1.1.1")
+def test_config_server_update_credentials(harness: Harness[MongoTestCharm]):
+    manager = harness.charm.operator.config_server_manager
+
+    harness.set_leader(True)
+
+    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.CONFIG_SERVER.value
+    harness.charm.operator.state.db_initialised = True
+
+    rel_id = harness.add_relation(RelationNames.CONFIG_SERVER.value, "shard0")
+
+    harness.update_relation_data(rel_id, "shard0", {"database": "unused"})
+
+    manager.update_credentials("operator-password", "deadbeef")
+
+    assert manager.data_interface.as_dict(rel_id).get("operator-password") == "deadbeef"
+
+
+@patch_network_get(private_address="1.1.1.1")
+def test_config_server_update_ca_secret(harness: Harness[MongoTestCharm]):
+    manager = harness.charm.operator.config_server_manager
+
+    harness.set_leader(True)
+
+    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.CONFIG_SERVER.value
+    harness.charm.operator.state.db_initialised = True
+
+    rel_id = harness.add_relation(RelationNames.CONFIG_SERVER.value, "shard0")
+
+    harness.update_relation_data(rel_id, "shard0", {"database": "unused"})
+
+    manager.update_ca_secret("newca")
+
+    assert manager.data_interface.as_dict(rel_id).get("int-ca-secret") == "newca"
+
+
+@patch_network_get(private_address="1.1.1.1")
+def test_config_server_add_shard(harness: Harness[MongoTestCharm], mocker):
+    manager = harness.charm.operator.config_server_manager
+
+    harness.set_leader(True)
+
+    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.CONFIG_SERVER.value
+    harness.charm.operator.state.db_initialised = True
+
+    mocked_add_shard = mocker.patch(
+        "single_kernel_mongo.utils.mongo_connection.MongoConnection.add_shard",
+    )
+
+    rel_id = harness.add_relation(RelationNames.CONFIG_SERVER.value, "shard0")
+    harness.add_relation_unit(rel_id, "shard0/0")
+
+    relation: Relation = harness.charm.model.get_relation(RelationNames.CONFIG_SERVER.value, rel_id)  # type: ignore[assignment]
+
+    harness.update_relation_data(rel_id, "shard0", {"database": "unused"})
+    harness.update_relation_data(rel_id, "shard0/0", {"private-address": "2.2.2.2"})
+
+    manager.add_shard(relation)
+
+    mocked_add_shard.assert_called_with("shard0", ["2.2.2.2"])
+
+
+@patch_network_get(private_address="1.1.1.1")
+def test_config_server_cluster_password_synced_success(harness: Harness[MongoTestCharm], mocker):
+    manager = harness.charm.operator.config_server_manager
+
+    harness.set_leader(True)
+
+    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.CONFIG_SERVER.value
+    harness.charm.operator.state.db_initialised = True
+
+    mocker.patch(
+        "single_kernel_mongo.utils.mongo_connection.MongoConnection.get_shard_members",
+    )
+    mocker.patch(
+        "single_kernel_mongo.utils.mongo_connection.MongoConnection.get_replset_status",
+    )
+
+    rel_id = harness.add_relation(RelationNames.CONFIG_SERVER.value, "shard0")
+    harness.add_relation_unit(rel_id, "shard0/0")
+
+    harness.update_relation_data(rel_id, "shard0", {"database": "unused"})
+
+    assert manager.cluster_password_synced()
+
+
+@pytest.mark.parametrize(
+    ("error"),
+    ((OperationFailure("", 13)), (OperationFailure("", 18)), (ServerSelectionTimeoutError)),
+)
+@patch_network_get(private_address="1.1.1.1")
+def test_config_server_cluster_password_synced_failure(
+    harness: Harness[MongoTestCharm], mocker, error
+):
+    manager = harness.charm.operator.config_server_manager
+
+    harness.set_leader(True)
+
+    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.CONFIG_SERVER.value
+    harness.charm.operator.state.db_initialised = True
+
+    mocker.patch(
+        "single_kernel_mongo.utils.mongo_connection.MongoConnection.get_shard_members",
+        side_effect=error,
+    )
+    mocker.patch(
+        "single_kernel_mongo.utils.mongo_connection.MongoConnection.get_replset_status",
+    )
+
+    rel_id = harness.add_relation(RelationNames.CONFIG_SERVER.value, "shard0")
+    harness.add_relation_unit(rel_id, "shard0/0")
+
+    harness.update_relation_data(rel_id, "shard0", {"database": "unused"})
+
+    assert not manager.cluster_password_synced()
+
+
+@patch_network_get(private_address="1.1.1.1")
+def test_config_server_cluster_password_synced_raises(harness: Harness[MongoTestCharm], mocker):
+    manager = harness.charm.operator.config_server_manager
+
+    harness.set_leader(True)
+
+    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.CONFIG_SERVER.value
+    harness.charm.operator.state.db_initialised = True
+
+    mocker.patch(
+        "single_kernel_mongo.utils.mongo_connection.MongoConnection.get_shard_members",
+        side_effect=OperationFailure("", 27),
+    )
+    mocker.patch(
+        "single_kernel_mongo.utils.mongo_connection.MongoConnection.get_replset_status",
+    )
+
+    rel_id = harness.add_relation(RelationNames.CONFIG_SERVER.value, "shard0")
+    harness.add_relation_unit(rel_id, "shard0/0")
+
+    harness.update_relation_data(rel_id, "shard0", {"database": "unused"})
+
+    with pytest.raises(OperationFailure) as err:
+        manager.cluster_password_synced()
+
+    assert err.value.code == 27
+
+
+@patch_network_get(private_address="1.1.1.1")
+def test_config_server_get_unreachable_shards(harness: Harness[MongoTestCharm], mocker):
+    manager = harness.charm.operator.config_server_manager
+
+    harness.set_leader(True)
+
+    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.CONFIG_SERVER.value
+    harness.charm.operator.state.db_initialised = True
+
+    mocker.patch("single_kernel_mongo.managers.mongo.MongoManager.mongod_ready", return_value=False)
+
+    rel_id = harness.add_relation(RelationNames.CONFIG_SERVER.value, "shard0")
+    rel_id_bis = harness.add_relation(RelationNames.CONFIG_SERVER.value, "shard1")
+    harness.add_relation_unit(rel_id, "shard0/0")
+    harness.add_relation_unit(rel_id_bis, "shard1/0")
+
+    harness.update_relation_data(rel_id, "shard0", {"database": "unused"})
+    harness.update_relation_data(rel_id_bis, "shard1", {"database": "unused"})
+
+    assert manager.get_unreachable_shards() == ["shard0", "shard1"]
+
+
+####################
+# Shard Side tests #
+####################
+
+
+@patch_network_get(private_address="1.1.1.1")
+def test_shard_manager_prepare_to_add_shard(harness: Harness[MongoTestCharm]):
+    manager = harness.charm.operator.shard_manager
+
+    harness.set_leader(True)
+
+    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.SHARD.value
+    harness.charm.operator.state.db_initialised = True
+
+    harness.add_relation(RelationNames.SHARDING.value, "config-server")
+
+    assert not manager.state.unit_peer_data.drained
+
+    assert harness.charm.unit.status == MaintenanceStatus("Adding shard to config-server")
+
+
+@patch_network_get(private_address="1.1.1.1")
+def test_shard_manager_synchronise_cluster_secrets(harness: Harness[MongoTestCharm], mocker):
+    manager = harness.charm.operator.shard_manager
+
+    harness.set_leader(True)
+
+    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.SHARD.value
+    harness.charm.operator.state.db_initialised = True
+    mocked_update_member_auth = mocker.patch(
+        "single_kernel_mongo.managers.sharding.ShardManager.update_member_auth"
+    )
+    mocked_sync = mocker.patch(
+        "single_kernel_mongo.managers.sharding.ShardManager.sync_cluster_passwords"
+    )
+    mocker.patch("single_kernel_mongo.managers.mongo.MongoManager.mongod_ready", return_value=True)
+
+    rel_id = harness.add_relation(RelationNames.SHARDING.value, "config-server")
+
+    harness.update_relation_data(
+        rel_id,
+        "config-server",
+        {
+            "key-file": "deadbeef",
+            "operator-password": "test-operator",
+            "backup-password": "test-backup",
+        },
+    )
+
+    relation: Relation = harness.charm.model.get_relation(RelationNames.SHARDING.value, rel_id)  # type: ignore[assignment]
+
+    manager.synchronise_cluster_secrets(relation)
+
+    mocked_update_member_auth.assert_called_with("deadbeef", None)
+    mocked_sync.assert_called_with("test-operator", "test-backup")
+
+    assert manager.data_requirer.as_dict(rel_id).get("auth-updated", "false") == "true"

--- a/tests/unit/test_sharding.py
+++ b/tests/unit/test_sharding.py
@@ -300,7 +300,7 @@ def test_config_server_get_unreachable_shards(harness: Harness[MongoTestCharm], 
     harness.update_relation_data(rel_id, "shard0", {"database": "unused"})
     harness.update_relation_data(rel_id_bis, "shard1", {"database": "unused"})
 
-    assert manager.get_unreachable_shards() == ["shard0", "shard1"]
+    assert set(manager.get_unreachable_shards()) == {"shard0", "shard1"}
 
 
 ####################

--- a/tests/unit/test_sharding.py
+++ b/tests/unit/test_sharding.py
@@ -6,12 +6,16 @@ from ops.model import MaintenanceStatus, Relation
 from ops.testing import Harness
 from pymongo.errors import OperationFailure, ServerSelectionTimeoutError
 
-from single_kernel_mongo.config.relations import RelationNames
+from single_kernel_mongo.config.relations import ExternalRequirerRelations, RelationNames
 from single_kernel_mongo.core.structured_config import MongoDBRoles
 from single_kernel_mongo.exceptions import (
     DeferrableFailedHookChecksError,
     NonDeferrableFailedHookChecksError,
+    WaitingForCertificatesError,
+    WaitingForSecretsError,
 )
+from single_kernel_mongo.utils.mongo_connection import NotReadyError
+from single_kernel_mongo.utils.mongodb_users import BackupUser, OperatorUser
 
 from .helpers import patch_network_get
 from .mongodb_test_charm.src.charm import MongoTestCharm
@@ -321,7 +325,9 @@ def test_shard_manager_prepare_to_add_shard(harness: Harness[MongoTestCharm]):
 
 
 @patch_network_get(private_address="1.1.1.1")
-def test_shard_manager_synchronise_cluster_secrets(harness: Harness[MongoTestCharm], mocker):
+def test_shard_manager_synchronise_cluster_secrets_success(
+    harness: Harness[MongoTestCharm], mocker
+):
     manager = harness.charm.operator.shard_manager
 
     harness.set_leader(True)
@@ -356,3 +362,154 @@ def test_shard_manager_synchronise_cluster_secrets(harness: Harness[MongoTestCha
     mocked_sync.assert_called_with("test-operator", "test-backup")
 
     assert manager.data_requirer.as_dict(rel_id).get("auth-updated", "false") == "true"
+
+
+@patch_network_get(private_address="1.1.1.1")
+def test_shard_manager_synchronise_cluster_secrets_no_keyfile(
+    harness: Harness[MongoTestCharm], mocker
+):
+    manager = harness.charm.operator.shard_manager
+
+    harness.set_leader(True)
+
+    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.SHARD.value
+    harness.charm.operator.state.db_initialised = True
+
+    rel_id = harness.add_relation(RelationNames.SHARDING.value, "config-server")
+
+    harness.update_relation_data(
+        rel_id,
+        "config-server",
+        {
+            "operator-password": "test-operator",
+            "backup-password": "test-backup",
+        },
+    )
+
+    relation: Relation = harness.charm.model.get_relation(RelationNames.SHARDING.value, rel_id)  # type: ignore[assignment]
+
+    with pytest.raises(WaitingForSecretsError):
+        manager.synchronise_cluster_secrets(relation)
+
+
+@patch_network_get(private_address="1.1.1.1")
+def test_shard_manager_synchronise_cluster_secrets_no_ca_cert_waiting_for_both_certs(
+    harness: Harness[MongoTestCharm], mocker
+):
+    manager = harness.charm.operator.shard_manager
+
+    harness.set_leader(True)
+
+    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.SHARD.value
+    harness.charm.operator.state.db_initialised = True
+
+    mocker.patch("single_kernel_mongo.managers.sharding.ShardManager.update_member_auth")
+
+    rel_id = harness.add_relation(ExternalRequirerRelations.TLS.value, "self-signed-certificates")
+    rel_id = harness.add_relation(RelationNames.SHARDING.value, "config-server")
+
+    harness.update_relation_data(
+        rel_id,
+        "config-server",
+        {
+            "key-file": "feeddead",
+            "int-ca-secret": "deadbeef",
+            "operator-password": "test-operator",
+            "backup-password": "test-backup",
+        },
+    )
+
+    relation: Relation = harness.charm.model.get_relation(RelationNames.SHARDING.value, rel_id)  # type: ignore[assignment]
+
+    with pytest.raises(WaitingForCertificatesError):
+        manager.synchronise_cluster_secrets(relation)
+
+
+@patch_network_get(private_address="1.1.1.1")
+def test_shard_manager_synchronise_cluster_secrets_mongod_not_ready(
+    harness: Harness[MongoTestCharm], mocker
+):
+    manager = harness.charm.operator.shard_manager
+
+    harness.set_leader(True)
+
+    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.SHARD.value
+    harness.charm.operator.state.db_initialised = True
+
+    mocker.patch("single_kernel_mongo.managers.sharding.ShardManager.update_member_auth")
+    mocker.patch("single_kernel_mongo.managers.mongo.MongoManager.mongod_ready", return_value=False)
+
+    rel_id = harness.add_relation(RelationNames.SHARDING.value, "config-server")
+
+    harness.update_relation_data(
+        rel_id,
+        "config-server",
+        {
+            "key-file": "feeddead",
+            "operator-password": "test-operator",
+            "backup-password": "test-backup",
+        },
+    )
+
+    relation: Relation = harness.charm.model.get_relation(RelationNames.SHARDING.value, rel_id)  # type: ignore[assignment]
+
+    with pytest.raises(NotReadyError):
+        manager.synchronise_cluster_secrets(relation)
+
+
+@patch_network_get(private_address="1.1.1.1")
+def test_shard_manager_synchronise_cluster_secrets_missing_creds(
+    harness: Harness[MongoTestCharm], mocker
+):
+    manager = harness.charm.operator.shard_manager
+
+    harness.set_leader(True)
+
+    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.SHARD.value
+    harness.charm.operator.state.db_initialised = True
+
+    mocker.patch("single_kernel_mongo.managers.sharding.ShardManager.update_member_auth")
+    mocker.patch("single_kernel_mongo.managers.mongo.MongoManager.mongod_ready", return_value=True)
+
+    rel_id = harness.add_relation(RelationNames.SHARDING.value, "config-server")
+
+    harness.update_relation_data(
+        rel_id,
+        "config-server",
+        {
+            "key-file": "feeddead",
+        },
+    )
+
+    relation: Relation = harness.charm.model.get_relation(RelationNames.SHARDING.value, rel_id)  # type: ignore[assignment]
+
+    with pytest.raises(WaitingForSecretsError):
+        manager.synchronise_cluster_secrets(relation)
+
+
+@patch_network_get(private_address="1.1.1.1")
+def test_shard_manager_sync_cluster_passwords(harness: Harness[MongoTestCharm], mocker):
+    manager = harness.charm.operator.shard_manager
+
+    harness.set_leader(True)
+
+    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.SHARD.value
+    harness.charm.operator.state.db_initialised = True
+    mocker.patch(
+        "single_kernel_mongo.utils.mongo_connection.MongoConnection.primary", return_value="1.1.1.1"
+    )
+    mock_set_user_password = mocker.patch(
+        "single_kernel_mongo.utils.mongo_connection.MongoConnection.set_user_password",
+    )
+    patch_config_and_restart = mocker.patch(
+        "single_kernel_mongo.managers.config.BackupConfigManager.configure_and_restart",
+    )
+
+    manager.sync_cluster_passwords("test-operator", "test-backup")
+
+    mock_set_user_password.assert_any_call("operator", "test-operator")
+    mock_set_user_password.assert_any_call("backup", "test-backup")
+    patch_config_and_restart.assert_called()
+
+    assert manager.state.get_user_password(OperatorUser) == "test-operator"
+    assert manager.state.get_user_password(BackupUser) == "test-backup"

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -24,10 +24,10 @@ def test_tls_relation_joined(harness: Harness[MongoTestCharm]):
 
     harness.add_relation_unit(rel_id, "self-signed-certificates/0")
 
-    external_key = manager.get_tls_secret(False, SECRET_KEY_LABEL)
-    external_csr = manager.get_tls_secret(False, SECRET_CSR_LABEL)
-    internal_key = manager.get_tls_secret(True, SECRET_KEY_LABEL)
-    internal_csr = manager.get_tls_secret(True, SECRET_CSR_LABEL)
+    external_key = manager.state.tls.get_secret(False, SECRET_KEY_LABEL)
+    external_csr = manager.state.tls.get_secret(False, SECRET_CSR_LABEL)
+    internal_key = manager.state.tls.get_secret(True, SECRET_KEY_LABEL)
+    internal_csr = manager.state.tls.get_secret(True, SECRET_CSR_LABEL)
 
     assert external_csr is not None
     assert external_key is not None
@@ -88,8 +88,8 @@ def test_set_private_key(harness: Harness[MongoTestCharm]):
         "set-tls-private-key", params={"internal-key": internal_key, "external-key": external_key}
     )
 
-    external_key_from_secret = manager.get_tls_secret(False, SECRET_KEY_LABEL)
-    internal_key_from_secret = manager.get_tls_secret(True, SECRET_KEY_LABEL)
+    external_key_from_secret = manager.state.tls.get_secret(False, SECRET_KEY_LABEL)
+    internal_key_from_secret = manager.state.tls.get_secret(True, SECRET_KEY_LABEL)
 
     assert internal_key.rstrip() == internal_key_from_secret
     assert external_key.rstrip() == external_key_from_secret


### PR DESCRIPTION
## 🏷 Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update
- [ ] Tooling and CI changes
- [ ] Dependencies upgrade or change

## 📝 Description

Add the managers and event handlers for config-server/shard relation.
Since the former model was using DatabaseRequire/DatabaseProvides, I'm keeping this for now, but making it already compatible with `data_interfaces` v40.
To note that we were using the interfaces but incorrectly, so it will be important to ensure that upgrades still work because there are now some more fields in the databag (which were left empty before because we were not using the whole power of data interfaces, only to be able to request secrets).

## 📑 Motivation and Context

Bring more features to the single kernel charm, in this case bring the sharding capabilities.

## 🧪 How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

This has for now only been tested manually, I'll add some unit testing later.

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](../blob/main/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.