### PR TITLE
fix: Remove local user as well

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -71,7 +71,7 @@ jobs:
           groups: '["main", "integration", "unit"]'
           repository: 'Canonical/${{ matrix.repository }}'
           branch: '6/edge'
-          python_version: 3.10
+          python_version: '3.10'
           pat: secrets.PAT
       - name: Convert PR's to ready to review.
         if: success()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "mongo-charms-single-kernel"
-version = "0.0.2"
+version = "0.0.3"
 description = "Shared and reusable code for Mongo-related charms"
 readme = "README.md"
 license = "Apache-2.0"

--- a/single_kernel_mongo/managers/cluster.py
+++ b/single_kernel_mongo/managers/cluster.py
@@ -30,6 +30,7 @@ from single_kernel_mongo.state.app_peer_state import AppPeerDataKeys
 from single_kernel_mongo.state.charm_state import CharmState
 from single_kernel_mongo.state.cluster_state import ClusterStateKeys
 from single_kernel_mongo.state.tls_state import SECRET_CA_LABEL
+from single_kernel_mongo.utils.mongo_connection import MongoConnection
 from single_kernel_mongo.workload.mongos_workload import MongosWorkload
 
 if TYPE_CHECKING:
@@ -324,6 +325,10 @@ class ClusterRequirer(Object):
             user_secrets.remove_all_revisions()
             user_secrets.get_content(refresh=True)
             relation.data[self.charm.app].clear()
+
+        # Also remove the local user.
+        with MongoConnection(self.state.mongo_config) as mongo:
+            mongo.drop_user(mongo.config.username)
 
     def is_ca_compatible(self) -> bool:
         """Returns true if both the mongos and the config-server use the same CA.

--- a/single_kernel_mongo/managers/sharding.py
+++ b/single_kernel_mongo/managers/sharding.py
@@ -189,6 +189,7 @@ class ConfigServerManager(Object, StatusProvider):
             )
             if not leaving:
                 raise DeferrableFailedHookChecksError("Upgrade is in progress")
+        if leaving:
             if not self.state.has_departed_run(relation.id):
                 raise DeferrableFailedHookChecksError(
                     "must wait for relation departed hook to decide if relation should be removed"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷 Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update
- [ ] Tooling and CI changes
- [ ] Dependencies upgrade or change

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and scope of this PR (what)
  - the impacted components (where, often match conventional commit scope)
  - explanation/algorithm if require (how)
-->
During the implementation of single kernel library, the removal of the mongos user on kubernetes was forgotten.
It was missed because the tests were running for <old mongos> <-> <new config server> but not the other way.

This commit fixes that.


## 📑 Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Either the associated JIRA reference or a paragraph. -->
This was discovered as part of https://github.com/canonical/mongodb-k8s-operator/pull/396

## 🧪 How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This has been tested manually.
There is a need to extend the current unit testing framework to support more easily testing both VM and Kubernetes workloads to make that easier to test.

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](../blob/6/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
