### PR TITLE
[DPE-6591] get statuses charm and backup (context free!)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "mongo-charms-single-kernel"
-version = "0.0.2"
+version = "0.0.3"
 description = "Shared and reusable code for Mongo-related charms"
 readme = "README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "mongo-charms-single-kernel"
-version = "0.0.3"
+version = "0.0.4"
 description = "Shared and reusable code for Mongo-related charms"
 readme = "README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "mongo-charms-single-kernel"
-version = "0.0.4"
+version = "0.0.5"
 description = "Shared and reusable code for Mongo-related charms"
 readme = "README.md"
 license = "Apache-2.0"

--- a/single_kernel_mongo/config/statuses.py
+++ b/single_kernel_mongo/config/statuses.py
@@ -27,7 +27,7 @@ class CharmStatuses:
 
     MONGODB_NOT_INSTALLED = BlockedStatus("MongoDB not installed")
 
-    class MongoDB(str, Enum):
+    class MongoDB:
         """MongoDB related statuses.
 
         TODO: add the remaining statuses for mongodb charm.
@@ -45,7 +45,7 @@ class CharmStatuses:
             "Relation to s3-integrator is not supported, config role must be config-server."
         )
 
-    class Mongos(str, Enum):
+    class Mongos:
         """Mongos related statuses.
 
         TODO: add the remaining statuses for mongos charm.

--- a/single_kernel_mongo/config/statuses.py
+++ b/single_kernel_mongo/config/statuses.py
@@ -17,7 +17,7 @@ from enum import Enum
 from ops.model import BlockedStatus, WaitingStatus
 
 
-class MongoDB(Enum):
+class MongoDBStatuses(Enum):
     """MongoDB related statuses.
 
     TODO: add the remaining statuses for mongodb charm.
@@ -34,7 +34,7 @@ class MongoDB(Enum):
     )
 
 
-class Mongos(Enum):
+class MongosStatuses(Enum):
     """Mongos related statuses.
 
     TODO: add the remaining statuses for mongos charm.
@@ -50,8 +50,8 @@ class CharmStatuses(Enum):
     """
 
     MONGODB_NOT_INSTALLED = BlockedStatus("MongoDB not installed")
-    mongodb = MongoDB
-    mongos = Mongos
+    mongodb = MongoDBStatuses
+    mongos = MongosStatuses
 
 
 class BackupStatuses(Enum):

--- a/single_kernel_mongo/config/statuses.py
+++ b/single_kernel_mongo/config/statuses.py
@@ -4,15 +4,14 @@
 
 """File containing all possible statuses for Mongo* charms.
 
-TODO (Future PR(s)): 
+TODO (Future PR(s)):
 - Add all statuses here
-- Update to be consistent wit hthe spec
+- Update to be consistent with the spec
 
-Note: The structure of this file is subject to change, as the implementation spec is still in 
+Note: The structure of this file is subject to change, as the implementation spec is still in
 progress. However the idea that all statuses belong in one file holds true regardless of the spec.
 """
 
-from enum import Enum
 from dataclasses import dataclass
 
 from ops.model import BlockedStatus, WaitingStatus
@@ -20,7 +19,7 @@ from ops.model import BlockedStatus, WaitingStatus
 
 @dataclass(frozen=True)
 class CharmStatuses:
-    """Charm Statuses
+    """Charm Statuses.
 
     TODO: add remaining statuses related to the two charms.
     """
@@ -35,9 +34,7 @@ class CharmStatuses:
 
         MONGODB_NOT_STARTED = WaitingStatus("Waiting to start mongod...")
         EXPORTER_NOT_STARTED = WaitingStatus("Waiting to start mongodb-exporter...")
-        SHARDING_ON_REPLICA = BlockedStatus(
-            "sharding interface cannot be used by replicas"
-        )
+        SHARDING_ON_REPLICA = BlockedStatus("sharding interface cannot be used by replicas")
         UNSUPPORTED_MONGOS_REL = BlockedStatus(
             "Relation to mongos not supported, config role must be config-server"
         )
@@ -67,4 +64,4 @@ class BackupStatuses:
     PBM_MISSING_CONFIGS = BlockedStatus("s3 configurations missing.")
     PBM_INCORRECT_CREDS = BlockedStatus("s3 credentials are incorrect.")
     PBM_INCOMPATIBLE_CONF = BlockedStatus("s3 configurations are incompatible.")
-    UNKNOWN_PBM_ERROR = BlockedStatus("Unknwon PBM error, check logs")
+    UNKNOWN_PBM_ERROR = BlockedStatus("Unknown PBM error, check logs")

--- a/single_kernel_mongo/config/statuses.py
+++ b/single_kernel_mongo/config/statuses.py
@@ -67,4 +67,4 @@ class BackupStatuses:
     PBM_MISSING_CONFIGS = BlockedStatus("s3 configurations missing.")
     PBM_INCORRECT_CREDS = BlockedStatus("s3 credentials are incorrect.")
     PBM_INCOMPATIBLE_CONF = BlockedStatus("s3 configurations are incompatible.")
-    UNKNWONN_PBM_ERROR = BlockedStatus("Unknwon PBM error, check logs")
+    UNKNOWN_PBM_ERROR = BlockedStatus("Unknwon PBM error, check logs")

--- a/single_kernel_mongo/config/statuses.py
+++ b/single_kernel_mongo/config/statuses.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""File containing all possible statuses for Mongo* charms.
+
+TODO (Future PR(s)): 
+- Add all statuses here
+- Update to be consistent wit hthe spec
+
+Note: The structure of this file is subject to change, as the implementation spec is still in 
+progress. However the idea that all statuses belong in one file holds true regardless of the spec.
+"""
+
+from enum import Enum
+from dataclasses import dataclass
+
+from ops.model import BlockedStatus, WaitingStatus
+
+
+@dataclass(frozen=True)
+class CharmStatuses:
+    """Charm Statuses
+
+    TODO: add remaining statuses related to the two charms.
+    """
+
+    MONGODB_NOT_INSTALLED = BlockedStatus("MongoDB not installed")
+
+    class MongoDB(str, Enum):
+        """MongoDB related statuses.
+
+        TODO: add the remaining statuses for mongodb charm.
+        """
+
+        MONGODB_NOT_STARTED = WaitingStatus("Waiting to start mongod...")
+        EXPORTER_NOT_STARTED = WaitingStatus("Waiting to start mongodb-exporter...")
+        SHARDING_ON_REPLICA = BlockedStatus(
+            "sharding interface cannot be used by replicas"
+        )
+        UNSUPPORTED_MONGOS_REL = BlockedStatus(
+            "Relation to mongos not supported, config role must be config-server"
+        )
+        INVALID_S3_INTEGRATION_STATUS = BlockedStatus(
+            "Relation to s3-integrator is not supported, config role must be config-server."
+        )
+
+    class Mongos(str, Enum):
+        """Mongos related statuses.
+
+        TODO: add the remaining statuses for mongos charm.
+        """
+
+        ...
+
+
+@dataclass(frozen=True)
+class BackupStatuses:
+    """Backup manager related statuses.
+
+    TODO: add the remaining statuses for backup manager.
+    """
+
+    # note unlike other daemons (exporter and mongod) this status belongs to the backup manager
+    # since certain configurations are required for pbm to be active and running.
+    PBM_NOT_STARTED = WaitingStatus("waiting for pbm to start")
+    PBM_MISSING_CONFIGS = BlockedStatus("s3 configurations missing.")
+    PBM_INCORRECT_CREDS = BlockedStatus("s3 credentials are incorrect.")
+    PBM_INCOMPATIBLE_CONF = BlockedStatus("s3 configurations are incompatible.")
+    UNKNWONN_PBM_ERROR = BlockedStatus("Unknwon PBM error, check logs")

--- a/single_kernel_mongo/config/statuses.py
+++ b/single_kernel_mongo/config/statuses.py
@@ -13,12 +13,13 @@ progress. However the idea that all statuses belong in one file holds true regar
 """
 
 from dataclasses import dataclass
+from enum import Enum
 
 from ops.model import BlockedStatus, WaitingStatus
 
 
 @dataclass(frozen=True)
-class CharmStatuses:
+class CharmStatuses(Enum):
     """Charm Statuses.
 
     TODO: add remaining statuses related to the two charms.
@@ -26,7 +27,7 @@ class CharmStatuses:
 
     MONGODB_NOT_INSTALLED = BlockedStatus("MongoDB not installed")
 
-    class MongoDB:
+    class MongoDB(Enum):
         """MongoDB related statuses.
 
         TODO: add the remaining statuses for mongodb charm.
@@ -42,7 +43,7 @@ class CharmStatuses:
             "Relation to s3-integrator is not supported, config role must be config-server."
         )
 
-    class Mongos:
+    class Mongos(Enum):
         """Mongos related statuses.
 
         TODO: add the remaining statuses for mongos charm.
@@ -51,8 +52,7 @@ class CharmStatuses:
         ...
 
 
-@dataclass(frozen=True)
-class BackupStatuses:
+class BackupStatuses(Enum):
     """Backup manager related statuses.
 
     TODO: add the remaining statuses for backup manager.

--- a/single_kernel_mongo/config/statuses.py
+++ b/single_kernel_mongo/config/statuses.py
@@ -12,13 +12,37 @@ Note: The structure of this file is subject to change, as the implementation spe
 progress. However the idea that all statuses belong in one file holds true regardless of the spec.
 """
 
-from dataclasses import dataclass
 from enum import Enum
 
 from ops.model import BlockedStatus, WaitingStatus
 
 
-@dataclass(frozen=True)
+class MongoDB(Enum):
+    """MongoDB related statuses.
+
+    TODO: add the remaining statuses for mongodb charm.
+    """
+
+    MONGODB_NOT_STARTED = WaitingStatus("Waiting to start mongod...")
+    EXPORTER_NOT_STARTED = WaitingStatus("Waiting to start mongodb-exporter...")
+    SHARDING_ON_REPLICA = BlockedStatus("sharding interface cannot be used by replicas")
+    UNSUPPORTED_MONGOS_REL = BlockedStatus(
+        "Relation to mongos not supported, config role must be config-server"
+    )
+    INVALID_S3_INTEGRATION_STATUS = BlockedStatus(
+        "Relation to s3-integrator is not supported, config role must be config-server."
+    )
+
+
+class Mongos(Enum):
+    """Mongos related statuses.
+
+    TODO: add the remaining statuses for mongos charm.
+    """
+
+    ...
+
+
 class CharmStatuses(Enum):
     """Charm Statuses.
 
@@ -26,30 +50,8 @@ class CharmStatuses(Enum):
     """
 
     MONGODB_NOT_INSTALLED = BlockedStatus("MongoDB not installed")
-
-    class MongoDB(Enum):
-        """MongoDB related statuses.
-
-        TODO: add the remaining statuses for mongodb charm.
-        """
-
-        MONGODB_NOT_STARTED = WaitingStatus("Waiting to start mongod...")
-        EXPORTER_NOT_STARTED = WaitingStatus("Waiting to start mongodb-exporter...")
-        SHARDING_ON_REPLICA = BlockedStatus("sharding interface cannot be used by replicas")
-        UNSUPPORTED_MONGOS_REL = BlockedStatus(
-            "Relation to mongos not supported, config role must be config-server"
-        )
-        INVALID_S3_INTEGRATION_STATUS = BlockedStatus(
-            "Relation to s3-integrator is not supported, config role must be config-server."
-        )
-
-    class Mongos(Enum):
-        """Mongos related statuses.
-
-        TODO: add the remaining statuses for mongos charm.
-        """
-
-        ...
+    mongodb = MongoDB
+    mongos = Mongos
 
 
 class BackupStatuses(Enum):

--- a/single_kernel_mongo/events/lifecycle.py
+++ b/single_kernel_mongo/events/lifecycle.py
@@ -68,9 +68,7 @@ class LifecycleEventsHandler(Object):
         self.framework.observe(getattr(self.charm.on, "install"), self.on_install)
         self.framework.observe(getattr(self.charm.on, "start"), self.on_start)
         self.framework.observe(getattr(self.charm.on, "stop"), self.on_stop)
-        self.framework.observe(
-            getattr(self.charm.on, "leader_elected"), self.on_leader_elected
-        )
+        self.framework.observe(getattr(self.charm.on, "leader_elected"), self.on_leader_elected)
 
         if self.charm.substrate == Substrates.K8S:
             self.framework.observe(
@@ -78,15 +76,9 @@ class LifecycleEventsHandler(Object):
                 self.on_start,
             )
 
-        self.framework.observe(
-            getattr(self.charm.on, "config_changed"), self.on_config_changed
-        )
-        self.framework.observe(
-            getattr(self.charm.on, "update_status"), self.on_update_status
-        )
-        self.framework.observe(
-            getattr(self.charm.on, "secret_changed"), self.on_secret_changed
-        )
+        self.framework.observe(getattr(self.charm.on, "config_changed"), self.on_config_changed)
+        self.framework.observe(getattr(self.charm.on, "update_status"), self.on_update_status)
+        self.framework.observe(getattr(self.charm.on, "secret_changed"), self.on_secret_changed)
 
         self.framework.observe(
             self.charm.on[rel_name.value].relation_joined, self.on_relation_joined
@@ -108,10 +100,7 @@ class LifecycleEventsHandler(Object):
                 self.on_storage_detaching,
             )
 
-        if (
-            self.charm.substrate == Substrates.VM
-            and self.dependent.name == CharmKind.MONGOD
-        ):
+        if self.charm.substrate == Substrates.VM and self.dependent.name == CharmKind.MONGOD:
             self.framework.observe(getattr(self.charm.on, "remove"), self.on_remove)
 
     def on_start(self, event: StartEvent):

--- a/single_kernel_mongo/events/lifecycle.py
+++ b/single_kernel_mongo/events/lifecycle.py
@@ -68,16 +68,25 @@ class LifecycleEventsHandler(Object):
         self.framework.observe(getattr(self.charm.on, "install"), self.on_install)
         self.framework.observe(getattr(self.charm.on, "start"), self.on_start)
         self.framework.observe(getattr(self.charm.on, "stop"), self.on_stop)
-        self.framework.observe(getattr(self.charm.on, "leader_elected"), self.on_leader_elected)
+        self.framework.observe(
+            getattr(self.charm.on, "leader_elected"), self.on_leader_elected
+        )
 
         if self.charm.substrate == Substrates.K8S:
             self.framework.observe(
-                getattr(self.charm.on, f"{dependent.name.value}_pebble_ready"), self.on_start
+                getattr(self.charm.on, f"{dependent.name.value}_pebble_ready"),
+                self.on_start,
             )
 
-        self.framework.observe(getattr(self.charm.on, "config_changed"), self.on_config_changed)
-        self.framework.observe(getattr(self.charm.on, "update_status"), self.on_update_status)
-        self.framework.observe(getattr(self.charm.on, "secret_changed"), self.on_secret_changed)
+        self.framework.observe(
+            getattr(self.charm.on, "config_changed"), self.on_config_changed
+        )
+        self.framework.observe(
+            getattr(self.charm.on, "update_status"), self.on_update_status
+        )
+        self.framework.observe(
+            getattr(self.charm.on, "secret_changed"), self.on_secret_changed
+        )
 
         self.framework.observe(
             self.charm.on[rel_name.value].relation_joined, self.on_relation_joined
@@ -91,13 +100,18 @@ class LifecycleEventsHandler(Object):
 
         if self.dependent.name == CharmKind.MONGOD:
             self.framework.observe(
-                getattr(self.charm.on, "mongodb_storage_attached"), self.on_storage_attached
+                getattr(self.charm.on, "mongodb_storage_attached"),
+                self.on_storage_attached,
             )
             self.framework.observe(
-                getattr(self.charm.on, "mongodb_storage_detaching"), self.on_storage_detaching
+                getattr(self.charm.on, "mongodb_storage_detaching"),
+                self.on_storage_detaching,
             )
 
-        if self.charm.substrate == Substrates.VM and self.dependent.name == CharmKind.MONGOD:
+        if (
+            self.charm.substrate == Substrates.VM
+            and self.dependent.name == CharmKind.MONGOD
+        ):
             self.framework.observe(getattr(self.charm.on, "remove"), self.on_remove)
 
     def on_start(self, event: StartEvent):
@@ -136,10 +150,7 @@ class LifecycleEventsHandler(Object):
 
     def on_update_status(self, event: UpdateStatusEvent):
         """Update Status Event."""
-        try:
-            self.dependent.on_update_status()
-        except Exception:
-            return
+        self.dependent.on_update_status()
 
     def on_secret_changed(self, event: SecretChangedEvent):
         """Secret changed event."""

--- a/single_kernel_mongo/managers/backups.py
+++ b/single_kernel_mongo/managers/backups.py
@@ -295,11 +295,11 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
             logger.info(
                 "Relation to S3 charm exists but not all necessary configurations have been set."
             )
-            return BackupStatuses.PBM_MISSING_CONFIGS
+            return BackupStatuses.PBM_MISSING_CONFIGS.value
 
         # PBM requires all configuration to be set in order to run.
         if not self.workload.active():
-            return BackupStatuses.PBM_NOT_STARTED
+            return BackupStatuses.PBM_NOT_STARTED.value
 
         try:
             previous_status = self.charm.unit.status
@@ -316,7 +316,7 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
             return processed_status
         except Exception as e:
             logger.error(f"Failed to get pbm status: {e}")
-            return BackupStatuses.UNKNOWN_PBM_ERROR
+            return BackupStatuses.UNKNOWN_PBM_ERROR.value
 
     def resync_config_options(self):  # pragma: nocover
         """Attempts to resync config options and sets status in case of failure."""
@@ -463,15 +463,15 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
             error_message = pbm_status
 
         if StatusCodeError.FORBIDDEN in error_message:
-            return BackupStatuses.PBM_INCORRECT_CREDS
+            return BackupStatuses.PBM_INCORRECT_CREDS.value
         if StatusCodeError.NOTFOUND in error_message:
-            return BackupStatuses.PBM_INCOMPATIBLE_CONF
+            return BackupStatuses.PBM_INCOMPATIBLE_CONF.value
         if StatusCodeError.MOVED_PERMANENTLY in error_message:
-            return BackupStatuses.PBM_INCOMPATIBLE_CONF
+            return BackupStatuses.PBM_INCOMPATIBLE_CONF.value
 
         if error_message:
             logger.info("PBM error: %s", error_message)
-            return BackupStatuses.UNKNOWN_PBM_ERROR
+            return BackupStatuses.UNKNOWN_PBM_ERROR.value
 
         return None
 

--- a/single_kernel_mongo/managers/backups.py
+++ b/single_kernel_mongo/managers/backups.py
@@ -46,6 +46,8 @@ from single_kernel_mongo.config.literals import (
     MongoPorts,
     Substrates,
 )
+
+from single_kernel_mongo.config.statuses import BackupStatuses
 from single_kernel_mongo.config.models import CharmSpec
 from single_kernel_mongo.core.status_provider import StatusProvider
 from single_kernel_mongo.core.structured_config import MongoDBRoles
@@ -66,7 +68,9 @@ from single_kernel_mongo.workload import get_pbm_workload_for_substrate
 from single_kernel_mongo.workload.backup_workload import PBMWorkload
 
 if TYPE_CHECKING:
-    from single_kernel_mongo.managers.mongodb_operator import MongoDBOperator  # pragma: nocover
+    from single_kernel_mongo.managers.mongodb_operator import (
+        MongoDBOperator,
+    )  # pragma: nocover
 
 BackupListType = NewType("BackupListType", list[tuple[str, str, str]])
 
@@ -143,7 +147,9 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
 
         Only replica sets and config_servers can integrate to s3-integrator.
         """
-        return (self.state.s3_relation is None) or (not self.state.is_role(MongoDBRoles.SHARD))
+        return (self.state.s3_relation is None) or (
+            not self.state.is_role(MongoDBRoles.SHARD)
+        )
 
     def on_relation_broken(self, relation: Relation) -> None:
         """On relation broken event, we need to remove the certificate from the trust store."""
@@ -252,7 +258,9 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
         reraise=True,
         before_sleep=_backup_restore_retry_before_sleep,
     )
-    def restore_backup(self, backup_id: str, remapping_pattern: str | None = None) -> None:
+    def restore_backup(
+        self, backup_id: str, remapping_pattern: str | None = None
+    ) -> None:
         """Try to restore cluster a backup specified by backup id.
 
         If PBM is resyncing, the function will retry to create backup
@@ -263,7 +271,9 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
         """
         try:
             remapping_pattern = remapping_pattern or self._remap_replicaset(backup_id)
-            remapping_args = ["--replset-remapping", remapping_pattern] if remapping_pattern else []
+            remapping_args = (
+                ["--replset-remapping", remapping_pattern] if remapping_pattern else []
+            )
             self.workload.run_bin_command(
                 "restore",
                 [backup_id] + remapping_args,
@@ -281,9 +291,10 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
             raise RestoreError(fail_message)
 
     def get_status(self) -> StatusBase | None:
-        """Gets the PBM status."""
-        if not self.workload.active():
-            return WaitingStatus("waiting for pbm to start")
+        """Gets the PBM status.
+
+        TODO: once implementation spec is approved update this function to return multiple statuses
+        """
         if not self.state.s3_relation:
             logger.info("No configuration for backups, not relation to s3-charm")
             return None
@@ -291,13 +302,18 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
             logger.info(
                 "Relation to S3 charm exists but not all necessary configurations have been set."
             )
-            return BlockedStatus("s3 configurations missing.")
+            return BackupStatuses.PBM_MISSING_CONFIGS
+
+        # PBM requires all configuration to be set in order to run.
+        if not self.workload.active():
+            return BackupStatuses.PBM_NOT_STARTED
+
         try:
             previous_status = self.charm.unit.status
             pbm_status = self.pbm_status
-            pbm_error = self.process_pbm_error(pbm_status)
-            if pbm_error:
-                return BlockedStatus(pbm_error)
+
+            if pbm_error := self.process_pbm_error(pbm_status):
+                return pbm_error
 
             processed_status = self.process_pbm_status(pbm_status)
             operation_result = self._get_backup_restore_operation_result(
@@ -307,7 +323,7 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
             return processed_status
         except Exception as e:
             logger.error(f"Failed to get pbm status: {e}")
-            return BlockedStatus("PBM error")
+            return BackupStatuses.UNKNWONN_PBM_ERROR
 
     def resync_config_options(self):  # pragma: nocover
         """Attempts to resync config options and sets status in case of failure."""
@@ -335,7 +351,9 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
 
         # wait for re-sync and update charm status based on pbm syncing status. Need to wait for
         # 2 seconds for pbm_agent to receive the resync command before verifying.
-        self.workload.run_bin_command("config", ["--force-resync"], environment=self.environment)
+        self.workload.run_bin_command(
+            "config", ["--force-resync"], environment=self.environment
+        )
         time.sleep(2)
         self._wait_pbm_status()
 
@@ -387,7 +405,9 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
         for pbm_key, pbm_value in config.items():
             try:
                 self.workload.run_bin_command(
-                    "config", ["--set", f"{pbm_key}={pbm_value}"], environment=self.environment
+                    "config",
+                    ["--set", f"{pbm_key}={pbm_value}"],
+                    environment=self.environment,
                 )
             except WorkloadExecError:
                 logger.error(f"Failed to configure PBM option: {pbm_key}")
@@ -401,7 +421,9 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
                 "# this file is to be left empty. Changes in this file will be ignored.\n",
             )
         self.workload.run_bin_command(
-            "config", ["--file", str(self.workload.paths.pbm_config)], environment=self.environment
+            "config",
+            ["--file", str(self.workload.paths.pbm_config)],
+            environment=self.environment,
         )
 
     def retrieve_error_message(self, pbm_status: dict) -> str:
@@ -418,9 +440,7 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
                     break
 
             for host_info in cluster["nodes"]:
-                replica_info = (
-                    f"mongodb/{self.state.unit_peer_data.internal_address}:{MongoPorts.MONGOS_PORT}"
-                )
+                replica_info = f"mongodb/{self.state.unit_peer_data.internal_address}:{MongoPorts.MONGOS_PORT}"
                 if host_info["host"] == replica_info:
                     break
 
@@ -439,7 +459,7 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
 
         return ""
 
-    def process_pbm_error(self, pbm_status: str) -> str:
+    def process_pbm_error(self, pbm_status: str) -> StatusBase:
         """Look up PBM status for errors."""
         error_message: str
         message = ""
@@ -450,12 +470,13 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
             error_message = pbm_status
 
         if StatusCodeError.FORBIDDEN in error_message:
-            message = "s3 credentials are incorrect."
+            message = BackupStatuses.PBM_INCORRECT_CREDS
         elif StatusCodeError.NOTFOUND in error_message:
-            message = "s3 configurations are incompatible."
+            message = BackupStatuses.PBM_INCOMPATIBLE_CONF
         elif StatusCodeError.MOVED_PERMANENTLY in error_message:
-            message = "s3 configurations are incompatible."
-        return message
+            message = BackupStatuses.PBM_INCOMPATIBLE_CONF
+
+        return BlockedStatus(message)
 
     def process_pbm_status(self, pbm_status: str) -> StatusBase:
         """Processes the pbm status if there's no error."""
@@ -463,9 +484,13 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
         current_op = pbm_as_dict.get("running", {})
         match current_op:
             case {"type": "backup", "name": backup_id}:
-                return MaintenanceStatus(f"backup started/running, backup id: '{backup_id}'")
+                return MaintenanceStatus(
+                    f"backup started/running, backup id: '{backup_id}'"
+                )
             case {"type": "restore", "name": backup_id}:
-                return MaintenanceStatus(f"restore started/running, backup id: '{backup_id}'")
+                return MaintenanceStatus(
+                    f"restore started/running, backup id: '{backup_id}'"
+                )
             case {"type": "resync"}:
                 return WaitingStatus("waiting to sync s3 configurations.")
             case _:
@@ -481,7 +506,9 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
         pbm_status = self.get_status()
         match pbm_status:
             case MaintenanceStatus():
-                raise InvalidPBMStatusError("Please wait for current backup/restore to finish.")
+                raise InvalidPBMStatusError(
+                    "Please wait for current backup/restore to finish."
+                )
             case WaitingStatus():
                 raise InvalidPBMStatusError(
                     "Sync-ing configurations needs more time, must wait before listing backups."
@@ -561,7 +588,7 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
                 raise ResyncError
         except WorkloadExecError as e:
             self.charm.status_manager.set_and_share_status(
-                BlockedStatus(self.process_pbm_error(e.stdout))
+                self.process_pbm_error(e.stdout)
             )
 
     def _get_backup_restore_operation_result(
@@ -598,7 +625,11 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
 
     def _format_backup_list(self, backup_list: list[tuple[str, str, str]]) -> str:
         """Formats provided list of backups as a table."""
-        backups = ["{:<21s} | {:<12s} | {:s}".format("backup-id", "backup-type", "backup-status")]
+        backups = [
+            "{:<21s} | {:<12s} | {:s}".format(
+                "backup-id", "backup-type", "backup-status"
+            )
+        ]
 
         backups.append("-" * len(backups[0]))
         for backup_id, backup_type, backup_status in backup_list:
@@ -620,9 +651,9 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
         backup_error_status = self.get_backup_error_status(backup_id)
 
         # When a charm is running as a Replica set it can generate its own remapping arguments
-        return self._is_backup_from_different_cluster(backup_error_status) and self.state.is_role(
-            MongoDBRoles.CONFIG_SERVER
-        )
+        return self._is_backup_from_different_cluster(
+            backup_error_status
+        ) and self.state.is_role(MongoDBRoles.CONFIG_SERVER)
 
     def _remap_replicaset(self, backup_id: str) -> str | None:
         """Returns options for remapping a replica set during a cluster migration restore.

--- a/single_kernel_mongo/managers/backups.py
+++ b/single_kernel_mongo/managers/backups.py
@@ -323,7 +323,7 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
             return processed_status
         except Exception as e:
             logger.error(f"Failed to get pbm status: {e}")
-            return BackupStatuses.UNKNWONN_PBM_ERROR
+            return BackupStatuses.UNKNOWN_PBM_ERROR
 
     def resync_config_options(self):  # pragma: nocover
         """Attempts to resync config options and sets status in case of failure."""
@@ -462,7 +462,7 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
     def process_pbm_error(self, pbm_status: str) -> StatusBase:
         """Look up PBM status for errors."""
         error_message: str
-        message = ""
+
         try:
             pbm_as_dict = json.loads(pbm_status)
             error_message = self.retrieve_error_message(pbm_as_dict)
@@ -470,13 +470,11 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
             error_message = pbm_status
 
         if StatusCodeError.FORBIDDEN in error_message:
-            message = BackupStatuses.PBM_INCORRECT_CREDS
+            return BackupStatuses.PBM_INCORRECT_CREDS
         elif StatusCodeError.NOTFOUND in error_message:
-            message = BackupStatuses.PBM_INCOMPATIBLE_CONF
+            return BackupStatuses.PBM_INCOMPATIBLE_CONF
         elif StatusCodeError.MOVED_PERMANENTLY in error_message:
-            message = BackupStatuses.PBM_INCOMPATIBLE_CONF
-
-        return BlockedStatus(message)
+            return BackupStatuses.PBM_INCOMPATIBLE_CONF
 
     def process_pbm_status(self, pbm_status: str) -> StatusBase:
         """Processes the pbm status if there's no error."""

--- a/single_kernel_mongo/managers/backups.py
+++ b/single_kernel_mongo/managers/backups.py
@@ -46,9 +46,8 @@ from single_kernel_mongo.config.literals import (
     MongoPorts,
     Substrates,
 )
-
-from single_kernel_mongo.config.statuses import BackupStatuses
 from single_kernel_mongo.config.models import CharmSpec
+from single_kernel_mongo.config.statuses import BackupStatuses
 from single_kernel_mongo.core.status_provider import StatusProvider
 from single_kernel_mongo.core.structured_config import MongoDBRoles
 from single_kernel_mongo.exceptions import (
@@ -147,9 +146,7 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
 
         Only replica sets and config_servers can integrate to s3-integrator.
         """
-        return (self.state.s3_relation is None) or (
-            not self.state.is_role(MongoDBRoles.SHARD)
-        )
+        return (self.state.s3_relation is None) or (not self.state.is_role(MongoDBRoles.SHARD))
 
     def on_relation_broken(self, relation: Relation) -> None:
         """On relation broken event, we need to remove the certificate from the trust store."""
@@ -258,9 +255,7 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
         reraise=True,
         before_sleep=_backup_restore_retry_before_sleep,
     )
-    def restore_backup(
-        self, backup_id: str, remapping_pattern: str | None = None
-    ) -> None:
+    def restore_backup(self, backup_id: str, remapping_pattern: str | None = None) -> None:
         """Try to restore cluster a backup specified by backup id.
 
         If PBM is resyncing, the function will retry to create backup
@@ -271,9 +266,7 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
         """
         try:
             remapping_pattern = remapping_pattern or self._remap_replicaset(backup_id)
-            remapping_args = (
-                ["--replset-remapping", remapping_pattern] if remapping_pattern else []
-            )
+            remapping_args = ["--replset-remapping", remapping_pattern] if remapping_pattern else []
             self.workload.run_bin_command(
                 "restore",
                 [backup_id] + remapping_args,
@@ -351,9 +344,7 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
 
         # wait for re-sync and update charm status based on pbm syncing status. Need to wait for
         # 2 seconds for pbm_agent to receive the resync command before verifying.
-        self.workload.run_bin_command(
-            "config", ["--force-resync"], environment=self.environment
-        )
+        self.workload.run_bin_command("config", ["--force-resync"], environment=self.environment)
         time.sleep(2)
         self._wait_pbm_status()
 
@@ -440,7 +431,9 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
                     break
 
             for host_info in cluster["nodes"]:
-                replica_info = f"mongodb/{self.state.unit_peer_data.internal_address}:{MongoPorts.MONGOS_PORT}"
+                replica_info = (
+                    f"mongodb/{self.state.unit_peer_data.internal_address}:{MongoPorts.MONGOS_PORT}"
+                )
                 if host_info["host"] == replica_info:
                     break
 
@@ -459,7 +452,7 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
 
         return ""
 
-    def process_pbm_error(self, pbm_status: str) -> StatusBase:
+    def process_pbm_error(self, pbm_status: str) -> StatusBase | None:
         """Look up PBM status for errors."""
         error_message: str
 
@@ -471,10 +464,16 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
 
         if StatusCodeError.FORBIDDEN in error_message:
             return BackupStatuses.PBM_INCORRECT_CREDS
-        elif StatusCodeError.NOTFOUND in error_message:
+        if StatusCodeError.NOTFOUND in error_message:
             return BackupStatuses.PBM_INCOMPATIBLE_CONF
-        elif StatusCodeError.MOVED_PERMANENTLY in error_message:
+        if StatusCodeError.MOVED_PERMANENTLY in error_message:
             return BackupStatuses.PBM_INCOMPATIBLE_CONF
+
+        if error_message:
+            logger.info("PBM error: %s", error_message)
+            return BackupStatuses.UNKNOWN_PBM_ERROR
+
+        return None
 
     def process_pbm_status(self, pbm_status: str) -> StatusBase:
         """Processes the pbm status if there's no error."""
@@ -482,13 +481,9 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
         current_op = pbm_as_dict.get("running", {})
         match current_op:
             case {"type": "backup", "name": backup_id}:
-                return MaintenanceStatus(
-                    f"backup started/running, backup id: '{backup_id}'"
-                )
+                return MaintenanceStatus(f"backup started/running, backup id: '{backup_id}'")
             case {"type": "restore", "name": backup_id}:
-                return MaintenanceStatus(
-                    f"restore started/running, backup id: '{backup_id}'"
-                )
+                return MaintenanceStatus(f"restore started/running, backup id: '{backup_id}'")
             case {"type": "resync"}:
                 return WaitingStatus("waiting to sync s3 configurations.")
             case _:
@@ -504,9 +499,7 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
         pbm_status = self.get_status()
         match pbm_status:
             case MaintenanceStatus():
-                raise InvalidPBMStatusError(
-                    "Please wait for current backup/restore to finish."
-                )
+                raise InvalidPBMStatusError("Please wait for current backup/restore to finish.")
             case WaitingStatus():
                 raise InvalidPBMStatusError(
                     "Sync-ing configurations needs more time, must wait before listing backups."
@@ -585,9 +578,7 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
                 )
                 raise ResyncError
         except WorkloadExecError as e:
-            self.charm.status_manager.set_and_share_status(
-                self.process_pbm_error(e.stdout)
-            )
+            self.charm.status_manager.set_and_share_status(self.process_pbm_error(e.stdout))
 
     def _get_backup_restore_operation_result(
         self, current_pbm_status: StatusBase, previous_pbm_status: StatusBase
@@ -623,11 +614,7 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
 
     def _format_backup_list(self, backup_list: list[tuple[str, str, str]]) -> str:
         """Formats provided list of backups as a table."""
-        backups = [
-            "{:<21s} | {:<12s} | {:s}".format(
-                "backup-id", "backup-type", "backup-status"
-            )
-        ]
+        backups = ["{:<21s} | {:<12s} | {:s}".format("backup-id", "backup-type", "backup-status")]
 
         backups.append("-" * len(backups[0]))
         for backup_id, backup_type, backup_status in backup_list:
@@ -649,9 +636,9 @@ class BackupManager(Object, BackupConfigManager, StatusProvider):
         backup_error_status = self.get_backup_error_status(backup_id)
 
         # When a charm is running as a Replica set it can generate its own remapping arguments
-        return self._is_backup_from_different_cluster(
-            backup_error_status
-        ) and self.state.is_role(MongoDBRoles.CONFIG_SERVER)
+        return self._is_backup_from_different_cluster(backup_error_status) and self.state.is_role(
+            MongoDBRoles.CONFIG_SERVER
+        )
 
     def _remap_replicaset(self, backup_id: str) -> str | None:
         """Returns options for remapping a replica set during a cluster migration restore.

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -902,13 +902,13 @@ class MongoDBOperator(OperatorProtocol, Object):
             charm_statuses.append(CharmStatuses.MONGODB_NOT_INSTALLED)
         else:  # don't bother checking if started if not installed
             if not self.state.db_initialised:
-                charm_statuses.append(CharmStatuses.MongoDB.MONGODB_NOT_STARTED)
+                charm_statuses.append(CharmStatuses.mongodb.MONGODB_NOT_STARTED)
 
             if not self.mongodb_exporter_config_manager.workload.active():
-                charm_statuses.append(CharmStatuses.MongoDB.EXPORTER_NOT_STARTED)
+                charm_statuses.append(CharmStatuses.mongodb.EXPORTER_NOT_STARTED)
 
         if not self.state.is_sharding_component and self.state.has_sharding_integration:
-            charm_statuses.append(CharmStatuses.MongoDB.SHARDING_ON_REPLICA)
+            charm_statuses.append(CharmStatuses.mongodb.SHARDING_ON_REPLICA)
         elif (  # don't bother checking revision mismatch on sharding interface if replica
             revision_mismatch_status
             := self.cluster_version_checker.get_cluster_mismatched_revision_status()
@@ -916,9 +916,9 @@ class MongoDBOperator(OperatorProtocol, Object):
             charm_statuses.append(revision_mismatch_status)
 
         if not self.cluster_manager.is_valid_mongos_integration():
-            charm_statuses.append(CharmStatuses.MongoDB.UNSUPPORTED_MONGOS_REL)
+            charm_statuses.append(CharmStatuses.mongodb.UNSUPPORTED_MONGOS_REL)
 
         if not self.backup_manager.is_valid_s3_integration():
-            charm_statuses.append(CharmStatuses.MongoDB.INVALID_S3_INTEGRATION_STATUS)
+            charm_statuses.append(CharmStatuses.mongodb.INVALID_S3_INTEGRATION_STATUS)
 
         return charm_statuses

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -7,14 +7,14 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, final, List
+from typing import TYPE_CHECKING, final
 
 from data_platform_helpers.version_check import (
     CrossAppVersionChecker,
     get_charm_revision,
 )
 from ops.framework import Object
-from ops.model import Container, MaintenanceStatus, Unit, StatusBase
+from ops.model import Container, MaintenanceStatus, StatusBase, Unit
 from pymongo.errors import PyMongoError, ServerSelectionTimeoutError
 from tenacity import Retrying, stop_after_attempt, wait_fixed
 from typing_extensions import override
@@ -28,10 +28,9 @@ from single_kernel_mongo.config.literals import (
     Substrates,
     UnitState,
 )
-from single_kernel_mongo.config.statuses import CharmStatuses
-
 from single_kernel_mongo.config.models import ROLES
 from single_kernel_mongo.config.relations import RelationNames
+from single_kernel_mongo.config.statuses import CharmStatuses
 from single_kernel_mongo.core.kubernetes_upgrades import KubernetesUpgrade
 from single_kernel_mongo.core.machine_upgrades import MachineUpgrade
 from single_kernel_mongo.core.operator import OperatorProtocol
@@ -175,18 +174,14 @@ class MongoDBOperator(OperatorProtocol, Object):
         self.cluster_manager = ClusterProvider(
             self, self.state, self.substrate, RelationNames.CLUSTER
         )
-        upgrade_backend = (
-            MachineUpgrade if self.substrate == Substrates.VM else KubernetesUpgrade
-        )
+        upgrade_backend = MachineUpgrade if self.substrate == Substrates.VM else KubernetesUpgrade
         self.upgrade_manager = MongoDBUpgradeManager(
             self, upgrade_backend, key=RelationNames.UPGRADE_VERSION.value
         )
 
         self.sysctl_config = sysctl.Config(name=self.charm.app.name)
 
-        self.observability_manager = ObservabilityManager(
-            self, self.state, self.substrate
-        )
+        self.observability_manager = ObservabilityManager(self, self.state, self.substrate)
 
         # Event Handlers
         self.password_actions = PasswordActionEvents(self)
@@ -276,9 +271,7 @@ class MongoDBOperator(OperatorProtocol, Object):
             self.charm.status_manager.to_maintenance("starting MongoDB")
             self.start_charm_services()
         except WorkloadServiceError as e:
-            logger.error(
-                f"An exception occurred when starting mongod agent, error: {e}."
-            )
+            logger.error(f"An exception occurred when starting mongod agent, error: {e}.")
             self.charm.status_manager.to_blocked("couldn't start MongoDB")
             return
 
@@ -359,9 +352,7 @@ class MongoDBOperator(OperatorProtocol, Object):
         # safe primary re-election.
         try:
             if self.charm.unit.name == self.primary_unit_name:
-                logger.debug(
-                    "Stepping down current primary, before upgrading service..."
-                )
+                logger.debug("Stepping down current primary, before upgrading service...")
                 self.upgrade_manager.step_down_primary_and_wait_reelection()
         except FailedToElectNewPrimaryError:
             logger.error("Failed to reelect primary before upgrading unit.")
@@ -375,9 +366,7 @@ class MongoDBOperator(OperatorProtocol, Object):
         unresponsive therefore causing a cluster failure, error the component. This prevents it
         from executing other hooks with a new role.
         """
-        if self.state.is_role(
-            MongoDBRoles.UNKNOWN
-        ):  # We haven't run the leader elected event yet.
+        if self.state.is_role(MongoDBRoles.UNKNOWN):  # We haven't run the leader elected event yet.
             self.state.app_peer_data.role = self.config.role
             return
 
@@ -540,20 +529,14 @@ class MongoDBOperator(OperatorProtocol, Object):
         # A single replica cannot step down as primary and we cannot reconfigure the replica set to
         # have 0 members.
         if self.is_removing_last_replica:
-            if (
-                self.state.is_role(MongoDBRoles.CONFIG_SERVER)
-                and self.state.config_server_relation
-            ):
+            if self.state.is_role(MongoDBRoles.CONFIG_SERVER) and self.state.config_server_relation:
                 current_shards = [
                     relation.app.name for relation in self.state.config_server_relation
                 ]
                 early_removal_message = f"Cannot remove config-server, still related to shards {', '.join(current_shards)}"
                 logger.error(early_removal_message)
                 raise EarlyRemovalOfConfigServerError(early_removal_message)
-            if (
-                self.state.is_role(MongoDBRoles.SHARD)
-                and self.state.shard_relation is not None
-            ):
+            if self.state.is_role(MongoDBRoles.SHARD) and self.state.shard_relation is not None:
                 logger.info("Wait for shard to drain before detaching storage.")
                 self.charm.status_manager.to_maintenance("Draining shard from cluster")
                 mongos_hosts = self.state.shard_state.mongos_hosts
@@ -621,9 +604,7 @@ class MongoDBOperator(OperatorProtocol, Object):
 
         self.charm.status_manager.process_and_share_statuses()
 
-    def on_set_password_action(
-        self, username: str, password: str | None = None
-    ) -> tuple[str, str]:
+    def on_set_password_action(self, username: str, password: str | None = None) -> tuple[str, str]:
         """Handler for the set password action."""
         self.assert_pass_password_checks()
 
@@ -641,9 +622,7 @@ class MongoDBOperator(OperatorProtocol, Object):
         if user == MonitorUser:
             # Update and restart mongodb exporter.
             self.mongodb_exporter_config_manager.configure_and_restart()
-        if user in (OperatorUser, BackupUser) and self.state.is_role(
-            MongoDBRoles.CONFIG_SERVER
-        ):
+        if user in (OperatorUser, BackupUser) and self.state.is_role(MongoDBRoles.CONFIG_SERVER):
             self.config_server_manager.update_credentials(
                 user.password_key_name,
                 new_password,
@@ -694,9 +673,7 @@ class MongoDBOperator(OperatorProtocol, Object):
         self.backup_manager.configure_and_restart()
 
         if not self.charm.unit.is_leader():
-            logger.debug(
-                "Only the leader can perform reconfigurations to the replica set."
-            )
+            logger.debug("Only the leader can perform reconfigurations to the replica set.")
             return
 
         # remove any IPs that are no longer juju hosts & update app data.
@@ -763,9 +740,7 @@ class MongoDBOperator(OperatorProtocol, Object):
             logger.error(f"Error setting values on sysctl: {e.message}")
             # containers share the kernel with the host system, and some sysctl parameters are
             # set at kernel level.
-            logger.warning(
-                "sysctl params cannot be set. Is the machine running on a container?"
-            )
+            logger.warning("sysctl params cannot be set. Is the machine running on a container?")
 
     @property
     def primary_unit_name(self) -> str | None:
@@ -852,9 +827,7 @@ class MongoDBOperator(OperatorProtocol, Object):
                 self.state.app_peer_data.role,
                 rel_name,
             )
-            self.charm.status_manager.to_blocked(
-                "sharding interface cannot be used by replicas"
-            )
+            self.charm.status_manager.to_blocked("sharding interface cannot be used by replicas")
             return False
         return True
 
@@ -921,7 +894,7 @@ class MongoDBOperator(OperatorProtocol, Object):
         """Returns True if the last replica (juju unit) is getting removed."""
         return self.state.planned_units == 0 and len(self.state.peers_units) == 0
 
-    def get_statuses(self) -> List[StatusBase]:
+    def get_statuses(self) -> list[StatusBase]:
         """Returns the statuses of the charm manager.."""
         charm_statuses = []
 
@@ -937,7 +910,8 @@ class MongoDBOperator(OperatorProtocol, Object):
         if not self.state.is_sharding_component and self.state.has_sharding_integration:
             charm_statuses.append(CharmStatuses.MongoDB.SHARDING_ON_REPLICA)
         elif (  # don't bother checking revision mismatch on sharding interface if replica
-            revision_mismatch_status := self.cluster_version_checker.get_cluster_mismatched_revision_status()
+            revision_mismatch_status
+            := self.cluster_version_checker.get_cluster_mismatched_revision_status()
         ):
             charm_statuses.append(revision_mismatch_status)
 

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -899,16 +899,16 @@ class MongoDBOperator(OperatorProtocol, Object):
         charm_statuses: list[StatusBase] = []
 
         if not self.workload.workload_present:
-            charm_statuses.append(CharmStatuses.MONGODB_NOT_INSTALLED)
+            charm_statuses.append(CharmStatuses.MONGODB_NOT_INSTALLED.value)
         else:  # don't bother checking if started if not installed
             if not self.state.db_initialised:
-                charm_statuses.append(CharmStatuses.mongodb.MONGODB_NOT_STARTED)
+                charm_statuses.append(CharmStatuses.mongodb.value.MONGODB_NOT_STARTED.value)
 
             if not self.mongodb_exporter_config_manager.workload.active():
-                charm_statuses.append(CharmStatuses.mongodb.EXPORTER_NOT_STARTED)
+                charm_statuses.append(CharmStatuses.mongodb.value.EXPORTER_NOT_STARTED.value)
 
         if not self.state.is_sharding_component and self.state.has_sharding_integration:
-            charm_statuses.append(CharmStatuses.mongodb.SHARDING_ON_REPLICA)
+            charm_statuses.append(CharmStatuses.mongodb.value.SHARDING_ON_REPLICA.value)
         elif (  # don't bother checking revision mismatch on sharding interface if replica
             revision_mismatch_status
             := self.cluster_version_checker.get_cluster_mismatched_revision_status()
@@ -916,9 +916,9 @@ class MongoDBOperator(OperatorProtocol, Object):
             charm_statuses.append(revision_mismatch_status)
 
         if not self.cluster_manager.is_valid_mongos_integration():
-            charm_statuses.append(CharmStatuses.mongodb.UNSUPPORTED_MONGOS_REL)
+            charm_statuses.append(CharmStatuses.mongodb.value.UNSUPPORTED_MONGOS_REL.value)
 
         if not self.backup_manager.is_valid_s3_integration():
-            charm_statuses.append(CharmStatuses.mongodb.INVALID_S3_INTEGRATION_STATUS)
+            charm_statuses.append(CharmStatuses.mongodb.value.INVALID_S3_INTEGRATION_STATUS.value)
 
         return charm_statuses

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -7,14 +7,14 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, final
+from typing import TYPE_CHECKING, final, List
 
 from data_platform_helpers.version_check import (
     CrossAppVersionChecker,
     get_charm_revision,
 )
 from ops.framework import Object
-from ops.model import Container, MaintenanceStatus, Unit
+from ops.model import Container, MaintenanceStatus, Unit, StatusBase
 from pymongo.errors import PyMongoError, ServerSelectionTimeoutError
 from tenacity import Retrying, stop_after_attempt, wait_fixed
 from typing_extensions import override
@@ -28,6 +28,8 @@ from single_kernel_mongo.config.literals import (
     Substrates,
     UnitState,
 )
+from single_kernel_mongo.config.statuses import CharmStatuses
+
 from single_kernel_mongo.config.models import ROLES
 from single_kernel_mongo.config.relations import RelationNames
 from single_kernel_mongo.core.kubernetes_upgrades import KubernetesUpgrade
@@ -36,12 +38,17 @@ from single_kernel_mongo.core.operator import OperatorProtocol
 from single_kernel_mongo.core.secrets import generate_secret_label
 from single_kernel_mongo.core.structured_config import MongoDBRoles
 from single_kernel_mongo.core.version_checker import VersionChecker
-from single_kernel_mongo.events.backups import INVALID_S3_INTEGRATION_STATUS, BackupEventsHandler
+from single_kernel_mongo.events.backups import (
+    BackupEventsHandler,
+)
 from single_kernel_mongo.events.cluster import ClusterConfigServerEventHandler
 from single_kernel_mongo.events.database import DatabaseEventsHandler
 from single_kernel_mongo.events.password_actions import PasswordActionEvents
 from single_kernel_mongo.events.primary_action import PrimaryActionHandler
-from single_kernel_mongo.events.sharding import ConfigServerEventHandler, ShardEventHandler
+from single_kernel_mongo.events.sharding import (
+    ConfigServerEventHandler,
+    ShardEventHandler,
+)
 from single_kernel_mongo.events.tls import TLSEventsHandler
 from single_kernel_mongo.events.upgrades import UpgradeEventHandler
 from single_kernel_mongo.exceptions import (
@@ -168,14 +175,18 @@ class MongoDBOperator(OperatorProtocol, Object):
         self.cluster_manager = ClusterProvider(
             self, self.state, self.substrate, RelationNames.CLUSTER
         )
-        upgrade_backend = MachineUpgrade if self.substrate == Substrates.VM else KubernetesUpgrade
+        upgrade_backend = (
+            MachineUpgrade if self.substrate == Substrates.VM else KubernetesUpgrade
+        )
         self.upgrade_manager = MongoDBUpgradeManager(
             self, upgrade_backend, key=RelationNames.UPGRADE_VERSION.value
         )
 
         self.sysctl_config = sysctl.Config(name=self.charm.app.name)
 
-        self.observability_manager = ObservabilityManager(self, self.state, self.substrate)
+        self.observability_manager = ObservabilityManager(
+            self, self.state, self.substrate
+        )
 
         # Event Handlers
         self.password_actions = PasswordActionEvents(self)
@@ -265,7 +276,9 @@ class MongoDBOperator(OperatorProtocol, Object):
             self.charm.status_manager.to_maintenance("starting MongoDB")
             self.start_charm_services()
         except WorkloadServiceError as e:
-            logger.error(f"An exception occurred when starting mongod agent, error: {e}.")
+            logger.error(
+                f"An exception occurred when starting mongod agent, error: {e}."
+            )
             self.charm.status_manager.to_blocked("couldn't start MongoDB")
             return
 
@@ -346,7 +359,9 @@ class MongoDBOperator(OperatorProtocol, Object):
         # safe primary re-election.
         try:
             if self.charm.unit.name == self.primary_unit_name:
-                logger.debug("Stepping down current primary, before upgrading service...")
+                logger.debug(
+                    "Stepping down current primary, before upgrading service..."
+                )
                 self.upgrade_manager.step_down_primary_and_wait_reelection()
         except FailedToElectNewPrimaryError:
             logger.error("Failed to reelect primary before upgrading unit.")
@@ -360,7 +375,9 @@ class MongoDBOperator(OperatorProtocol, Object):
         unresponsive therefore causing a cluster failure, error the component. This prevents it
         from executing other hooks with a new role.
         """
-        if self.state.is_role(MongoDBRoles.UNKNOWN):  # We haven't run the leader elected event yet.
+        if self.state.is_role(
+            MongoDBRoles.UNKNOWN
+        ):  # We haven't run the leader elected event yet.
             self.state.app_peer_data.role = self.config.role
             return
 
@@ -523,14 +540,20 @@ class MongoDBOperator(OperatorProtocol, Object):
         # A single replica cannot step down as primary and we cannot reconfigure the replica set to
         # have 0 members.
         if self.is_removing_last_replica:
-            if self.state.is_role(MongoDBRoles.CONFIG_SERVER) and self.state.config_server_relation:
+            if (
+                self.state.is_role(MongoDBRoles.CONFIG_SERVER)
+                and self.state.config_server_relation
+            ):
                 current_shards = [
                     relation.app.name for relation in self.state.config_server_relation
                 ]
                 early_removal_message = f"Cannot remove config-server, still related to shards {', '.join(current_shards)}"
                 logger.error(early_removal_message)
                 raise EarlyRemovalOfConfigServerError(early_removal_message)
-            if self.state.is_role(MongoDBRoles.SHARD) and self.state.shard_relation is not None:
+            if (
+                self.state.is_role(MongoDBRoles.SHARD)
+                and self.state.shard_relation is not None
+            ):
                 logger.info("Wait for shard to drain before detaching storage.")
                 self.charm.status_manager.to_maintenance("Draining shard from cluster")
                 mongos_hosts = self.state.shard_state.mongos_hosts
@@ -541,7 +564,10 @@ class MongoDBOperator(OperatorProtocol, Object):
         try:
             # retries over a period of 10 minutes in an attempt to resolve race conditions it is
             # not possible to defer in storage detached.
-            logger.debug("Removing %s from replica set", self.state.unit_peer_data.internal_address)
+            logger.debug(
+                "Removing %s from replica set",
+                self.state.unit_peer_data.internal_address,
+            )
             for attempt in Retrying(
                 stop=stop_after_attempt(600),
                 wait=wait_fixed(1),
@@ -556,12 +582,19 @@ class MongoDBOperator(OperatorProtocol, Object):
                 self.charm.unit.name,
             )
         except PyMongoError as e:
-            logger.error("Failed to remove %s from replica set, error=%r", self.charm.unit.name, e)
+            logger.error(
+                "Failed to remove %s from replica set, error=%r",
+                self.charm.unit.name,
+                e,
+            )
 
     @override
     def on_update_status(self) -> None:
         """Status update Handler."""
-        if not self.pass_status_basic_checks():
+        # TODO update the usage of this once the spec is approved and we have a consistent way of
+        # handling statuses
+        if len(self.get_statuses()):
+            self.charm.status_manager.set_and_share_status(self.get_statuses()[0])
             return
 
         if self.state.is_role(MongoDBRoles.SHARD):
@@ -588,7 +621,9 @@ class MongoDBOperator(OperatorProtocol, Object):
 
         self.charm.status_manager.process_and_share_statuses()
 
-    def on_set_password_action(self, username: str, password: str | None = None) -> tuple[str, str]:
+    def on_set_password_action(
+        self, username: str, password: str | None = None
+    ) -> tuple[str, str]:
         """Handler for the set password action."""
         self.assert_pass_password_checks()
 
@@ -606,7 +641,9 @@ class MongoDBOperator(OperatorProtocol, Object):
         if user == MonitorUser:
             # Update and restart mongodb exporter.
             self.mongodb_exporter_config_manager.configure_and_restart()
-        if user in (OperatorUser, BackupUser) and self.state.is_role(MongoDBRoles.CONFIG_SERVER):
+        if user in (OperatorUser, BackupUser) and self.state.is_role(
+            MongoDBRoles.CONFIG_SERVER
+        ):
             self.config_server_manager.update_credentials(
                 user.password_key_name,
                 new_password,
@@ -657,7 +694,9 @@ class MongoDBOperator(OperatorProtocol, Object):
         self.backup_manager.configure_and_restart()
 
         if not self.charm.unit.is_leader():
-            logger.debug("Only the leader can perform reconfigurations to the replica set.")
+            logger.debug(
+                "Only the leader can perform reconfigurations to the replica set."
+            )
             return
 
         # remove any IPs that are no longer juju hosts & update app data.
@@ -724,7 +763,9 @@ class MongoDBOperator(OperatorProtocol, Object):
             logger.error(f"Error setting values on sysctl: {e.message}")
             # containers share the kernel with the host system, and some sysctl parameters are
             # set at kernel level.
-            logger.warning("sysctl params cannot be set. Is the machine running on a container?")
+            logger.warning(
+                "sysctl params cannot be set. Is the machine running on a container?"
+            )
 
     @property
     def primary_unit_name(self) -> str | None:
@@ -787,30 +828,6 @@ class MongoDBOperator(OperatorProtocol, Object):
             self.charm.status_manager.to_blocked("couldn't start pbm-agent")
             raise
 
-    def pass_status_basic_checks(self) -> bool:
-        """Integration and initial checks for update-status events."""
-        if not self.state.is_sharding_component and self.state.has_sharding_integration:
-            self.charm.status_manager.to_blocked("sharding interface cannot be used by replicas")
-            return False
-        if not self.backup_manager.is_valid_s3_integration():
-            self.charm.status_manager.to_blocked(INVALID_S3_INTEGRATION_STATUS)
-            return False
-        if (
-            revision_mismatch_status
-            := self.cluster_version_checker.get_cluster_mismatched_revision_status()
-        ):
-            self.charm.status_manager.set_and_share_status(revision_mismatch_status)
-            return False
-        if not self.cluster_manager.is_valid_mongos_integration():
-            self.charm.status_manager.to_blocked(
-                "Relation to mongos not supported, config role must be config-server"
-            )
-            return False
-        if not self.state.db_initialised:
-            return False
-
-        return True
-
     @override
     def is_relation_feasible(self, rel_name: str) -> bool:
         """Checks if the relation is feasible in the current context.
@@ -835,7 +852,9 @@ class MongoDBOperator(OperatorProtocol, Object):
                 self.state.app_peer_data.role,
                 rel_name,
             )
-            self.charm.status_manager.to_blocked("sharding interface cannot be used by replicas")
+            self.charm.status_manager.to_blocked(
+                "sharding interface cannot be used by replicas"
+            )
             return False
         return True
 
@@ -901,3 +920,31 @@ class MongoDBOperator(OperatorProtocol, Object):
     def is_removing_last_replica(self) -> bool:
         """Returns True if the last replica (juju unit) is getting removed."""
         return self.state.planned_units == 0 and len(self.state.peers_units) == 0
+
+    def get_statuses(self) -> List[StatusBase]:
+        """Returns the statuses of the charm manager.."""
+        charm_statuses = []
+
+        if self.workload.present():
+            charm_statuses.append(CharmStatuses.MONGODB_NOT_INSTALLED)
+        else:  # don't bother checking if started if not installed
+            if self.state.db_initialised:
+                charm_statuses.append(CharmStatuses.MONGODB_NOT_STARTED)
+
+            if self.mongodb_exporter_config_manager.workload.active():
+                charm_statuses.append(CharmStatuses.EXPORTER_NOT_STARTED)
+
+        if not self.state.is_sharding_component and self.state.has_sharding_integration:
+            charm_statuses.append(CharmStatuses.SHARDING_ON_REPLICA)
+        elif (  # don't bother checking revision mismatch on sharding interface if replica
+            revision_mismatch_status := self.cluster_version_checker.get_cluster_mismatched_revision_status()
+        ):
+            charm_statuses.append(revision_mismatch_status)
+
+        if not self.cluster_manager.is_valid_mongos_integration():
+            charm_statuses.append(CharmStatuses.UNSUPPORTED_MONGOS_REL)
+
+        if not self.backup_manager.is_valid_s3_integration():
+            charm_statuses.append(CharmStatuses.INVALID_S3_INTEGRATION_STATUS)
+
+        return charm_statuses

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -896,7 +896,7 @@ class MongoDBOperator(OperatorProtocol, Object):
 
     def get_statuses(self) -> list[StatusBase]:
         """Returns the statuses of the charm manager.."""
-        charm_statuses = []
+        charm_statuses: list[StatusBase] = []
 
         if not self.workload.workload_present:
             charm_statuses.append(CharmStatuses.MONGODB_NOT_INSTALLED)

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -593,8 +593,8 @@ class MongoDBOperator(OperatorProtocol, Object):
         """Status update Handler."""
         # TODO update the usage of this once the spec is approved and we have a consistent way of
         # handling statuses
-        if len(self.get_statuses()):
-            self.charm.status_manager.set_and_share_status(self.get_statuses()[0])
+        if charm_statuses := self.get_statuses():
+            self.charm.status_manager.set_and_share_status(charm_statuses[0])
             return
 
         if self.state.is_role(MongoDBRoles.SHARD):
@@ -925,26 +925,26 @@ class MongoDBOperator(OperatorProtocol, Object):
         """Returns the statuses of the charm manager.."""
         charm_statuses = []
 
-        if self.workload.present():
+        if not self.workload.workload_present:
             charm_statuses.append(CharmStatuses.MONGODB_NOT_INSTALLED)
         else:  # don't bother checking if started if not installed
-            if self.state.db_initialised:
-                charm_statuses.append(CharmStatuses.MONGODB_NOT_STARTED)
+            if not self.state.db_initialised:
+                charm_statuses.append(CharmStatuses.MongoDB.MONGODB_NOT_STARTED)
 
-            if self.mongodb_exporter_config_manager.workload.active():
-                charm_statuses.append(CharmStatuses.EXPORTER_NOT_STARTED)
+            if not self.mongodb_exporter_config_manager.workload.active():
+                charm_statuses.append(CharmStatuses.MongoDB.EXPORTER_NOT_STARTED)
 
         if not self.state.is_sharding_component and self.state.has_sharding_integration:
-            charm_statuses.append(CharmStatuses.SHARDING_ON_REPLICA)
+            charm_statuses.append(CharmStatuses.MongoDB.SHARDING_ON_REPLICA)
         elif (  # don't bother checking revision mismatch on sharding interface if replica
             revision_mismatch_status := self.cluster_version_checker.get_cluster_mismatched_revision_status()
         ):
             charm_statuses.append(revision_mismatch_status)
 
         if not self.cluster_manager.is_valid_mongos_integration():
-            charm_statuses.append(CharmStatuses.UNSUPPORTED_MONGOS_REL)
+            charm_statuses.append(CharmStatuses.MongoDB.UNSUPPORTED_MONGOS_REL)
 
         if not self.backup_manager.is_valid_s3_integration():
-            charm_statuses.append(CharmStatuses.INVALID_S3_INTEGRATION_STATUS)
+            charm_statuses.append(CharmStatuses.MongoDB.INVALID_S3_INTEGRATION_STATUS)
 
         return charm_statuses

--- a/tests/unit/test_backup_manager.py
+++ b/tests/unit/test_backup_manager.py
@@ -32,9 +32,9 @@ def test_valid_s3_integration(harness: Harness[MongoTestCharm]):
 
     relation: Relation = harness.charm.operator.state.s3_relation
 
-    harness.charm.on[
-        ExternalRequirerRelations.S3_CREDENTIALS.value
-    ].relation_joined.emit(relation=relation)
+    harness.charm.on[ExternalRequirerRelations.S3_CREDENTIALS.value].relation_joined.emit(
+        relation=relation
+    )
     assert harness.charm.unit.status != BlockedStatus(INVALID_S3_INTEGRATION_STATUS)
 
 
@@ -48,9 +48,9 @@ def test_invalid_s3_integration(harness: Harness[MongoTestCharm]):
 
     relation: Relation = harness.charm.operator.state.s3_relation
 
-    harness.charm.on[
-        ExternalRequirerRelations.S3_CREDENTIALS.value
-    ].relation_joined.emit(relation=relation)
+    harness.charm.on[ExternalRequirerRelations.S3_CREDENTIALS.value].relation_joined.emit(
+        relation=relation
+    )
     assert harness.charm.unit.status == BlockedStatus(INVALID_S3_INTEGRATION_STATUS)
 
 
@@ -75,13 +75,9 @@ def test_get_status_fail(harness: Harness[MongoTestCharm], mocker):
         return_value=True,
     )
 
-    harness.add_relation(
-        ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
-    )
+    harness.add_relation(ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator")
 
-    mocker.patch(
-        "single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=False
-    )
+    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=False)
     status = backup_manager.get_status()
     assert status == WaitingStatus("waiting for pbm to start")
 
@@ -92,7 +88,7 @@ def test_get_status_fail(harness: Harness[MongoTestCharm], mocker):
         ("status code: 403", "s3 credentials are incorrect."),
         ("status code: 404", "s3 configurations are incompatible."),
         ("status code: 301", "s3 configurations are incompatible."),
-        ("Unknown message", "Unknwon PBM error, check logs"),
+        ("Unknown message", "Unknown PBM error, check logs"),
         (
             '{"cluster": [{"nodes":[{"host": "mongodb/1.1.1.1:27018", "errors": "status code: 403"}], "rs": "test-mongodb"}]}',
             "s3 credentials are incorrect.",
@@ -100,15 +96,11 @@ def test_get_status_fail(harness: Harness[MongoTestCharm], mocker):
     ),
 )
 @patch_network_get(private_address="1.1.1.1")
-def test_get_status_pbm_error(
-    harness: Harness[MongoTestCharm], mocker, pbm_status, expected
-):
+def test_get_status_pbm_error(harness: Harness[MongoTestCharm], mocker, pbm_status, expected):
     backup_manager = harness.charm.operator.backup_manager
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION.value
-    mocker.patch(
-        "single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True
-    )
+    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True)
     mocker.patch(
         "single_kernel_mongo.managers.backups.BackupManager.validate_s3_config",
         return_value=True,
@@ -132,38 +124,28 @@ def test_get_status_success(harness: Harness[MongoTestCharm], mocker):
     backup_manager = harness.charm.operator.backup_manager
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION.value
-    mocker.patch(
-        "single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True
-    )
+    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True)
     relation_id = harness.add_relation(
         ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
     )
     harness.add_relation_unit(relation_id, "s3-integrator/0")
 
-    mocker.patch(
-        "single_kernel_mongo.managers.backups.BackupManager.validate_s3_config"
-    )
+    mocker.patch("single_kernel_mongo.managers.backups.BackupManager.validate_s3_config")
     mock = mocker.patch(
         "single_kernel_mongo.managers.backups.BackupManager.pbm_status",
         new_callable=mocker.PropertyMock,
     )
-    mock.return_value = (
-        '{"running":{"type":"resync","opID":"64f5cc22a73b330c3880e3b2"}}'
-    )
+    mock.return_value = '{"running":{"type":"resync","opID":"64f5cc22a73b330c3880e3b2"}}'
     status = backup_manager.get_status()
     assert status == WaitingStatus("waiting to sync s3 configurations.")
 
     mock.return_value = '{"running":{"type":"backup","name":"2024-11-25"}}'
     status = backup_manager.get_status()
-    assert status == MaintenanceStatus(
-        "backup started/running, backup id: '2024-11-25'"
-    )
+    assert status == MaintenanceStatus("backup started/running, backup id: '2024-11-25'")
 
     mock.return_value = '{"running":{"type":"restore","name":"2024-11-25"}}'
     status = backup_manager.get_status()
-    assert status == MaintenanceStatus(
-        "restore started/running, backup id: '2024-11-25'"
-    )
+    assert status == MaintenanceStatus("restore started/running, backup id: '2024-11-25'")
 
     mock.return_value = "{}"
     status = backup_manager.get_status()
@@ -174,9 +156,7 @@ def test_create_backup_success(harness: Harness[MongoTestCharm], mocker):
     backup_manager = harness.charm.operator.backup_manager
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION.value
-    mocker.patch(
-        "single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True
-    )
+    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True)
     relation_id = harness.add_relation(
         ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
     )
@@ -196,9 +176,7 @@ def test_create_backup_fail_resync(harness: Harness[MongoTestCharm], mocker):
     backup_manager = harness.charm.operator.backup_manager
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION.value
-    mocker.patch(
-        "single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True
-    )
+    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True)
     relation_id = harness.add_relation(
         ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
     )
@@ -206,9 +184,7 @@ def test_create_backup_fail_resync(harness: Harness[MongoTestCharm], mocker):
 
     mocker.patch(
         "single_kernel_mongo.core.vm_workload.VMWorkload.run_bin_command",
-        side_effect=WorkloadExecError(
-            cmd="backup", return_code=1, stdout="Resync", stderr=None
-        ),
+        side_effect=WorkloadExecError(cmd="backup", return_code=1, stdout="Resync", stderr=None),
     )
 
     with pytest.raises(ResyncError):
@@ -219,9 +195,7 @@ def test_create_backup_fail_other(harness: Harness[MongoTestCharm], mocker):
     backup_manager = harness.charm.operator.backup_manager
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION.value
-    mocker.patch(
-        "single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True
-    )
+    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True)
     relation_id = harness.add_relation(
         ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
     )
@@ -229,9 +203,7 @@ def test_create_backup_fail_other(harness: Harness[MongoTestCharm], mocker):
 
     mocker.patch(
         "single_kernel_mongo.core.vm_workload.VMWorkload.run_bin_command",
-        side_effect=WorkloadExecError(
-            cmd="backup", return_code=1, stdout="deadbeef", stderr=None
-        ),
+        side_effect=WorkloadExecError(cmd="backup", return_code=1, stdout="deadbeef", stderr=None),
     )
 
     with pytest.raises(BackupError) as e:
@@ -244,9 +216,7 @@ def test_list_backup_action_success(harness: Harness[MongoTestCharm], mocker):
     backup_manager = harness.charm.operator.backup_manager
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION.value
-    mocker.patch(
-        "single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True
-    )
+    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True)
     relation_id = harness.add_relation(
         ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
     )
@@ -271,15 +241,11 @@ def test_list_backup_action_success(harness: Harness[MongoTestCharm], mocker):
     assert backup_formatted == backup_manager._format_backup_list(expected_list)
 
 
-def test_list_backup_action_success_no_backups(
-    harness: Harness[MongoTestCharm], mocker
-):
+def test_list_backup_action_success_no_backups(harness: Harness[MongoTestCharm], mocker):
     backup_manager = harness.charm.operator.backup_manager
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION.value
-    mocker.patch(
-        "single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True
-    )
+    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True)
     relation_id = harness.add_relation(
         ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
     )
@@ -302,18 +268,14 @@ def test_list_backup_action_error(harness: Harness[MongoTestCharm], mocker) -> N
     backup_manager = harness.charm.operator.backup_manager
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION.value
-    mocker.patch(
-        "single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True
-    )
+    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True)
     relation_id = harness.add_relation(
         ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
     )
     harness.add_relation_unit(relation_id, "s3-integrator/0")
     mocker.patch(
         "single_kernel_mongo.core.vm_workload.VMWorkload.run_bin_command",
-        side_effect=WorkloadExecError(
-            cmd="status", return_code=1, stdout=None, stderr=None
-        ),
+        side_effect=WorkloadExecError(cmd="status", return_code=1, stdout=None, stderr=None),
     )
     with pytest.raises(ListBackupError):
         backup_manager.list_backup_action()
@@ -323,16 +285,12 @@ def test_restore_backup_success(harness: Harness[MongoTestCharm], mocker) -> Non
     backup_manager = harness.charm.operator.backup_manager
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION.value
-    mocker.patch(
-        "single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True
-    )
+    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True)
     relation_id = harness.add_relation(
         ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
     )
     harness.add_relation_unit(relation_id, "s3-integrator/0")
-    mock_call = mocker.patch(
-        "single_kernel_mongo.core.vm_workload.VMWorkload.run_bin_command"
-    )
+    mock_call = mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.run_bin_command")
 
     backup_manager.restore_backup("deadbeef", "test-mongodb=test-mongodb")
 
@@ -347,9 +305,7 @@ def test_get_backup_error_status(harness: Harness[MongoTestCharm], mocker) -> No
     backup_manager = harness.charm.operator.backup_manager
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION.value
-    mocker.patch(
-        "single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True
-    )
+    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True)
     relation_id = harness.add_relation(
         ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
     )
@@ -381,9 +337,7 @@ def test_can_restore_fail_status(
     backup_manager = harness.charm.operator.backup_manager
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION.value
-    mocker.patch(
-        "single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True
-    )
+    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True)
     relation_id = harness.add_relation(
         ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
     )
@@ -408,9 +362,7 @@ def test_can_restore_fail_params(
     backup_manager = harness.charm.operator.backup_manager
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION.value
-    mocker.patch(
-        "single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True
-    )
+    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True)
     relation_id = harness.add_relation(
         ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
     )
@@ -437,15 +389,11 @@ def test_can_restore_fail_params(
         (BlockedStatus("error"), "error"),
     ),
 )
-def test_can_backup_fail(
-    harness: Harness[MongoTestCharm], mocker, pbm_status, pattern
-) -> None:
+def test_can_backup_fail(harness: Harness[MongoTestCharm], mocker, pbm_status, pattern) -> None:
     backup_manager = harness.charm.operator.backup_manager
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION.value
-    mocker.patch(
-        "single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True
-    )
+    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True)
     relation_id = harness.add_relation(
         ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
     )
@@ -473,9 +421,7 @@ def test_can_list_backup_fail(
     backup_manager = harness.charm.operator.backup_manager
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION.value
-    mocker.patch(
-        "single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True
-    )
+    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True)
     relation_id = harness.add_relation(
         ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
     )

--- a/tests/unit/test_backup_manager.py
+++ b/tests/unit/test_backup_manager.py
@@ -32,9 +32,9 @@ def test_valid_s3_integration(harness: Harness[MongoTestCharm]):
 
     relation: Relation = harness.charm.operator.state.s3_relation
 
-    harness.charm.on[ExternalRequirerRelations.S3_CREDENTIALS.value].relation_joined.emit(
-        relation=relation
-    )
+    harness.charm.on[
+        ExternalRequirerRelations.S3_CREDENTIALS.value
+    ].relation_joined.emit(relation=relation)
     assert harness.charm.unit.status != BlockedStatus(INVALID_S3_INTEGRATION_STATUS)
 
 
@@ -48,9 +48,9 @@ def test_invalid_s3_integration(harness: Harness[MongoTestCharm]):
 
     relation: Relation = harness.charm.operator.state.s3_relation
 
-    harness.charm.on[ExternalRequirerRelations.S3_CREDENTIALS.value].relation_joined.emit(
-        relation=relation
-    )
+    harness.charm.on[
+        ExternalRequirerRelations.S3_CREDENTIALS.value
+    ].relation_joined.emit(relation=relation)
     assert harness.charm.unit.status == BlockedStatus(INVALID_S3_INTEGRATION_STATUS)
 
 
@@ -67,14 +67,23 @@ def test_environment_is_valid(harness: Harness[MongoTestCharm]):
 
 def test_get_status_fail(harness: Harness[MongoTestCharm], mocker):
     backup_manager = harness.charm.operator.backup_manager
-
-    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=False)
-    status = backup_manager.get_status()
-    assert status == WaitingStatus("waiting for pbm to start")
-
-    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True)
     status = backup_manager.get_status()
     assert status is None
+
+    mocker.patch(
+        "single_kernel_mongo.managers.backups.BackupManager.validate_s3_config",
+        return_value=True,
+    )
+
+    harness.add_relation(
+        ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
+    )
+
+    mocker.patch(
+        "single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=False
+    )
+    status = backup_manager.get_status()
+    assert status == WaitingStatus("waiting for pbm to start")
 
 
 @pytest.mark.parametrize(
@@ -83,7 +92,7 @@ def test_get_status_fail(harness: Harness[MongoTestCharm], mocker):
         ("status code: 403", "s3 credentials are incorrect."),
         ("status code: 404", "s3 configurations are incompatible."),
         ("status code: 301", "s3 configurations are incompatible."),
-        ("Unknown message", "PBM error"),
+        ("Unknown message", "Unknwon PBM error, check logs"),
         (
             '{"cluster": [{"nodes":[{"host": "mongodb/1.1.1.1:27018", "errors": "status code: 403"}], "rs": "test-mongodb"}]}',
             "s3 credentials are incorrect.",
@@ -91,13 +100,18 @@ def test_get_status_fail(harness: Harness[MongoTestCharm], mocker):
     ),
 )
 @patch_network_get(private_address="1.1.1.1")
-def test_get_status_pbm_error(harness: Harness[MongoTestCharm], mocker, pbm_status, expected):
+def test_get_status_pbm_error(
+    harness: Harness[MongoTestCharm], mocker, pbm_status, expected
+):
     backup_manager = harness.charm.operator.backup_manager
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION.value
-    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True)
     mocker.patch(
-        "single_kernel_mongo.managers.backups.BackupManager.validate_s3_config", return_value=True
+        "single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True
+    )
+    mocker.patch(
+        "single_kernel_mongo.managers.backups.BackupManager.validate_s3_config",
+        return_value=True,
     )
     relation_id = harness.add_relation(
         ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
@@ -118,28 +132,38 @@ def test_get_status_success(harness: Harness[MongoTestCharm], mocker):
     backup_manager = harness.charm.operator.backup_manager
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION.value
-    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True)
+    mocker.patch(
+        "single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True
+    )
     relation_id = harness.add_relation(
         ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
     )
     harness.add_relation_unit(relation_id, "s3-integrator/0")
 
-    mocker.patch("single_kernel_mongo.managers.backups.BackupManager.validate_s3_config")
+    mocker.patch(
+        "single_kernel_mongo.managers.backups.BackupManager.validate_s3_config"
+    )
     mock = mocker.patch(
         "single_kernel_mongo.managers.backups.BackupManager.pbm_status",
         new_callable=mocker.PropertyMock,
     )
-    mock.return_value = '{"running":{"type":"resync","opID":"64f5cc22a73b330c3880e3b2"}}'
+    mock.return_value = (
+        '{"running":{"type":"resync","opID":"64f5cc22a73b330c3880e3b2"}}'
+    )
     status = backup_manager.get_status()
     assert status == WaitingStatus("waiting to sync s3 configurations.")
 
     mock.return_value = '{"running":{"type":"backup","name":"2024-11-25"}}'
     status = backup_manager.get_status()
-    assert status == MaintenanceStatus("backup started/running, backup id: '2024-11-25'")
+    assert status == MaintenanceStatus(
+        "backup started/running, backup id: '2024-11-25'"
+    )
 
     mock.return_value = '{"running":{"type":"restore","name":"2024-11-25"}}'
     status = backup_manager.get_status()
-    assert status == MaintenanceStatus("restore started/running, backup id: '2024-11-25'")
+    assert status == MaintenanceStatus(
+        "restore started/running, backup id: '2024-11-25'"
+    )
 
     mock.return_value = "{}"
     status = backup_manager.get_status()
@@ -150,7 +174,9 @@ def test_create_backup_success(harness: Harness[MongoTestCharm], mocker):
     backup_manager = harness.charm.operator.backup_manager
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION.value
-    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True)
+    mocker.patch(
+        "single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True
+    )
     relation_id = harness.add_relation(
         ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
     )
@@ -170,7 +196,9 @@ def test_create_backup_fail_resync(harness: Harness[MongoTestCharm], mocker):
     backup_manager = harness.charm.operator.backup_manager
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION.value
-    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True)
+    mocker.patch(
+        "single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True
+    )
     relation_id = harness.add_relation(
         ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
     )
@@ -178,7 +206,9 @@ def test_create_backup_fail_resync(harness: Harness[MongoTestCharm], mocker):
 
     mocker.patch(
         "single_kernel_mongo.core.vm_workload.VMWorkload.run_bin_command",
-        side_effect=WorkloadExecError(cmd="backup", return_code=1, stdout="Resync", stderr=None),
+        side_effect=WorkloadExecError(
+            cmd="backup", return_code=1, stdout="Resync", stderr=None
+        ),
     )
 
     with pytest.raises(ResyncError):
@@ -189,7 +219,9 @@ def test_create_backup_fail_other(harness: Harness[MongoTestCharm], mocker):
     backup_manager = harness.charm.operator.backup_manager
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION.value
-    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True)
+    mocker.patch(
+        "single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True
+    )
     relation_id = harness.add_relation(
         ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
     )
@@ -197,7 +229,9 @@ def test_create_backup_fail_other(harness: Harness[MongoTestCharm], mocker):
 
     mocker.patch(
         "single_kernel_mongo.core.vm_workload.VMWorkload.run_bin_command",
-        side_effect=WorkloadExecError(cmd="backup", return_code=1, stdout="deadbeef", stderr=None),
+        side_effect=WorkloadExecError(
+            cmd="backup", return_code=1, stdout="deadbeef", stderr=None
+        ),
     )
 
     with pytest.raises(BackupError) as e:
@@ -210,7 +244,9 @@ def test_list_backup_action_success(harness: Harness[MongoTestCharm], mocker):
     backup_manager = harness.charm.operator.backup_manager
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION.value
-    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True)
+    mocker.patch(
+        "single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True
+    )
     relation_id = harness.add_relation(
         ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
     )
@@ -235,11 +271,15 @@ def test_list_backup_action_success(harness: Harness[MongoTestCharm], mocker):
     assert backup_formatted == backup_manager._format_backup_list(expected_list)
 
 
-def test_list_backup_action_success_no_backups(harness: Harness[MongoTestCharm], mocker):
+def test_list_backup_action_success_no_backups(
+    harness: Harness[MongoTestCharm], mocker
+):
     backup_manager = harness.charm.operator.backup_manager
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION.value
-    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True)
+    mocker.patch(
+        "single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True
+    )
     relation_id = harness.add_relation(
         ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
     )
@@ -262,14 +302,18 @@ def test_list_backup_action_error(harness: Harness[MongoTestCharm], mocker) -> N
     backup_manager = harness.charm.operator.backup_manager
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION.value
-    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True)
+    mocker.patch(
+        "single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True
+    )
     relation_id = harness.add_relation(
         ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
     )
     harness.add_relation_unit(relation_id, "s3-integrator/0")
     mocker.patch(
         "single_kernel_mongo.core.vm_workload.VMWorkload.run_bin_command",
-        side_effect=WorkloadExecError(cmd="status", return_code=1, stdout=None, stderr=None),
+        side_effect=WorkloadExecError(
+            cmd="status", return_code=1, stdout=None, stderr=None
+        ),
     )
     with pytest.raises(ListBackupError):
         backup_manager.list_backup_action()
@@ -279,12 +323,16 @@ def test_restore_backup_success(harness: Harness[MongoTestCharm], mocker) -> Non
     backup_manager = harness.charm.operator.backup_manager
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION.value
-    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True)
+    mocker.patch(
+        "single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True
+    )
     relation_id = harness.add_relation(
         ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
     )
     harness.add_relation_unit(relation_id, "s3-integrator/0")
-    mock_call = mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.run_bin_command")
+    mock_call = mocker.patch(
+        "single_kernel_mongo.core.vm_workload.VMWorkload.run_bin_command"
+    )
 
     backup_manager.restore_backup("deadbeef", "test-mongodb=test-mongodb")
 
@@ -299,7 +347,9 @@ def test_get_backup_error_status(harness: Harness[MongoTestCharm], mocker) -> No
     backup_manager = harness.charm.operator.backup_manager
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION.value
-    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True)
+    mocker.patch(
+        "single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True
+    )
     relation_id = harness.add_relation(
         ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
     )
@@ -331,7 +381,9 @@ def test_can_restore_fail_status(
     backup_manager = harness.charm.operator.backup_manager
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION.value
-    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True)
+    mocker.patch(
+        "single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True
+    )
     relation_id = harness.add_relation(
         ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
     )
@@ -356,13 +408,16 @@ def test_can_restore_fail_params(
     backup_manager = harness.charm.operator.backup_manager
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION.value
-    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True)
+    mocker.patch(
+        "single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True
+    )
     relation_id = harness.add_relation(
         ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
     )
     harness.add_relation_unit(relation_id, "s3-integrator/0")
     mocker.patch(
-        "single_kernel_mongo.managers.backups.BackupManager.get_status", return_value=ActiveStatus()
+        "single_kernel_mongo.managers.backups.BackupManager.get_status",
+        return_value=ActiveStatus(),
     )
     mocker.patch(
         "single_kernel_mongo.managers.backups.BackupManager._needs_provided_remap_arguments",
@@ -382,11 +437,15 @@ def test_can_restore_fail_params(
         (BlockedStatus("error"), "error"),
     ),
 )
-def test_can_backup_fail(harness: Harness[MongoTestCharm], mocker, pbm_status, pattern) -> None:
+def test_can_backup_fail(
+    harness: Harness[MongoTestCharm], mocker, pbm_status, pattern
+) -> None:
     backup_manager = harness.charm.operator.backup_manager
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION.value
-    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True)
+    mocker.patch(
+        "single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True
+    )
     relation_id = harness.add_relation(
         ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
     )
@@ -414,7 +473,9 @@ def test_can_list_backup_fail(
     backup_manager = harness.charm.operator.backup_manager
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION.value
-    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True)
+    mocker.patch(
+        "single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True
+    )
     relation_id = harness.add_relation(
         ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
     )


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷 Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update
- [ ] Tooling and CI changes
- [ ] Dependencies upgrade or change

## 📝 Description
Update backup + charm (MongoDB VM) to have function that can compute the state/status of the charm regardless of the context

## 📑 Motivation and Context
We want to begin preparing the charm for Advanced Status Handling. Before migrating all managers to have a status compute function we first try with backup + mongodb charm manager

## Future work
1. add status computers for all managers
2. move all statuses to config file
3. implement advanced status handling 

## 🧪 How Has This Been Tested?
Charm was tested by injecting the code into the MongoDB operator and manually verifying behavior

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](../blob/6/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
