### PR TITLE
fix: set current revision even if no snap upgrade

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "mongo-charms-single-kernel"
-version = "0.0.3"
+version = "0.0.4"
 description = "Shared and reusable code for Mongo-related charms"
 readme = "README.md"
 license = "Apache-2.0"

--- a/single_kernel_mongo/managers/upgrade.py
+++ b/single_kernel_mongo/managers/upgrade.py
@@ -91,6 +91,9 @@ class MongoUpgradeManager(Generic[T], GenericMongoDBUpgradeManager[T]):
         if self.charm.unit.is_leader():
             if not self.state.upgrade_in_progress:
                 logger.info("Charm refreshed. MongoDB version unchanged")
+                self.state.unit_upgrade_peer_data.current_revision = (
+                    self.dependent.cross_app_version_checker.version  # type: ignore
+                )
             if self.dependent.name == CharmKind.MONGOD:
                 self.state.app_upgrade_peer_data.upgrade_resumed = False
                 self.dependent.cross_app_version_checker.set_version_across_all_relations()  # type: ignore

--- a/single_kernel_mongo/managers/upgrade.py
+++ b/single_kernel_mongo/managers/upgrade.py
@@ -88,12 +88,13 @@ class MongoUpgradeManager(Generic[T], GenericMongoDBUpgradeManager[T]):
             self.dependent.upgrade_events.post_app_upgrade_event.emit()
 
     def _on_vm_upgrade(self):
+        if not self.state.upgrade_in_progress:
+            self.state.unit_upgrade_peer_data.current_revision = (
+                self.dependent.cross_app_version_checker.version  # type: ignore
+            )
         if self.charm.unit.is_leader():
             if not self.state.upgrade_in_progress:
                 logger.info("Charm refreshed. MongoDB version unchanged")
-                self.state.unit_upgrade_peer_data.current_revision = (
-                    self.dependent.cross_app_version_checker.version  # type: ignore
-                )
             if self.dependent.name == CharmKind.MONGOD:
                 self.state.app_upgrade_peer_data.upgrade_resumed = False
                 self.dependent.cross_app_version_checker.set_version_across_all_relations()  # type: ignore


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷 Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update
- [ ] Tooling and CI changes
- [ ] Dependencies upgrade or change

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and scope of this PR (what)
  - the impacted components (where, often match conventional commit scope)
  - explanation/algorithm if require (how)
-->
The `current_version` in unit databag was not set in case the snap was not upgraded.
This is fixed by this commit.

## 📑 Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Either the associated JIRA reference or a paragraph. -->
Bug fix, something missed in the move to single kernel.

## 🧪 How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Integration tested on my machine.

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](../blob/6/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
