### PR TITLE
fix: Add to managed users in case of config server

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -116,7 +116,7 @@ jobs:
           branch: '6/edge'
           new_branch: '${{ steps.comment-branch.outputs.head_ref }}'
           python_version: '3.10'
-          pat: secrets.PAT
+          pat: '${{ secrets.PAT }}'
       - name: Convert PR's to ready to review.
         if: success()
         shell: bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@
 
 [project]
 name = "mongo-charms-single-kernel"
-version = "0.0.4"
+version = "0.0.5"
 description = "Shared and reusable code for Mongo-related charms"
 readme = "README.md"
 license = "Apache-2.0"

--- a/single_kernel_mongo/managers/mongo.py
+++ b/single_kernel_mongo/managers/mongo.py
@@ -236,6 +236,8 @@ class MongoManager(Object, StatusProvider):
             data_interface.set_database(relation.id, config.database)
             data_interface.set_credentials(relation.id, config.username, config.password)
 
+            self.state.app_peer_data.managed_users = managed_users
+
             if self.state.is_role(MongoDBRoles.CONFIG_SERVER):
                 return
 
@@ -246,8 +248,6 @@ class MongoManager(Object, StatusProvider):
                 data_interface.set_replset(
                     relation.id, config.replset or self.state.app_peer_data.replica_set
                 )
-
-        self.state.app_peer_data.managed_users = managed_users
 
     def update_user(self, relation: Relation) -> None:
         """Add the user for this relation."""

--- a/single_kernel_mongo/managers/upgrade.py
+++ b/single_kernel_mongo/managers/upgrade.py
@@ -88,7 +88,7 @@ class MongoUpgradeManager(Generic[T], GenericMongoDBUpgradeManager[T]):
             self.dependent.upgrade_events.post_app_upgrade_event.emit()
 
     def _on_vm_upgrade(self):
-        if not self.state.upgrade_in_progress:
+        if not self.state.upgrade_in_progress and self.dependent.name == CharmKind.MONGOD:
             self.state.unit_upgrade_peer_data.current_revision = (
                 self.dependent.cross_app_version_checker.version  # type: ignore
             )


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷 Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update
- [ ] Tooling and CI changes
- [ ] Dependencies upgrade or change

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and scope of this PR (what)
  - the impacted components (where, often match conventional commit scope)
  - explanation/algorithm if require (how)
-->
[Mongos VM Operator CI](https://github.com/canonical/mongos-operator/actions/runs/13654009064/job/38475306538) has showed that we were forgetting to add the user for the cluster relation on the config-server side.
This fixes this issue.
The bug is due to the change of workflows between the former libraries and the single kernel library.
This once again highlights the need for #24 so we have tests directly in this repository to avoid such silly bugs.

Second bug raised is a miss in the former PR which introduced a regression.
The unit tests for upgrades haven't been ported yet in single kernel and are lacking some cases and this is why we missed it.

## 📑 Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Either the associated JIRA reference or a paragraph. -->
This is a bug fix.

## 🧪 How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually.

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](../blob/6/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
