### PR TITLE
feat(DPE-6792): Share config with mongos

### DIFF
--- a/single_kernel_mongo/core/operator.py
+++ b/single_kernel_mongo/core/operator.py
@@ -280,9 +280,10 @@ class OperatorProtocol(ABC, Object):
 
     def remove_ca_cert_from_trust_store(self, file: TrustStoreFiles):
         """Removes the certificate from the trust store."""
-        # Remove the file
-        self.workload.delete(TRUST_STORE_PATH / file.value)
-        # Update CA certificates to remove the certificate from the trust store
-        self.workload.exec("update-ca-certificates")
-        # Restart the service
-        self.restart_charm_services(force=True)
+        if self.workload.exists(TRUST_STORE_PATH / file.value):
+            # Remove the file
+            self.workload.delete(TRUST_STORE_PATH / file.value)
+            # Update CA certificates to remove the certificate from the trust store
+            self.workload.exec("update-ca-certificates")
+            # Restart the service
+            self.restart_charm_services(force=True)

--- a/single_kernel_mongo/core/operator.py
+++ b/single_kernel_mongo/core/operator.py
@@ -280,10 +280,12 @@ class OperatorProtocol(ABC, Object):
 
     def remove_ca_cert_from_trust_store(self, file: TrustStoreFiles):
         """Removes the certificate from the trust store."""
-        if self.workload.exists(TRUST_STORE_PATH / file.value):
-            # Remove the file
-            self.workload.delete(TRUST_STORE_PATH / file.value)
-            # Update CA certificates to remove the certificate from the trust store
-            self.workload.exec("update-ca-certificates")
-            # Restart the service
-            self.restart_charm_services(force=True)
+        if not self.workload.exists(TRUST_STORE_PATH / file.value):
+            return
+
+        # Remove the file
+        self.workload.delete(TRUST_STORE_PATH / file.value)
+        # Update CA certificates to remove the certificate from the trust store
+        self.workload.exec("update-ca-certificates")
+        # Restart the service
+        self.restart_charm_services(force=True)

--- a/single_kernel_mongo/events/ldap.py
+++ b/single_kernel_mongo/events/ldap.py
@@ -111,7 +111,7 @@ class LDAPEventHandler(Object):
         action = "restart-ldap-if-ready"
         try:
             self.manager.restart_when_ready()
-        except DeferrableFailedHookChecksError as err:
+        except (DeferrableFailedHookChecksError, DeferrableError) as err:
             defer_event_with_info_log(logger, event, action, f"{err}")
         except NonDeferrableFailedHookChecksError as err:
             logger.error(f"{err}")

--- a/single_kernel_mongo/exceptions.py
+++ b/single_kernel_mongo/exceptions.py
@@ -263,3 +263,7 @@ class InvalidLdapQueryTemplateError(Exception):
 
 class WaitingForLeaderError(Exception):
     """Raised when we haven't elected a leader yet but we need it."""
+
+
+class InvalidLdapHashError(DeferrableError):
+    """Raised when the hash shared by config server is invalid."""

--- a/single_kernel_mongo/managers/cluster.py
+++ b/single_kernel_mongo/managers/cluster.py
@@ -161,7 +161,11 @@ class ClusterProvider(Object):
 
     def update_ldap_user_to_dn_mapping(self) -> None:
         """Updates the ldap user to dn mapping value in the databag."""
-        self.assert_pass_hook_checks()
+        try:
+            self.assert_pass_hook_checks()
+        except (DeferrableFailedHookChecksError, NonDeferrableFailedHookChecksError):
+            logger.info("Not updating ldap user to dn mapping now, not ready.")
+            return
 
         if not self.charm.unit.is_leader():
             return

--- a/single_kernel_mongo/managers/cluster.py
+++ b/single_kernel_mongo/managers/cluster.py
@@ -102,6 +102,9 @@ class ClusterProvider(Object):
         if int_tls_ca := self.state.tls.get_secret(label_name=SECRET_CA_LABEL, internal=True):
             relation_data[ClusterStateKeys.INT_CA_SECRET.value] = int_tls_ca
 
+        if hashed_data := self.dependent.ldap_manager.get_hash():
+            relation_data[ClusterStateKeys.LDAP_HASH.value] = hashed_data
+
         # We want to avoid having to configure both applications with the exact
         # same string so the config-server shares it with the client.
         if ldap_user_to_dn_mapping := self.state.app_peer_data.ldap_user_to_dn_mapping:
@@ -159,6 +162,40 @@ class ClusterProvider(Object):
                 },
             )
 
+    def update_ldap_hash_to_mongos(self, hashed_data: str) -> None:
+        """Sends the hash to mongos to confirm we are integrated with the same units."""
+        try:
+            self.assert_pass_hook_checks()
+        except (DeferrableFailedHookChecksError, NonDeferrableFailedHookChecksError):
+            logger.info("Not updating ldap hash now, not ready.")
+            return
+
+        if not self.charm.unit.is_leader():
+            return
+
+        for relation in self.state.cluster_relations:
+            self.data_interface.update_relation_data(
+                relation.id,
+                {ClusterStateKeys.LDAP_HASH.value: hashed_data},
+            )
+
+    def remove_ldap_hash(self) -> None:
+        """Removes the hash from all relations."""
+        try:
+            self.assert_pass_hook_checks()
+        except (DeferrableFailedHookChecksError, NonDeferrableFailedHookChecksError):
+            logger.info("Not removing ldap hash now, not ready.")
+            return
+
+        if not self.charm.unit.is_leader():
+            return
+
+        for relation in self.state.cluster_relations:
+            self.data_interface.delete_relation_data(
+                relation.id,
+                [ClusterStateKeys.LDAP_HASH.value],
+            )
+
     def update_ldap_user_to_dn_mapping(self) -> None:
         """Updates the ldap user to dn mapping value in the databag."""
         try:
@@ -174,7 +211,7 @@ class ClusterProvider(Object):
             self.data_interface.update_relation_data(
                 relation.id,
                 {
-                    ClusterStateKeys.LDAP_USER_TO_DN_MAPPING.value: self.state.config.ldap_user_to_dn_mapping
+                    ClusterStateKeys.LDAP_USER_TO_DN_MAPPING.value: self.state.app_peer_data.ldap_user_to_dn_mapping
                 },
             )
 

--- a/single_kernel_mongo/managers/cluster.py
+++ b/single_kernel_mongo/managers/cluster.py
@@ -102,6 +102,9 @@ class ClusterProvider(Object):
         if int_tls_ca := self.state.tls.get_secret(label_name=SECRET_CA_LABEL, internal=True):
             relation_data[ClusterStateKeys.INT_CA_SECRET.value] = int_tls_ca
 
+        if ldap_user_to_dn_mapping := self.state.app_peer_data.ldap_user_to_dn_mapping:
+            relation_data[ClusterStateKeys.LDAP_USER_TO_DN_MAPPING.value] = ldap_user_to_dn_mapping
+
         self.data_interface.update_relation_data(relation.id, relation_data)
 
     def update_keyfile_and_hosts_on_mongos(self, relation: Relation) -> None:
@@ -151,6 +154,17 @@ class ClusterProvider(Object):
                 relation.id,
                 {
                     ClusterStateKeys.CONFIG_SERVER_DB.value: config_server_db,
+                },
+            )
+
+    def update_ldap_user_to_dn_mapping(self) -> None:
+        """Updates the ldap user to dn mapping value in the databag."""
+        self.assert_pass_hook_checks()
+        for relation in self.state.cluster_relations:
+            self.data_interface.update_relation_data(
+                relation.id,
+                {
+                    ClusterStateKeys.LDAP_USER_TO_DN_MAPPING.value: self.state.config.ldap_user_to_dn_mapping
                 },
             )
 
@@ -228,6 +242,10 @@ class ClusterRequirer(Object):
         self.assert_pass_hook_checks()
         key_file_contents = self.state.cluster.keyfile
         config_server_db_uri = self.state.cluster.config_server_uri
+
+        if ldap_user_to_dn_mapping := self.state.cluster.ldap_user_to_dn_mapping:
+            logger.debug("Received a userToDNMapping, storing it in databag.")
+            self.state.app_peer_data.ldap_user_to_dn_mapping = ldap_user_to_dn_mapping
 
         if not key_file_contents or not config_server_db_uri:
             raise WaitingForSecretsError("Waiting for keyfile or config server db uri")

--- a/single_kernel_mongo/managers/cluster.py
+++ b/single_kernel_mongo/managers/cluster.py
@@ -102,6 +102,8 @@ class ClusterProvider(Object):
         if int_tls_ca := self.state.tls.get_secret(label_name=SECRET_CA_LABEL, internal=True):
             relation_data[ClusterStateKeys.INT_CA_SECRET.value] = int_tls_ca
 
+        # We want to avoid having to configure both applications with the exact
+        # same string so the config-server shares it with the client.
         if ldap_user_to_dn_mapping := self.state.app_peer_data.ldap_user_to_dn_mapping:
             relation_data[ClusterStateKeys.LDAP_USER_TO_DN_MAPPING.value] = ldap_user_to_dn_mapping
 
@@ -160,6 +162,10 @@ class ClusterProvider(Object):
     def update_ldap_user_to_dn_mapping(self) -> None:
         """Updates the ldap user to dn mapping value in the databag."""
         self.assert_pass_hook_checks()
+
+        if not self.charm.unit.is_leader():
+            return
+
         for relation in self.state.cluster_relations:
             self.data_interface.update_relation_data(
                 relation.id,
@@ -243,7 +249,9 @@ class ClusterRequirer(Object):
         key_file_contents = self.state.cluster.keyfile
         config_server_db_uri = self.state.cluster.config_server_uri
 
-        if ldap_user_to_dn_mapping := self.state.cluster.ldap_user_to_dn_mapping:
+        if self.charm.unit.is_leader() and (
+            ldap_user_to_dn_mapping := self.state.cluster.ldap_user_to_dn_mapping
+        ):
             logger.debug("Received a userToDNMapping, storing it in databag.")
             self.state.app_peer_data.ldap_user_to_dn_mapping = ldap_user_to_dn_mapping
 

--- a/single_kernel_mongo/managers/config.py
+++ b/single_kernel_mongo/managers/config.py
@@ -493,7 +493,6 @@ class MongosConfigManager(MongoConfigManager):
                         "queryUser": self.state.ldap.bind_user,
                         "queryPassword": self.state.ldap.bind_password,
                     },
-                    # TODO: Update this when writing config-server/mongos sync.
                     "userToDNMapping": self.state.app_peer_data.ldap_user_to_dn_mapping or "[]",
                 }
             },

--- a/single_kernel_mongo/managers/ldap.py
+++ b/single_kernel_mongo/managers/ldap.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import ssl
 from logging import getLogger
 from typing import TYPE_CHECKING
@@ -26,6 +27,7 @@ from single_kernel_mongo.core.status_provider import StatusProvider
 from single_kernel_mongo.core.structured_config import MongoDBRoles
 from single_kernel_mongo.exceptions import (
     DeferrableFailedHookChecksError,
+    InvalidLdapHashError,
     LDAPSNotEnabledError,
     NonDeferrableFailedHookChecksError,
     WaitingForLdapDataError,
@@ -42,6 +44,9 @@ if TYPE_CHECKING:
 logger = getLogger(__name__)
 
 CANNOT_INTEGRATE_WITH_SHARD_STATUS = BlockedStatus("Cannot integrate LDAP with shard.")
+INVALID_HASH_STATUS = BlockedStatus(
+    "mongos and config-server not integrated with the same ldap server."
+)
 
 
 class LDAPManager(Object, StatusProvider):
@@ -110,17 +115,23 @@ class LDAPManager(Object, StatusProvider):
             case None:
                 return
             case ActiveStatus():
+                self.share_hash_with_mongos()
                 logger.info("Restarting mongodb server for LDAP integration")
                 self.dependent.restart_charm_services()
                 self.charm.status_manager.set_and_share_status(ActiveStatus())
             case status:
                 self.charm.status_manager.set_and_share_status(status)
+                if status == INVALID_HASH_STATUS:
+                    raise InvalidLdapHashError(
+                        "mongos and config-server not integrated with the same ldap server."
+                    )
 
     def ldap_unavailable(self) -> None:
         """Runs when the LDAP integration is broken."""
         self.state.ldap.clean_databag()
 
-        self.dependent.restart_charm_services()
+        if self.state.db_initialised:  # Don't restart if we haven't initialised the DB yet.
+            self.dependent.restart_charm_services()
         self.charm.status_manager.set_and_share_status(self.get_status() or ActiveStatus())
 
     def certificate_available(self, certificate: str, ca: str, chain: list[str]) -> None:
@@ -158,7 +169,8 @@ class LDAPManager(Object, StatusProvider):
         if self.workload.exists(self.workload.paths.ldap_certificates_file):
             self.workload.delete(self.workload.paths.ldap_certificates_file)
 
-        self.dependent.restart_charm_services()
+        if self.state.db_initialised:  # Don't restart if we haven't initialised the DB yet.
+            self.dependent.restart_charm_services()
 
         self.charm.status_manager.set_and_share_status(self.get_status() or ActiveStatus())
 
@@ -184,9 +196,15 @@ class LDAPManager(Object, StatusProvider):
             )
             return BlockedStatus("GLauth TLS is integrated but LDAP is not.")
 
-        ldap_relation_status = self.state.ldap.ldap_ready()
+        if self.state.is_role(MongoDBRoles.MONGOS):
+            if self.state.cluster.ldap_hash != self.get_hash():
+                logger.error(
+                    "Config Server and mongos integrations with LDAP have a different checksum."
+                    "This usually means they are not integrated with the same LDAP application."
+                )
+                return INVALID_HASH_STATUS
 
-        # We can ignore the typing error because we'll end up here only if both are not None.
+        ldap_relation_status = self.state.ldap.ldap_ready()
         ldap_certificate_integration_status = self.state.ldap.ldap_certs_ready()
 
         match (ldap_relation_status, ldap_certificate_integration_status):
@@ -244,3 +262,24 @@ class LDAPManager(Object, StatusProvider):
             return BlockedStatus("Could not bind with ldap")
 
         return ActiveStatus()
+
+    def share_hash_with_mongos(self):
+        """If we are a config-server, we share a hash to confirm the integration."""
+        if not self.state.is_role(MongoDBRoles.CONFIG_SERVER):
+            return
+        if not (hashed_data := self.get_hash()):
+            return
+        self.dependent.cluster_manager.update_ldap_hash_to_mongos(hashed_data)  # type: ignore
+
+    def get_hash(self) -> str | None:
+        """Gets the hash in a consistent way."""
+        if not (chain := self.state.ldap.chain):
+            return None
+        if not (ldaps_urls := self.state.ldap.chain):
+            return None
+        data = sorted(chain) + sorted(ldaps_urls)
+        return hashlib.sha256(".".join(data).encode("ascii")).hexdigest()
+
+    def remove_hash_from_mongos(self):
+        """When one of the relation is broken, we clean the hash from the integration."""
+        self.dependent.cluster_manager.remove_ldap_hash()  # type: ignore

--- a/single_kernel_mongo/managers/ldap.py
+++ b/single_kernel_mongo/managers/ldap.py
@@ -205,9 +205,13 @@ class LDAPManager(Object, StatusProvider):
         bind_dn = self.state.ldap.bind_user
         bind_password = self.state.ldap.bind_password
         base_dn = self.state.ldap.base_dn
+        cert_chain = self.state.ldap.chain
 
         if not base_dn:
             return BlockedStatus("Missing base DN.")
+
+        if not cert_chain:
+            return BlockedStatus("Missing chain.")
 
         if not self.state.ldap.ldaps_urls:
             return BlockedStatus("Missing LDAPS URLs.")
@@ -217,7 +221,7 @@ class LDAPManager(Object, StatusProvider):
                 tls = LDAPTls(
                     validate=ssl.CERT_REQUIRED,
                     version=ssl.PROTOCOL_TLSv1_2,
-                    ca_certs_file=f"{self.state.paths.ldap_certificates_file}",
+                    ca_certs_data="\n".join(cert_chain),
                 )
                 server = LDAPServer(host=ldap_uri, use_ssl=True, tls=tls)
                 conn = LDAPConnection(server, user=bind_dn, password=bind_password)

--- a/single_kernel_mongo/managers/ldap.py
+++ b/single_kernel_mongo/managers/ldap.py
@@ -211,13 +211,22 @@ class LDAPManager(Object, StatusProvider):
         cert_chain = self.state.ldap.chain
 
         if not base_dn:
-            return BlockedStatus("Missing base DN.")
+            logger.info(
+                "The ldap data seems incomplete, it is missing the base DN, check that the integration was completed without error."
+            )
+            return BlockedStatus("Missing base DN for LDAP.")
 
         if not cert_chain:
-            return BlockedStatus("Missing chain.")
+            logger.info(
+                "The ldap data seems incomplete, it is missing the certificates chain, check that the integration was completed without error."
+            )
+            return BlockedStatus("Missing chain for LDAP.")
 
         if not self.state.ldap.ldaps_urls:
-            return BlockedStatus("Missing LDAPS URLs.")
+            logger.info(
+                "The ldap data seems incomplete, it is missing the LDAP URIs of the server, check that the integration was completed without error."
+            )
+            return BlockedStatus("Missing LDAPS URLs for LDAP.")
 
         try:
             for ldap_uri in self.state.ldap.ldaps_urls:

--- a/single_kernel_mongo/managers/ldap.py
+++ b/single_kernel_mongo/managers/ldap.py
@@ -128,13 +128,13 @@ class LDAPManager(Object, StatusProvider):
         self.assert_pass_hook_checks()
         self.state.ldap.set_certificates(certificate, ca, chain)
 
-        self.save_certificates()
+        self.save_certificates(chain)
 
         self.dependent.ldap_events.restart_if_ready_event.emit()
 
-    def save_certificates(self) -> None:
+    def save_certificates(self, chain: list[str] | None) -> None:
         """Saves the certificates in different files."""
-        if not (chain := self.state.ldap.chain):
+        if not chain:
             return
 
         full_chain = "\n".join(chain)
@@ -153,7 +153,10 @@ class LDAPManager(Object, StatusProvider):
     def certificate_removed(self):
         """Runs when the certificate is removed."""
         self.state.ldap.clean_certificates()
-        self.workload.delete(self.workload.paths.ldap_certificates_file)
+
+        # Conditional removal of the certificates
+        if self.workload.exists(self.workload.paths.ldap_certificates_file):
+            self.workload.delete(self.workload.paths.ldap_certificates_file)
 
         self.dependent.restart_charm_services()
 

--- a/single_kernel_mongo/managers/ldap.py
+++ b/single_kernel_mongo/managers/ldap.py
@@ -275,7 +275,7 @@ class LDAPManager(Object, StatusProvider):
         """Gets the hash in a consistent way."""
         if not (chain := self.state.ldap.chain):
             return None
-        if not (ldaps_urls := self.state.ldap.chain):
+        if not (ldaps_urls := self.state.ldap.ldaps_urls):
             return None
         data = sorted(chain) + sorted(ldaps_urls)
         return hashlib.sha256(".".join(data).encode("ascii")).hexdigest()

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -897,7 +897,7 @@ class MongoDBOperator(OperatorProtocol, Object):
 
         # Push TLS files if necessary
         self.tls_manager.push_tls_files_to_workload()
-        self.ldap_manager.save_certificates()
+        self.ldap_manager.save_certificates(self.state.ldap.chain)
 
         # Update licenses
         self.handle_licenses()

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -417,7 +417,8 @@ class MongoDBOperator(OperatorProtocol, Object):
                 self.state.app_peer_data.ldap_user_to_dn_mapping = (
                     self.config.ldap_user_to_dn_mapping
                 )
-            self.cluster_manager.update_ldap_user_to_dn_mapping()
+            if self.state.is_role(MongoDBRoles.CONFIG_SERVER):
+                self.cluster_manager.update_ldap_user_to_dn_mapping()
 
             if self.config.ldap_query_template:
                 self.state.app_peer_data.ldap_query_template = self.config.ldap_query_template

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -417,7 +417,7 @@ class MongoDBOperator(OperatorProtocol, Object):
                 self.state.app_peer_data.ldap_user_to_dn_mapping = (
                     self.config.ldap_user_to_dn_mapping
                 )
-            # TODO: Send this to mongos as well.
+            self.cluster_manager.update_ldap_user_to_dn_mapping()
 
             if self.config.ldap_query_template:
                 self.state.app_peer_data.ldap_query_template = self.config.ldap_query_template

--- a/single_kernel_mongo/managers/mongos_operator.py
+++ b/single_kernel_mongo/managers/mongos_operator.py
@@ -151,6 +151,7 @@ class MongosOperator(OperatorProtocol, Object):
 
     def _configure_workloads(self) -> None:
         self.tls_manager.push_tls_files_to_workload()
+        self.ldap_manager.save_certificates(self.state.ldap.chain)
         self.handle_licenses()
         self.set_permissions()
 

--- a/single_kernel_mongo/state/cluster_state.py
+++ b/single_kernel_mongo/state/cluster_state.py
@@ -24,6 +24,7 @@ class ClusterStateKeys(str, Enum):
     KEYFILE = "key-file"
     INT_CA_SECRET = "int-ca-secret"
     LDAP_USER_TO_DN_MAPPING = "ldap-user-to-dn-mapping"
+    LDAP_HASH = "ldap-hash"
 
 
 class ClusterState(AbstractRelationState[Data]):
@@ -77,3 +78,8 @@ class ClusterState(AbstractRelationState[Data]):
     def ldap_user_to_dn_mapping(self) -> str | None:
         """Returns the userToDNMapping config option shared by the config-server."""
         return self.relation_data.get(ClusterStateKeys.LDAP_USER_TO_DN_MAPPING.value, None)
+
+    @property
+    def ldap_hash(self) -> str | None:
+        """Returns the ldap hash shared by the config-server."""
+        return self.relation_data.get(ClusterStateKeys.LDAP_HASH.value, None)

--- a/single_kernel_mongo/state/cluster_state.py
+++ b/single_kernel_mongo/state/cluster_state.py
@@ -23,6 +23,7 @@ class ClusterStateKeys(str, Enum):
     CONFIG_SERVER_DB = "config-server-db"
     KEYFILE = "key-file"
     INT_CA_SECRET = "int-ca-secret"
+    LDAP_USER_TO_DN_MAPPING = "ldap-user-to-dn-mapping"
 
 
 class ClusterState(AbstractRelationState[Data]):
@@ -71,3 +72,8 @@ class ClusterState(AbstractRelationState[Data]):
         if not self.relation:
             return None
         return self.relation_data.get(ClusterStateKeys.INT_CA_SECRET.value, None)
+
+    @property
+    def ldap_user_to_dn_mapping(self) -> str | None:
+        """Returns the userToDNMapping config option shared by the config-server."""
+        return self.relation_data.get(ClusterStateKeys.LDAP_USER_TO_DN_MAPPING.value, None)

--- a/single_kernel_mongo/state/ldap_state.py
+++ b/single_kernel_mongo/state/ldap_state.py
@@ -77,6 +77,7 @@ class LdapState(AbstractRelationState[DataPeerData]):
         self.certificate = certificate
         self.ca = ca
         self.chain = chain
+        self.secrets.get(Scope.UNIT)
 
     def clean_certificates(self) -> None:
         """Removes the certificate secrets."""

--- a/single_kernel_mongo/status.py
+++ b/single_kernel_mongo/status.py
@@ -99,7 +99,10 @@ class StatusManager(Object):
                 ldap=self.operator.ldap_manager.get_status(),
             )
         # Mongos case
-        return Statuses(mongodb=self.operator.get_sanity_check_status() or ActiveStatus())
+        return Statuses(
+            mongodb=self.operator.get_sanity_check_status() or ActiveStatus(),
+            ldap=self.operator.ldap_manager.get_status(),
+        )
 
     def prioritize_statuses(self, statuses: Statuses) -> StatusBase:
         """Prioritizes the statuses."""

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -107,5 +107,6 @@ def harness() -> Harness[MongoTestCharm]:
 def mongos_harness() -> Harness[MongosTestCharm]:
     harness = Harness(MongosTestCharm, meta=MONGOS_METADATA, actions=MONGOS_ACTIONS)
     harness.add_relation("router-peers", "router-peers")
+    harness.add_relation("ldap-peers", "ldap-peers")
     harness.begin()
     return harness

--- a/tests/unit/mongodb_k8s_test_charm/metadata.yaml
+++ b/tests/unit/mongodb_k8s_test_charm/metadata.yaml
@@ -72,6 +72,14 @@ requires:
     interface: shards
     # shards can only relate to one config-server
     limit: 1
+  ldap:
+    interface: ldap
+    limit: 1
+    optional: true
+  ldap-certificate-transfer:
+    interface: certificate_transfer
+    limit: 1
+    optional: true
 
 resources:
   mongodb-image:

--- a/tests/unit/mongos_k8s_test_charm/charmcraft.yaml
+++ b/tests/unit/mongos_k8s_test_charm/charmcraft.yaml
@@ -13,20 +13,22 @@ bases:
 parts:
   charm:
     charm-strict-dependencies: true
-    override-pull: |
+    override-build: |
+      rustup default stable
       craftctl default
-      if [[ ! -f requirements.txt ]]
-      then
-          echo 'ERROR: Use "tox run -e build" instead of calling "charmcraft pack" directly' >&2
-          exit 1
-      fi
+    build-snaps:
+      - rustup
     build-packages:
       - git
+      - build-essential
       - libffi-dev
       - libssl-dev
       - pkg-config
       - rustc
       - cargo
+  version_data:
+    plugin: dump
+    source: .
     prime:
       - workload_version
       - charm_version

--- a/tests/unit/test_cluster_manager.py
+++ b/tests/unit/test_cluster_manager.py
@@ -1,5 +1,6 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
+import json
 from pathlib import Path
 
 import pytest
@@ -113,6 +114,47 @@ def test_share_secret_to_mongos(harness: Harness[MongoTestCharm], mocker):
 
     assert len(data.get("key-file", "")) == 1024
     assert data.get("config-server-db") == f"{harness.charm.app.name}/1.1.1.1:27017"
+
+
+@patch_network_get(private_address="1.1.1.1")
+def test_share_secret_to_mongos_also_shares_ldap_config(harness: Harness[MongoTestCharm], mocker):
+    manager = harness.charm.operator.cluster_manager
+
+    harness.set_leader(True)
+    harness.charm.operator.state.db_initialised = True
+    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.CONFIG_SERVER
+
+    mocked_reconcile = mocker.patch(
+        "single_kernel_mongo.managers.mongo.MongoManager.reconcile_mongo_users_and_dbs"
+    )
+    mocker.patch(
+        "single_kernel_mongo.managers.mongodb_operator.MongoDBOperator.restart_charm_services"
+    )
+
+    valid_mapping = [
+        {
+            "match": "([^@]+)@([^@\\.]+)\\.example\\.com",
+            "substitution": "CN={0},CN=Users,DC={1},DC=example,DC=com",
+        }
+    ]
+
+    harness.update_config(
+        {
+            "role": MongoDBRoles.CONFIG_SERVER.value,
+            "ldap-user-to-dn-mapping": json.dumps(valid_mapping),
+        }
+    )
+
+    rel_id = harness.add_relation(RelationNames.CLUSTER.value, "test-mongos")
+    harness.add_relation_unit(rel_id, "test-mongos/0")
+    harness.update_relation_data(rel_id, "test-mongos", {"database": "test_mongos"})
+
+    mocked_reconcile.assert_called()
+    data = manager.data_interface.as_dict(rel_id)
+
+    assert len(data.get("key-file", "")) == 1024
+    assert data.get("config-server-db") == f"{harness.charm.app.name}/1.1.1.1:27017"
+    assert data.get("ldap-user-to-dn-mapping") == json.dumps(valid_mapping)
 
 
 @patch_network_get(private_address="1.1.1.1")

--- a/tests/unit/test_ldap_manager.py
+++ b/tests/unit/test_ldap_manager.py
@@ -251,6 +251,7 @@ def test_on_certificate_removed_clean_certs(
     mock_restart = mocker.patch(
         "single_kernel_mongo.managers.mongodb_operator.MongoDBOperator.restart_charm_services"
     )
+    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.exists", return_value=True)
     mock_remove_ca_cert = mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.delete")
     ldap_cert_relation_id = harness.add_relation(
         ExternalRequirerRelations.LDAP_CERT.value, "glauth-k8s"

--- a/tests/unit/test_ldap_manager.py
+++ b/tests/unit/test_ldap_manager.py
@@ -2,12 +2,13 @@
 # See LICENSE file for licensing details.
 
 import json
+from pathlib import Path
 
 import pytest
 from ops.model import ActiveStatus, BlockedStatus, Relation, WaitingStatus
 from ops.testing import Harness
 
-from single_kernel_mongo.config.relations import ExternalRequirerRelations
+from single_kernel_mongo.config.relations import ExternalRequirerRelations, RelationNames
 from single_kernel_mongo.core.structured_config import MongoDBRoles
 from single_kernel_mongo.exceptions import (
     DeferrableFailedHookChecksError,
@@ -15,6 +16,7 @@ from single_kernel_mongo.exceptions import (
 )
 
 from .mongodb_test_charm.src.charm import MongoTestCharm
+from .mongos_test_charm.src.charm import MongosTestCharm
 
 
 def test_valid_ldap_integration(harness: Harness[MongoTestCharm]):
@@ -387,3 +389,61 @@ def test_ldaps_not_enabled(harness: Harness[MongoTestCharm], mocker, mock_fs_int
 
     assert harness.charm.unit.status == BlockedStatus("LDAPS not enabled on LDAP application.")
     mock_restart.assert_not_called()
+
+
+def test_ldaps_mongos_invalid_hash(
+    mongos_harness: Harness[MongosTestCharm], mocker, mock_fs_interactions
+):
+    mongos_harness.set_leader(True)
+    mongos_harness.charm.operator.state.db_initialised = True
+    rel_id_ldap = mongos_harness.add_relation(ExternalRequirerRelations.LDAP.value, "glauth-k8s")
+    mongos_harness.update_relation_data(
+        rel_id_ldap,
+        "glauth-k8s",
+        {
+            "base_dn": "dc=glauth,dc=com",
+            "bind_dn": "cn=user,ou=group,dc=glauth,dc=com",
+            "bind_password": "password",
+            "bind_password_id": "secret-id",
+            "auth_method": "simple",
+            "starttls": "true",
+            "ldaps_urls": '["ldaps://ldap.glauth.com"]',
+            "urls": '["ldap://ldap.glauth.com"]',
+        },
+    )
+    rel_id_ldap_cert = mongos_harness.add_relation(
+        ExternalRequirerRelations.LDAP_CERT.value, "glauth-k8s"
+    )
+    mongos_harness.add_relation_unit(rel_id_ldap_cert, "glauth-k8s/0")
+
+    mongos_harness.update_relation_data(
+        rel_id_ldap_cert,
+        "glauth-k8s/0",
+        {"ca": "deadbeef", "chain": '["feeddead"]', "certificate": "beefdead"},
+    )
+
+    assert mongos_harness.charm.unit.status == BlockedStatus(
+        "mongos and config-server not integrated with the same ldap server."
+    )
+
+    data = Path("tests/unit/data/mongos.conf").read_text().splitlines()
+
+    mocker.patch(
+        "single_kernel_mongo.core.vm_workload.VMWorkload.read",
+        return_value=data,
+    )
+
+    rel_id_cluster = mongos_harness.add_relation(RelationNames.CLUSTER.value, "test-mongodb")
+    mongos_harness.add_relation_unit(rel_id_cluster, "test-mongodb/0")
+
+    mongos_harness.update_relation_data(
+        rel_id_cluster,
+        "test-mongodb",
+        {
+            "key-file": "deadbeef",
+            "config-server-db": "test-mongodb/2.2.2.2:27017",
+            "ldap-hash": "deabeef",
+        },
+    )
+
+    assert mongos_harness.charm.operator.ldap_manager.get_status() == BlockedStatus()

--- a/tests/unit/test_ldap_manager.py
+++ b/tests/unit/test_ldap_manager.py
@@ -446,4 +446,21 @@ def test_ldaps_mongos_invalid_hash(
         },
     )
 
-    assert mongos_harness.charm.operator.ldap_manager.get_status() == BlockedStatus()
+    assert mongos_harness.charm.operator.ldap_manager.get_status() == BlockedStatus(
+        "mongos and config-server not integrated with the same ldap server."
+    )
+
+    mocker.patch(
+        "single_kernel_mongo.managers.ldap.LDAPManager.get_ldap_connection_status",
+        return_value=ActiveStatus(),
+    )
+
+    mongos_harness.update_relation_data(
+        rel_id_cluster,
+        "test-mongodb",
+        {
+            "ldap-hash": "ea94093f0d37df1ba61800afd667921396f1f6d7e9957832456058df2ad8602f",
+        },
+    )
+
+    assert mongos_harness.charm.operator.ldap_manager.get_status() == ActiveStatus()

--- a/tests/unit/test_ldap_manager.py
+++ b/tests/unit/test_ldap_manager.py
@@ -323,6 +323,11 @@ def test_ldap_full_integration_cycle(
     # All is good, we are green
     assert harness.charm.unit.status == ActiveStatus("")
 
+    assert (
+        harness.charm.operator.ldap_manager.get_hash()
+        == "ea94093f0d37df1ba61800afd667921396f1f6d7e9957832456058df2ad8602f"
+    )
+
     # Check the parameters
     ldap_parameters = harness.charm.operator.config_manager.ldap_parameters["security"]["ldap"]  # type: ignore
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷 Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update
- [ ] Tooling and CI changes
- [ ] Dependencies upgrade or change

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and scope of this PR (what)
  - the impacted components (where, often match conventional commit scope)
  - explanation/algorithm if require (how)
-->
Synchronization of MongoDB and Mongos for the config option.

## 📑 Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Either the associated JIRA reference or a paragraph. -->
Instead of requiring the operator to config the two services, the config-server shares the ldapUserToDNMapping with mongos through the cluster relation.

## 🧪 How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually tested + unit testing.

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](../blob/6/edge/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
