### PR TITLE
fix: Enable services and restart on upgrades.

### DIFF
--- a/single_kernel_mongo/core/machine_upgrades.py
+++ b/single_kernel_mongo/core/machine_upgrades.py
@@ -164,6 +164,9 @@ class MachineUpgrade(AbstractUpgrade):
         logger.debug(f"Upgrading {self.unit_name=}")
         self.unit_state = UnitState.UPGRADING
         dependent.workload.install()
+        dependent.start_charm_services()
+        if dependent.name == CharmKind.MONGOD:
+            dependent._restart_related_services()  # type: ignore[attr-defined]
         self.state.unit_upgrade_peer_data.snap_revision = SNAP.revision
         logger.debug(f"Saved {SNAP.revision} in unit databag after refresh")
 

--- a/single_kernel_mongo/core/vm_workload.py
+++ b/single_kernel_mongo/core/vm_workload.py
@@ -48,7 +48,7 @@ class VMWorkload(WorkloadBase):
     @override
     def start(self) -> None:
         try:
-            self.mongod_snap.start(services=[self.service])
+            self.mongod_snap.start(services=[self.service], enable=True)
         except snap.SnapError as e:
             logger.exception(str(e))
             raise WorkloadServiceError(str(e)) from e
@@ -70,7 +70,7 @@ class VMWorkload(WorkloadBase):
     @override
     def stop(self) -> None:
         try:
-            self.mongod_snap.stop(services=[self.service])
+            self.mongod_snap.stop(services=[self.service], disable=True)
         except snap.SnapError as e:
             logger.exception(str(e))
             raise WorkloadServiceError(str(e)) from e


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷 Type of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update
- [ ] Tooling and CI changes
- [ ] Dependencies upgrade or change

## 📝 Description

With snapd 2.67.1, the behavior of refreshing a snap has changed when it comes to services.

The services are not restarted if they were disabled and started, they will be left disabled and stopped.

In order to fix that, two steps:
 * On start of services, enable them
 * On stop of services, disable them (so that they don't restart unexpectedly upon machine restart)
 * During refreshes, after installing the new snap, start the services (so that the upgrade flow doesn't break)

## 📑 Motivation and Context

This is a bug fix uncovered while working on #34 .

## 🧪 How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested manually on upgrades / rollbacks.

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](../blob/6/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
