### PR TITLE
patch(DPE-7471): Improve method namings in managers

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -1,0 +1,9 @@
+name: cla-check
+on: [pull_request]
+
+jobs:
+  cla-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if CLA signed
+        uses: canonical/has-signed-canonical-cla@v2

--- a/single_kernel_mongo/core/abstract_upgrades.py
+++ b/single_kernel_mongo/core/abstract_upgrades.py
@@ -354,7 +354,7 @@ class GenericMongoDBUpgradeManager(ManagerStatusProtocol, Generic[T], Object, AB
             case _:
                 raise ValueError(f"Invalid scope {scope}")
 
-    def on_upgrade_peer_relation_created(self) -> None:
+    def store_initial_revisions(self) -> None:
         """Handle peer relation created event."""
         assert self._upgrade
         if self.substrate == Substrates.VM:

--- a/single_kernel_mongo/core/operator.py
+++ b/single_kernel_mongo/core/operator.py
@@ -99,61 +99,61 @@ class OperatorProtocol(ABC, Object, ManagerStatusProtocol):
         ...
 
     @abstractmethod
-    def on_install(self) -> None:
+    def install_workloads(self) -> None:
         """Handles the install event."""
         ...
 
     @abstractmethod
-    def on_start(self) -> None:
+    def prepare_for_startup(self) -> None:
         """Handles the start event."""
         ...
 
     @abstractmethod
-    def on_secret_changed(self, secret_label: str, secret_id: str) -> None:
+    def update_secrets_and_restart(self, secret_label: str, secret_id: str) -> None:
         """Handles the secret changed events."""
 
     @abstractmethod
-    def on_config_changed(self) -> None:
+    def update_config_and_restart(self) -> None:
         """Handles the config changed events."""
         ...
 
     @abstractmethod
-    def on_storage_attached(self) -> None:
+    def prepare_storage(self) -> None:
         """Handles the storage attached events."""
         ...
 
     @abstractmethod
-    def on_storage_detaching(self) -> None:
+    def prepare_storage_for_shutdown(self) -> None:
         """Handles the storage attached events."""
         ...
 
     @abstractmethod
-    def on_leader_elected(self) -> None:
+    def new_leader(self) -> None:
         """Handles the leader elected events."""
         ...
 
     @abstractmethod
-    def on_update_status(self) -> None:
+    def update_status(self) -> None:
         """Handle the status update events."""
         ...
 
     @abstractmethod
-    def on_relation_joined(self) -> None:
+    def new_peer(self) -> None:
         """Handles the relation changed events."""
         ...
 
     @abstractmethod
-    def on_relation_changed(self) -> None:
+    def peer_changed(self) -> None:
         """Handles the relation changed events."""
         ...
 
     @abstractmethod
-    def on_relation_departed(self, departing_unit: Unit | None) -> None:
+    def peer_leaving(self, departing_unit: Unit | None) -> None:
         """Handles the relation departed events."""
         ...
 
     @abstractmethod
-    def on_stop(self) -> None:
+    def prepare_for_shutdown(self) -> None:
         """Handles the stop event."""
         ...
 

--- a/single_kernel_mongo/events/backups.py
+++ b/single_kernel_mongo/events/backups.py
@@ -174,7 +174,7 @@ class BackupEventsHandler(Object):
 
     def _on_s3_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Proceed on s3 relation broken."""
-        self.manager.on_relation_broken(event.relation)
+        self.manager.cleanup_certs_and_restart(event.relation)
 
     def _on_create_backup_action(self, event: ActionEvent) -> None:
         action = "backup"

--- a/single_kernel_mongo/events/lifecycle.py
+++ b/single_kernel_mongo/events/lifecycle.py
@@ -110,7 +110,7 @@ class LifecycleEventsHandler(Object):
     def on_start(self, event: StartEvent):
         """Start event."""
         try:
-            self.dependent.on_start()
+            self.dependent.prepare_for_startup()
         except Exception as e:
             logger.error(f"Deferring because of {e.__class__.__name__} {e}")
             self.dependent.state.statuses.add(
@@ -123,12 +123,12 @@ class LifecycleEventsHandler(Object):
 
     def on_stop(self, event: StopEvent):
         """Stop event."""
-        self.dependent.on_stop()
+        self.dependent.prepare_for_shutdown()
 
     def on_install(self, event: InstallEvent):
         """Install event."""
         try:
-            self.dependent.on_install()
+            self.dependent.install_workloads()
         except (ContainerNotReadyError, WorkloadServiceError):
             logger.info("Not ready to start.")
             event.defer()
@@ -136,12 +136,12 @@ class LifecycleEventsHandler(Object):
 
     def on_leader_elected(self, event: LeaderElectedEvent):
         """Leader elected event."""
-        self.dependent.on_leader_elected()
+        self.dependent.new_leader()
 
     def on_config_changed(self, event: ConfigChangedEvent):
         """Config Changed Event."""
         try:
-            self.dependent.on_config_changed()
+            self.dependent.update_config_and_restart()
         except (UpgradeInProgressError, WaitingForLeaderError):
             event.defer()
         except InvalidLdapUserToDnMappingError:
@@ -159,11 +159,11 @@ class LifecycleEventsHandler(Object):
 
     def on_update_status(self, event: UpdateStatusEvent):
         """Update Status Event."""
-        self.dependent.on_update_status()
+        self.dependent.update_status()
 
     def on_secret_changed(self, event: SecretChangedEvent):
         """Secret changed event."""
-        self.dependent.on_secret_changed(
+        self.dependent.update_secrets_and_restart(
             secret_label=event.secret.label or "",
             secret_id=event.secret.id or "",
         )
@@ -171,7 +171,7 @@ class LifecycleEventsHandler(Object):
     def on_relation_joined(self, event: RelationJoinedEvent):
         """Relation joined event."""
         try:
-            self.dependent.on_relation_joined()
+            self.dependent.new_peer()
         except UpgradeInProgressError:
             event.defer()
             return
@@ -182,7 +182,7 @@ class LifecycleEventsHandler(Object):
     def on_relation_changed(self, event: RelationChangedEvent):
         """Relation changed event."""
         try:
-            self.dependent.on_relation_changed()
+            self.dependent.peer_changed()
         except UpgradeInProgressError:
             event.defer()
             return
@@ -193,18 +193,18 @@ class LifecycleEventsHandler(Object):
     def on_relation_departed(self, event: RelationDepartedEvent):
         """Relation departed event."""
         try:
-            self.dependent.on_relation_departed(departing_unit=event.departing_unit)
+            self.dependent.peer_leaving(departing_unit=event.departing_unit)
         except (NotReadyError, PyMongoError):
             event.defer()
             return
 
     def on_storage_attached(self, event: StorageAttachedEvent):
         """Storage Attached Event."""
-        self.dependent.on_storage_attached()
+        self.dependent.prepare_storage()
 
     def on_storage_detaching(self, event: StorageDetachingEvent):
         """Storage Detaching Event."""
-        self.dependent.on_storage_detaching()
+        self.dependent.prepare_storage_for_shutdown()
 
     def on_remove(self, _):
         """For MongoD VM, remove sysctl config."""

--- a/single_kernel_mongo/events/password_actions.py
+++ b/single_kernel_mongo/events/password_actions.py
@@ -72,7 +72,7 @@ class PasswordActionEvents(Object):
             )
             return
         try:
-            passwd, secret_id = self.dependent.on_set_password_action(username, password)
+            passwd, secret_id = self.dependent.set_password(username, password)
         except (NonDeferrableFailedHookChecksError, SetPasswordError) as e:
             fail_action_with_error_log(logger, event, action, str(e))
             return
@@ -95,5 +95,5 @@ class PasswordActionEvents(Object):
 
         if not username:
             return
-        password = self.dependent.on_get_password_action(username)
+        password = self.dependent.get_password(username)
         event.set_results({PasswordActionParameter.PASSWORD: password})

--- a/single_kernel_mongo/events/upgrades.py
+++ b/single_kernel_mongo/events/upgrades.py
@@ -80,7 +80,7 @@ class UpgradeEventHandler(Object):
 
     def _on_pre_upgrade_check_action(self, event: ActionEvent):
         try:
-            self.manager.on_pre_upgrade_check_action()
+            self.manager.run_pre_refresh_checks()
             event.set_results({"result": "Charm is ready for refresh."})
         except ActionFailedError as e:
             logger.debug(f"Pre-refresh check failed: {e}")
@@ -90,7 +90,7 @@ class UpgradeEventHandler(Object):
         # We have to catch a possible ModelError here.
         # TODO: remove try/catch when https://bugs.launchpad.net/juju/+bug/2093129 is fixed.
         try:
-            self.manager.on_upgrade_peer_relation_created()
+            self.manager.store_initial_revisions()
         except ModelError as err:
             logger.info(f"Deferring because of model error: {err}")
             event.defer()
@@ -100,7 +100,7 @@ class UpgradeEventHandler(Object):
 
     def _on_upgrade_charm(self, event: UpgradeCharmEvent) -> None:
         try:
-            self.manager.on_upgrade_charm()
+            self.manager.upgrade_charm()
         except DeferrableError as err:
             logger.info(f"Deferring upgrade because of {err}")
             event.defer()
@@ -108,7 +108,7 @@ class UpgradeEventHandler(Object):
     def _on_resume_upgrade_action(self, event: ActionEvent) -> None:
         try:
             force: bool = event.params.get("force", False)
-            message = self.manager.on_resume_upgrade_action(force=force)
+            message = self.manager.resume_upgrade(force=force)
             event.set_results({"result": message})
         except ActionFailedError as e:
             logger.debug(f"Resume refresh failed: {e}")
@@ -116,7 +116,7 @@ class UpgradeEventHandler(Object):
 
     def _on_force_upgrade_action(self, event: ActionEvent) -> None:
         try:
-            message = self.manager.on_force_upgrade_action(event)
+            message = self.manager.force_upgrade(event)
             event.set_results({"result": message})
         except ActionFailedError as e:
             logger.debug(f"Resume refresh failed: {e}")

--- a/single_kernel_mongo/managers/backups.py
+++ b/single_kernel_mongo/managers/backups.py
@@ -156,7 +156,7 @@ class BackupManager(Object, BackupConfigManager, ManagerStatusProtocol):
         """
         return (self.state.s3_relation is None) or (not self.state.is_role(MongoDBRoles.SHARD))
 
-    def on_relation_broken(self, relation: Relation) -> None:
+    def cleanup_certs_and_restart(self, relation: Relation) -> None:
         """On relation broken event, we need to remove the certificate from the trust store."""
         if self.state.is_scaling_down(relation.id):
             logger.info("Relation broken event occurring due to scale down.")

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -284,7 +284,7 @@ class MongoDBOperator(OperatorProtocol, Object):
     # BEGIN: Handlers.
 
     @override
-    def on_install(self) -> None:
+    def install_workloads(self) -> None:
         """Handler on install."""
         if not self.workload.workload_present:
             raise ContainerNotReadyError
@@ -298,7 +298,7 @@ class MongoDBOperator(OperatorProtocol, Object):
         self.workload.write(self.workload.paths.config_file, "")
 
     @override
-    def on_start(self) -> None:
+    def prepare_for_startup(self) -> None:
         """Handler on start."""
         if not self.workload.workload_present:
             logger.debug("mongod installation is not ready yet.")
@@ -363,7 +363,7 @@ class MongoDBOperator(OperatorProtocol, Object):
             self.upgrade_manager._reconcile_upgrade()
 
     @override
-    def on_stop(self) -> None:  # pragma: nocover
+    def prepare_for_shutdown(self) -> None:  # pragma: nocover
         """Handler for the stop event.
 
         K8S Only, VM has nothing to do on this step.
@@ -407,7 +407,7 @@ class MongoDBOperator(OperatorProtocol, Object):
             return
 
     @override
-    def on_config_changed(self) -> None:
+    def update_config_and_restart(self) -> None:
         """Listen to changes in application configuration.
 
         To prevent a user from migrating a cluster, and causing the component to become
@@ -464,7 +464,7 @@ class MongoDBOperator(OperatorProtocol, Object):
         self.ldap_events.restart_if_ready_event.emit()
 
     @override
-    def on_leader_elected(self) -> None:
+    def new_leader(self) -> None:
         """Handles the leader elected event.
 
         Generates the keyfile and users credentials.
@@ -478,7 +478,7 @@ class MongoDBOperator(OperatorProtocol, Object):
                 self.state.set_user_password(user, self.workload.generate_password())
 
     @override
-    def on_relation_joined(self) -> None:
+    def new_peer(self) -> None:
         """Handle relation joined events.
 
         In this event, we first check for status checks (are we leader, is the
@@ -493,10 +493,10 @@ class MongoDBOperator(OperatorProtocol, Object):
             )
             raise UpgradeInProgressError
 
-        self.on_relation_changed()
+        self.peer_changed()
         self.update_related_hosts()
 
-    def on_relation_changed(self) -> None:
+    def peer_changed(self) -> None:
         """Handle relation changed events.
 
         Adds the unit as a replica to the MongoDB replica set.
@@ -534,7 +534,7 @@ class MongoDBOperator(OperatorProtocol, Object):
             raise
 
     @override
-    def on_secret_changed(self, secret_label: str, secret_id: str) -> None:
+    def update_secrets_and_restart(self, secret_label: str, secret_id: str) -> None:
         """Handles secrets changes event.
 
         When user run set-password action, juju leader changes the password inside the database
@@ -561,7 +561,7 @@ class MongoDBOperator(OperatorProtocol, Object):
         # Always process the statuses.
 
     @override
-    def on_relation_departed(self, departing_unit: Unit | None) -> None:
+    def peer_leaving(self, departing_unit: Unit | None) -> None:
         """Handles the relation departed events."""
         if not self.charm.unit.is_leader() or departing_unit == self.charm.unit:
             return
@@ -575,7 +575,7 @@ class MongoDBOperator(OperatorProtocol, Object):
         self.update_hosts()
 
     @override
-    def on_storage_attached(self) -> None:  # pragma: nocover
+    def prepare_storage(self) -> None:  # pragma: nocover
         """Handler for `storage_attached` event.
 
         This should handle fixing the permissions for the data dir.
@@ -594,7 +594,7 @@ class MongoDBOperator(OperatorProtocol, Object):
         )
 
     @override
-    def on_storage_detaching(self) -> None:
+    def prepare_storage_for_shutdown(self) -> None:
         """Before storage detaches, allow removing unit to remove itself from the set.
 
         If the removing unit is primary also allow it to step down and elect another unit as
@@ -653,7 +653,7 @@ class MongoDBOperator(OperatorProtocol, Object):
             )
 
     @override
-    def on_update_status(self) -> None:
+    def update_status(self) -> None:
         """Status update Handler."""
         # TODO update the usage of this once the spec is approved and we have a consistent way of
         # handling statuses
@@ -687,7 +687,7 @@ class MongoDBOperator(OperatorProtocol, Object):
             except NotDrainedError:
                 logger.warning("Still draining shard.")
 
-    def on_set_password_action(self, username: str, password: str | None = None) -> tuple[str, str]:
+    def set_password(self, username: str, password: str | None = None) -> tuple[str, str]:
         """Handler for the set password action."""
         self.assert_pass_password_checks()
 
@@ -712,10 +712,6 @@ class MongoDBOperator(OperatorProtocol, Object):
             )
 
         return new_password, secret_id
-
-    def on_get_password_action(self, username: str) -> str:
-        """Handler for the get password action."""
-        return self.get_password(username)
 
     # END: Handlers.
 
@@ -763,7 +759,7 @@ class MongoDBOperator(OperatorProtocol, Object):
         self.update_hosts()
         # Add in any new IPs to the replica set. Relation handlers require a reference to
         # a unit.
-        self.on_relation_changed()
+        self.peer_changed()
 
         # make sure all nodes in the replica set have the same priority for re-election. This is
         # necessary in the case that pre-upgrade hook fails to reset the priority of election for

--- a/single_kernel_mongo/managers/mongos_operator.py
+++ b/single_kernel_mongo/managers/mongos_operator.py
@@ -146,7 +146,7 @@ class MongosOperator(OperatorProtocol, Object):
         return self.charm.parsed_config
 
     @override
-    def on_install(self) -> None:
+    def install_workloads(self) -> None:
         """Handles the install event.
 
         We ensure the workload (container or snap) is present before setting
@@ -165,7 +165,7 @@ class MongosOperator(OperatorProtocol, Object):
         self.mongos_config_manager.set_environment()
 
     @override
-    def on_start(self) -> None:
+    def prepare_for_startup(self) -> None:
         """For this case, we don't start any service.
 
         Mongos charms need to be integrated to its config server before
@@ -192,12 +192,12 @@ class MongosOperator(OperatorProtocol, Object):
             )
 
     @override
-    def on_secret_changed(self, secret_label: str, secret_id: str) -> None:
+    def update_secrets_and_restart(self, secret_label: str, secret_id: str) -> None:
         """Nothing happens in this handler for mongos operators."""
         pass
 
     @override
-    def on_config_changed(self) -> None:
+    def update_config_and_restart(self) -> None:
         """Handle configurations for expose-external.
 
         It is necessary to check that the option is valid, and if it has
@@ -231,17 +231,17 @@ class MongosOperator(OperatorProtocol, Object):
             self.share_connection_info()
 
     @override
-    def on_storage_attached(self) -> None:
+    def prepare_storage(self) -> None:
         """Nothing happens in this handler for mongos operators."""
         pass
 
     @override
-    def on_storage_detaching(self) -> None:
+    def prepare_storage_for_shutdown(self) -> None:
         """Nothing happens in this handler for mongos operators."""
         pass
 
     @override
-    def on_leader_elected(self) -> None:
+    def new_leader(self) -> None:
         """Just forward the call, this is for simplicity and typing.
 
         Leader elected events indicate that a unit may have been removed or
@@ -251,7 +251,7 @@ class MongosOperator(OperatorProtocol, Object):
         self.share_connection_info()
 
     @override
-    def on_update_status(self) -> None:
+    def update_status(self) -> None:
         """Many things happening here.
 
         First, as always we ensure the expose external value is valid.
@@ -274,22 +274,22 @@ class MongosOperator(OperatorProtocol, Object):
                 self.upgrade_manager._reconcile_upgrade()
 
     @override
-    def on_relation_joined(self) -> None:
+    def new_peer(self) -> None:
         """Any relation event will just share the connection with the client."""
         self.share_connection_info()
 
     @override
-    def on_relation_changed(self) -> None:
+    def peer_changed(self) -> None:
         """Any relation event will just share the connection with the client."""
         self.share_connection_info()
 
     @override
-    def on_relation_departed(self, departing_unit: Unit | None) -> None:
+    def peer_leaving(self, departing_unit: Unit | None) -> None:
         """Any relation event will just share the connection with the client."""
         self.share_connection_info()
 
     @override
-    def on_stop(self) -> None:
+    def prepare_for_shutdown(self) -> None:
         if self.substrate == Substrates.VM:
             return
 

--- a/single_kernel_mongo/managers/upgrade.py
+++ b/single_kernel_mongo/managers/upgrade.py
@@ -43,7 +43,7 @@ ROLLBACK_INSTRUCTIONS = "To rollback, `juju refresh` to the previous revision"
 class MongoUpgradeManager(Generic[T], GenericMongoDBUpgradeManager[T]):
     """Upgrade manager for Mongo upgrades."""
 
-    def on_upgrade_charm(self):
+    def upgrade_charm(self):
         """Upgrade event handler.
 
         On K8S, during an upgrade event, it will set the version in all relations,
@@ -54,11 +54,11 @@ class MongoUpgradeManager(Generic[T], GenericMongoDBUpgradeManager[T]):
         after setting the version across all relations.
         """
         if self.dependent.substrate == Substrates.VM:
-            self._on_vm_upgrade()
+            self._vm_upgrade()
         else:
-            self._on_kubernetes_upgrade()
+            self._kubernetes_upgrade()
 
-    def _on_kubernetes_upgrade(self) -> None:
+    def _kubernetes_upgrade(self) -> None:
         assert self._upgrade
         if self.charm.unit.is_leader() and self.dependent.name == CharmKind.MONGOD:
             self.dependent.cross_app_version_checker.set_version_across_all_relations()  # type: ignore
@@ -92,7 +92,7 @@ class MongoUpgradeManager(Generic[T], GenericMongoDBUpgradeManager[T]):
             # Post upgrade event verifies the success of the upgrade.
             self.dependent.upgrade_events.post_app_upgrade_event.emit()
 
-    def _on_vm_upgrade(self):
+    def _vm_upgrade(self):
         if not self.state.upgrade_in_progress and self.dependent.name == CharmKind.MONGOD:
             self.state.unit_upgrade_peer_data.current_revision = (
                 self.dependent.cross_app_version_checker.version  # type: ignore
@@ -112,7 +112,7 @@ class MongoUpgradeManager(Generic[T], GenericMongoDBUpgradeManager[T]):
             # All units call it on mongos
             self._reconcile_upgrade()
 
-    def on_pre_upgrade_check_action(self) -> None:
+    def run_pre_refresh_checks(self) -> None:
         """Pre upgrade checks."""
         if not self.charm.unit.is_leader():
             message = f"Must run action on leader unit. (e.g. `juju run {self.charm.app.name}/leader {UpgradeActions.PRECHECK_ACTION_NAME.value}`)"
@@ -131,7 +131,7 @@ class MongoUpgradeManager(Generic[T], GenericMongoDBUpgradeManager[T]):
             )
             raise ActionFailedError(message)
 
-    def on_resume_upgrade_action(self, force: bool = False) -> str | None:
+    def resume_upgrade(self, force: bool = False) -> str | None:
         """Resume upgrade action handler."""
         if not self.charm.unit.is_leader():
             message = f"Must run action on leader unit. (e.g. `juju run {self.charm.app.name}/leader {UpgradeActions.RESUME_ACTION_NAME.value}`)"
@@ -141,7 +141,7 @@ class MongoUpgradeManager(Generic[T], GenericMongoDBUpgradeManager[T]):
             raise ActionFailedError(message)
         return self._upgrade.reconcile_partition(from_event=True, force=force)
 
-    def on_force_upgrade_action(self: MongoUpgradeManager[T], event: ActionEvent) -> str:
+    def force_upgrade(self: MongoUpgradeManager[T], event: ActionEvent) -> str:
         """Force upgrade action handler."""
         if not self._upgrade or not self.state.upgrade_in_progress:
             message = "No refresh in progress"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -296,7 +296,7 @@ def test_on_secret_changed(harness: Harness[MongoTestCharm], mocker, mock_fs_int
     content["monitor-password"] = password
     secret.set_content(content)
 
-    harness.charm.operator.on_secret_changed(secret_label, secret.get_info().id)
+    harness.charm.operator.update_secrets_and_restart(secret_label, secret.get_info().id)
 
     mocked.assert_called()
     assert (
@@ -308,7 +308,7 @@ def test_on_secret_changed_unknown(harness: Harness[MongoTestCharm], mocker):
     harness.set_leader(True)
     mock_get = mocker.patch("single_kernel_mongo.core.secrets.SecretCache.get")
 
-    harness.charm.operator.on_secret_changed("unknown", "kdfjqlmdfjldq")
+    harness.charm.operator.update_secrets_and_restart("unknown", "kdfjqlmdfjldq")
     mock_get.assert_not_called()
 
 
@@ -401,9 +401,9 @@ def test_pbm_connect_active_other_password(harness: Harness[MongoTestCharm], moc
 def test_relation_joined_non_leader_does_nothing(harness: Harness[MongoTestCharm], mocker):
     rel = harness.charm.operator.state.peer_relation
     mock_on_relation_changed = mocker.patch(
-        "single_kernel_mongo.managers.mongodb_operator.MongoDBOperator.on_relation_changed"
+        "single_kernel_mongo.managers.mongodb_operator.MongoDBOperator.peer_changed"
     )
-    spied = mocker.spy(harness.charm.operator, "on_relation_joined")
+    spied = mocker.spy(harness.charm.operator, "new_peer")
 
     harness.set_leader(False)
     harness.add_relation_unit(rel.id, "mongodb/1")
@@ -415,13 +415,13 @@ def test_relation_joined_non_leader_does_nothing(harness: Harness[MongoTestCharm
 def test_relation_joined_upgrade_in_progress_defers(harness: Harness[MongoTestCharm], mocker):
     rel = harness.charm.operator.state.peer_relation
     mock_on_relation_changed = mocker.patch(
-        "single_kernel_mongo.managers.mongodb_operator.MongoDBOperator.on_relation_changed"
+        "single_kernel_mongo.managers.mongodb_operator.MongoDBOperator.peer_changed"
     )
     mocker.patch(
         "single_kernel_mongo.state.charm_state.CharmState.upgrade_in_progress",
         return_value=True,
     )
-    spied = mocker.spy(harness.charm.operator, "on_relation_joined")
+    spied = mocker.spy(harness.charm.operator, "new_peer")
     harness.set_leader(True)
     harness.add_relation_unit(rel.id, "mongodb/1")
 
@@ -466,7 +466,7 @@ def test_on_relation_departed_not_leader(
 ):
     harness.set_leader(True)
     harness.charm.operator.state.db_initialised = True
-    spied = mocker.spy(harness.charm.operator, "on_relation_departed")
+    spied = mocker.spy(harness.charm.operator, "peer_leaving")
     mocker.patch(
         "single_kernel_mongo.utils.mongo_connection.MongoConnection.is_ready",
         new_callable=mocker.PropertyMock,
@@ -491,10 +491,12 @@ def test_on_relation_departed_not_leader(
     update_host_mock.assert_not_called()
 
 
-def test_on_relation_departed_eader(harness: Harness[MongoTestCharm], mocker, mock_fs_interactions):
+def test_on_relation_departed_leader(
+    harness: Harness[MongoTestCharm], mocker, mock_fs_interactions
+):
     harness.set_leader(True)
     harness.charm.operator.state.db_initialised = True
-    spied = mocker.spy(harness.charm.operator, "on_relation_departed")
+    spied = mocker.spy(harness.charm.operator, "peer_leaving")
     mocker.patch(
         "single_kernel_mongo.utils.mongo_connection.MongoConnection.is_ready",
         new_callable=mocker.PropertyMock,

--- a/tests/unit/test_charm_state.py
+++ b/tests/unit/test_charm_state.py
@@ -37,7 +37,7 @@ def test_users_secrets(harness: Harness[MongoTestCharm]):
     harness.add_relation_unit(rel.id, "mongodb/1")  # type: ignore
 
     harness.set_leader(True)
-    harness.charm.operator.on_leader_elected()
+    harness.charm.operator.new_leader()
 
     state = harness.charm.operator.state
     assert state.operator_config.password == state.secrets.get_for_key(


### PR DESCRIPTION
Some managers have names very close to ops.
They are renamed here to be closer to the business logic.

<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷 Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update
- [ ] Tooling and CI changes
- [ ] Dependencies upgrade or change

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and scope of this PR (what)
  - the impacted components (where, often match conventional commit scope)
  - explanation/algorithm if require (how)
-->
Improves the naming of manager methods to be closer to the business logic problem they are addressing.

## 📑 Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Either the associated JIRA reference or a paragraph. -->
Fixes https://warthogs.atlassian.net/browse/DPE-7471

## 🧪 How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This is purely renaming methods but it has been tested with the unit tests and will be tested on the 4 charms with integration tests.

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](../blob/6/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
