### PR TITLE
patch(DPE-7742): Refine statuses on start

### DIFF
--- a/single_kernel_mongo/config/statuses.py
+++ b/single_kernel_mongo/config/statuses.py
@@ -82,6 +82,7 @@ class CharmStatuses(Enum):
 
     ACTIVE_IDLE = StatusObject(status="active", message="")
     FAILED_SERVICES_START = StatusObject(status="blocked", message="Failed to start services.")
+    WAITING_TO_START = StatusObject(status="waiting", message="Starting services.")
     MONGODB_NOT_INSTALLED = StatusObject(status="blocked", message="MongoDB not installed.")
     MONGOS_NOT_STARTED = StatusObject(status="waiting", message="Waiting to start mongos...")
 

--- a/single_kernel_mongo/events/lifecycle.py
+++ b/single_kernel_mongo/events/lifecycle.py
@@ -42,7 +42,11 @@ from pymongo.errors import PyMongoError
 
 from single_kernel_mongo.config.literals import CharmKind, Substrates
 from single_kernel_mongo.config.relations import PeerRelationNames
-from single_kernel_mongo.config.statuses import CharmStatuses, LdapStatuses
+from single_kernel_mongo.config.statuses import (
+    CharmStatuses,
+    LdapStatuses,
+    MongoDBStatuses,
+)
 from single_kernel_mongo.core.operator import OperatorProtocol
 from single_kernel_mongo.exceptions import (
     ContainerNotReadyError,
@@ -50,6 +54,7 @@ from single_kernel_mongo.exceptions import (
     InvalidLdapUserToDnMappingError,
     UpgradeInProgressError,
     WaitingForLeaderError,
+    WorkloadNotReadyError,
     WorkloadServiceError,
 )
 from single_kernel_mongo.utils.mongo_connection import NotReadyError
@@ -113,6 +118,15 @@ class LifecycleEventsHandler(Object):
             self.dependent.prepare_for_startup()
         except (ContainerNotReadyError, WorkloadServiceError):
             logger.info("Not ready to start.")
+            event.defer()
+            return
+        except WorkloadNotReadyError:
+            logger.info("Still starting service.")
+            self.dependent.state.statuses.add(
+                MongoDBStatuses.WAITING_FOR_MONGODB_START.value,
+                scope="unit",
+                component=self.dependent.name,
+            )
             event.defer()
             return
         except Exception as e:

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -331,11 +331,6 @@ class MongoDBOperator(OperatorProtocol, Object):
         #        raise WorkloadNotReadyError
 
         if not self.mongo_manager.mongod_ready():
-            self.state.statuses.add(
-                MongoDBStatuses.WAITING_FOR_MONGODB_START.value,
-                scope="unit",
-                component=self.name,
-            )
             raise WorkloadNotReadyError
 
         self.state.statuses.set(CharmStatuses.ACTIVE_IDLE.value, scope="unit", component=self.name)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -7,7 +7,7 @@ import pytest
 from ops.testing import ActionFailed, Harness
 
 from single_kernel_mongo.config.literals import Scope
-from single_kernel_mongo.config.statuses import LdapStatuses, MongodStatuses
+from single_kernel_mongo.config.statuses import LdapStatuses, MongoDBStatuses, MongodStatuses
 from single_kernel_mongo.core.structured_config import MongoDBRoles
 from single_kernel_mongo.exceptions import (
     ShardingMigrationError,
@@ -27,6 +27,22 @@ def test_install_blocks_snap_install_failure(harness, mocker):
     )
     with pytest.raises(WorkloadNotReadyError):
         harness.charm.on.install.emit()
+
+
+def test_start_not_ready(harness, mocker, mock_fs_interactions):
+    mocker.patch("single_kernel_mongo.managers.mongo.MongoManager.mongod_ready", return_value=False)
+    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.start", return_value=True)
+    patched_mongo_initialise = mocker.patch(
+        "single_kernel_mongo.managers.mongo.MongoManager.initialise_replica_set"
+    )
+
+    harness.set_leader(True)
+    harness.charm.on.start.emit()
+    patched_mongo_initialise.assert_not_called()
+    statuses = harness.charm.operator.state.statuses.get(
+        scope=Scope.UNIT, component=harness.charm.operator.name
+    )
+    assert statuses[0] == MongoDBStatuses.WAITING_FOR_MONGODB_START.value
 
 
 def test_snap_start_failure_doesnt_init(harness, mocker, mock_fs_interactions):


### PR DESCRIPTION
Closes: https://github.com/canonical/mongodb-k8s-operator/issues/409

<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷 Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update
- [ ] Tooling and CI changes
- [ ] Dependencies upgrade or change

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and scope of this PR (what)
  - the impacted components (where, often match conventional commit scope)
  - explanation/algorithm if require (how)
-->
Refines the statuses on start:
 * If we started the service but it's not ready yet, keep the starting status
 * If the container is not ready, defer and don't add statuses
 * If the service failed to start, set a blocked status.

## 📑 Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Either the associated JIRA reference or a paragraph. -->
Bug fix raised in [MongoDB K8S](https://github.com/canonical/mongodb-k8s-operator/issues/409)

## 🧪 How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Unit tests to add

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](../blob/6/edge/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
