### PR TITLE
patch: Check that REQUIRES_TLS are cleared upon TLS integration

### DIFF
--- a/single_kernel_mongo/events/tls.py
+++ b/single_kernel_mongo/events/tls.py
@@ -13,7 +13,7 @@ from ops.charm import ActionEvent, RelationBrokenEvent, RelationJoinedEvent
 from ops.framework import Object
 
 from single_kernel_mongo.config.relations import ExternalRequirerRelations
-from single_kernel_mongo.config.statuses import TLSStatuses
+from single_kernel_mongo.config.statuses import MongosStatuses, TLSStatuses
 from single_kernel_mongo.core.operator import OperatorProtocol
 from single_kernel_mongo.core.structured_config import MongoDBRoles
 from single_kernel_mongo.exceptions import (
@@ -112,6 +112,12 @@ class TLSEventsHandler(Object):
             )
             event.defer()
             return
+
+        # When we can integrate, clean the mongos requires tls status.
+        if self.manager.state.is_role(MongoDBRoles.MONGOS):
+            self.manager.state.statuses.delete(
+                MongosStatuses.REQUIRES_TLS.value, scope="unit", component=self.dependent.name
+            )
 
         for internal in (True, False):
             csr = self.manager.generate_certificate_request(None, internal=internal)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷 Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update
- [ ] Tooling and CI changes
- [ ] Dependencies upgrade or change

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and scope of this PR (what)
  - the impacted components (where, often match conventional commit scope)
  - explanation/algorithm if require (how)
-->

This PR ensures that the REQUIRES TLS statuses are cleared for both shard and mongos upon TLS integration.
This is useful to ensure that the status is correct from the next event instead of having to wait for the next update-status event for this status to be cleared.

## 📑 Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Either the associated JIRA reference or a paragraph. -->
The Requires TLS status of Mongos Operator was not cleared upon integration with TLS.
Same for shard.

## 🧪 How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manually + all tests should stay green

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](../blob/6/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
