### PR TITLE
patch: extend status messages for MongoDBStatuses

### DIFF
--- a/single_kernel_mongo/config/statuses.py
+++ b/single_kernel_mongo/config/statuses.py
@@ -31,31 +31,31 @@ class MongoDBStatuses(Enum):
         message="Waiting for mongodb-exporter to start...",
         check="MongoDB Exporter status check.",
     )
-    INCOMPATIBLE_SHARDING_REL = StatusObject(
+    INVALID_SHARDING_REL = StatusObject(
         status="blocked",
         message="The sharding interface cannot be used with replica sets.",
-        short_message="Incompatible sharding relation.",
+        short_message="Invalid sharding relation.",
         check="Relation validation.",
         action="Remove the relation on the shards interface (config-server or sharding relation) from this application.",
     )
-    INCOMPATIBLE_MONGOS_REL = StatusObject(
+    INVALID_MONGOS_REL = StatusObject(
         status="blocked",
         message="The cluster relation is can only be used with config servers.",
-        short_message="Incompatible cluster relation.",
+        short_message="Invalid cluster relation.",
         check="Relation validation.",
         action="Remove the cluster relation (config-server interface) from this application.",
     )
-    INCOMPATIBLE_S3_REL = StatusObject(
+    INVALID_S3_REL = StatusObject(
         status="blocked",
         message="The s3-credentials relation cannot be used with config servers and replica sets.",
-        short_message="Incompatible s3-credentials relation.",
+        short_message="Invalid s3-credentials relation.",
         check="Relation validation.",
         action="Remove the s3-credentials relation (s3 interface) from this application.",
     )
-    INCOMPATIBLE_DB_REL = StatusObject(
+    INVALID_DB_REL = StatusObject(
         status="blocked",
         message="The database relation cannot be used with sharding components (shards or config servers).",
-        short_message="Incompatible database relation.",
+        short_message="Invalid database relation.",
         check="Relation validation.",
         action="Remove the database relation (mongodb_client interface) from this application.",
     )

--- a/single_kernel_mongo/config/statuses.py
+++ b/single_kernel_mongo/config/statuses.py
@@ -21,24 +21,43 @@ class MongoDBStatuses(Enum):
     """MongoDB related statuses."""
 
     # STATE statuses:
-    WAITING_FOR_MONGODB_START = StatusObject(status="waiting", message="Waiting to start mongod...")
+    WAITING_FOR_MONGODB_START = StatusObject(
+        status="waiting",
+        message="Waiting for mongod to start...",
+        check="MongoDB process status check.",
+    )
     WAITING_FOR_EXPORTER_START = StatusObject(
-        status="waiting", message="Waiting to start mongodb-exporter..."
+        status="waiting",
+        message="Waiting for mongodb-exporter to start...",
+        check="MongoDB Exporter status check.",
     )
-    SHARDING_ON_REPLICA = StatusObject(
-        status="blocked", message="Sharding interface cannot be used by replicas."
-    )
-    UNSUPPORTED_MONGOS_REL = StatusObject(
+    INCOMPATIBLE_SHARDING_REL = StatusObject(
         status="blocked",
-        message="Relation to mongos not supported, config role must be config-server.",
+        message="The sharding interface cannot be used with replica sets.",
+        short_message="Incompatible sharding relation.",
+        check="Relation validation.",
+        action="Remove the relation on the shards interface (config-server or sharding relation) from this application.",
     )
-    INVALID_S3_INTEGRATION_STATUS = StatusObject(
+    INCOMPATIBLE_MONGOS_REL = StatusObject(
         status="blocked",
-        message="Relation to s3-integrator is not supported, config role must be config-server.",
+        message="The cluster relation is can only be used with config servers.",
+        short_message="Incompatible cluster relation.",
+        check="Relation validation.",
+        action="Remove the cluster relation (config-server interface) from this application.",
     )
-
-    INVALID_DB_REL_ON_SHARD = StatusObject(
-        status="blocked", message="Sharding roles do not support database interface."
+    INCOMPATIBLE_S3_REL = StatusObject(
+        status="blocked",
+        message="The s3-credentials relation cannot be used with config servers and replica sets.",
+        short_message="Incompatible s3-credentials relation.",
+        check="Relation validation.",
+        action="Remove the s3-credentials relation (s3 interface) from this application.",
+    )
+    INCOMPATIBLE_DB_REL = StatusObject(
+        status="blocked",
+        message="The database relation cannot be used with sharding components (shards or config servers).",
+        short_message="Incompatible database relation.",
+        check="Relation validation.",
+        action="Remove the database relation (mongodb_client interface) from this application.",
     )
 
     # RUNNING statuses:

--- a/single_kernel_mongo/config/statuses.py
+++ b/single_kernel_mongo/config/statuses.py
@@ -33,28 +33,28 @@ class MongoDBStatuses(Enum):
     )
     INVALID_SHARDING_REL = StatusObject(
         status="blocked",
-        message="The sharding interface cannot be used with replica sets.",
+        message="The sharding interface cannot be used by replica sets.",
         short_message="Invalid sharding relation.",
         check="Relation validation.",
         action="Remove the relation on the shards interface (config-server or sharding relation) from this application.",
     )
     INVALID_MONGOS_REL = StatusObject(
         status="blocked",
-        message="The cluster relation is can only be used with config servers.",
+        message="The cluster relation can only be used by config servers.",
         short_message="Invalid cluster relation.",
         check="Relation validation.",
         action="Remove the cluster relation (config-server interface) from this application.",
     )
     INVALID_S3_REL = StatusObject(
         status="blocked",
-        message="The s3-credentials relation cannot be used with config servers and replica sets.",
+        message="The s3-credentials relation can only be used by config servers or replica sets.",
         short_message="Invalid s3-credentials relation.",
         check="Relation validation.",
         action="Remove the s3-credentials relation (s3 interface) from this application.",
     )
     INVALID_DB_REL = StatusObject(
         status="blocked",
-        message="The database relation cannot be used with sharding components (shards or config servers).",
+        message="The database relation cannot be used by sharding components (shards or config servers).",
         short_message="Invalid database relation.",
         check="Relation validation.",
         action="Remove the database relation (mongodb_client interface) from this application.",

--- a/single_kernel_mongo/core/structured_config.py
+++ b/single_kernel_mongo/core/structured_config.py
@@ -121,7 +121,7 @@ class MongoDBCharmConfig(MongoConfigModel):
     @field_validator("role", mode="before")
     @classmethod
     def invalid_role_to_unknown(cls, v: str) -> MongoDBRoles:
-        """If the value is neither none or nodeport, returns unknown."""
+        """If the value is neither replication, config-server, or shard, returns unknown."""
         if v not in MongoDBRoles.valid_roles():
             return MongoDBRoles.UNKNOWN
         return MongoDBRoles(v)

--- a/single_kernel_mongo/events/backups.py
+++ b/single_kernel_mongo/events/backups.py
@@ -90,7 +90,7 @@ class BackupEventsHandler(Object):
                 "Shard does not support S3 relations. Please relate s3-integrator to config-server only."
             )
             self.manager.state.statuses.add(
-                MongoDBStatuses.INVALID_S3_INTEGRATION_STATUS.value,
+                MongoDBStatuses.INCOMPATIBLE_S3_REL.value,
                 scope="unit",
                 component=self.manager.name,
             )
@@ -108,7 +108,7 @@ class BackupEventsHandler(Object):
                 "Shard does not support s3 relations, please relate s3-integrator to config-server only."
             )
             self.manager.state.statuses.add(
-                MongoDBStatuses.INVALID_S3_INTEGRATION_STATUS.value,
+                MongoDBStatuses.INCOMPATIBLE_S3_REL.value,
                 scope="unit",
                 component=self.manager.name,
             )

--- a/single_kernel_mongo/events/backups.py
+++ b/single_kernel_mongo/events/backups.py
@@ -90,7 +90,7 @@ class BackupEventsHandler(Object):
                 "Shard does not support S3 relations. Please relate s3-integrator to config-server only."
             )
             self.manager.state.statuses.add(
-                MongoDBStatuses.INCOMPATIBLE_S3_REL.value,
+                MongoDBStatuses.INVALID_S3_REL.value,
                 scope="unit",
                 component=self.manager.name,
             )
@@ -108,7 +108,7 @@ class BackupEventsHandler(Object):
                 "Shard does not support s3 relations, please relate s3-integrator to config-server only."
             )
             self.manager.state.statuses.add(
-                MongoDBStatuses.INCOMPATIBLE_S3_REL.value,
+                MongoDBStatuses.INVALID_S3_REL.value,
                 scope="unit",
                 component=self.manager.name,
             )

--- a/single_kernel_mongo/managers/backups.py
+++ b/single_kernel_mongo/managers/backups.py
@@ -245,7 +245,7 @@ class BackupManager(Object, BackupConfigManager, ManagerStatusProtocol):
         """Returns true if relation to s3-integrator is valid.
 
         Only replica sets and config_servers can integrate to s3-integrator.
-        """
+        """  # need to check against mongos or unknown?
         return (self.state.s3_relation is None) or (not self.state.is_role(MongoDBRoles.SHARD))
 
     def cleanup_certs_and_restart(self, relation: Relation) -> None:

--- a/single_kernel_mongo/managers/backups.py
+++ b/single_kernel_mongo/managers/backups.py
@@ -246,7 +246,11 @@ class BackupManager(Object, BackupConfigManager, ManagerStatusProtocol):
 
         Only replica sets and config_servers can integrate to s3-integrator.
         """
-        return (self.state.s3_relation is None) or (not self.state.is_role(MongoDBRoles.SHARD))
+        return (
+            self.state.s3_relation is None
+            or self.state.is_role(MongoDBRoles.REPLICATION)
+            or self.state.is_role(MongoDBRoles.CONFIG_SERVER)
+        )
 
     def cleanup_certs_and_restart(self, relation: Relation) -> None:
         """On relation broken event, we need to remove the certificate from the trust store."""

--- a/single_kernel_mongo/managers/backups.py
+++ b/single_kernel_mongo/managers/backups.py
@@ -245,7 +245,7 @@ class BackupManager(Object, BackupConfigManager, ManagerStatusProtocol):
         """Returns true if relation to s3-integrator is valid.
 
         Only replica sets and config_servers can integrate to s3-integrator.
-        """  # need to check against mongos or unknown?
+        """
         return (self.state.s3_relation is None) or (not self.state.is_role(MongoDBRoles.SHARD))
 
     def cleanup_certs_and_restart(self, relation: Relation) -> None:

--- a/single_kernel_mongo/managers/cluster.py
+++ b/single_kernel_mongo/managers/cluster.py
@@ -66,7 +66,7 @@ class ClusterProvider(Object):
 
         if not self.is_valid_mongos_integration():
             self.state.statuses.add(
-                MongoDBStatuses.UNSUPPORTED_MONGOS_REL.value,
+                MongoDBStatuses.INCOMPATIBLE_MONGOS_REL.value,
                 scope="unit",
                 component=self.dependent.name,
             )

--- a/single_kernel_mongo/managers/cluster.py
+++ b/single_kernel_mongo/managers/cluster.py
@@ -66,7 +66,7 @@ class ClusterProvider(Object):
 
         if not self.is_valid_mongos_integration():
             self.state.statuses.add(
-                MongoDBStatuses.INCOMPATIBLE_MONGOS_REL.value,
+                MongoDBStatuses.INVALID_MONGOS_REL.value,
                 scope="unit",
                 component=self.dependent.name,
             )

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -916,8 +916,7 @@ class MongoDBOperator(OperatorProtocol, Object):
                 MongoDBStatuses.INVALID_DB_REL.value, scope="unit", component=self.name
             )
             return False
-        if not self.state.is_sharding_component and (
-            rel_name == RelationNames.SHARDING or rel_name == RelationNames.CONFIG_SERVER
+        if not self.state.is_sharding_component and rel_name in {RelationNames.SHARDING, RelationNames.CONFIG_SERVER}
         ):
             logger.error(
                 "Charm is in replication role: %s. Does not support %s interface.",

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -916,7 +916,9 @@ class MongoDBOperator(OperatorProtocol, Object):
                 MongoDBStatuses.INVALID_DB_REL.value, scope="unit", component=self.name
             )
             return False
-        if not self.state.is_sharding_component and self.state.has_sharding_integration:
+        if not self.state.is_sharding_component and (
+            rel_name == RelationNames.SHARDING or rel_name == RelationNames.CONFIG_SERVER
+        ):
             logger.error(
                 "Charm is in replication role: %s. Does not support %s interface.",
                 self.state.app_peer_data.role,

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -916,7 +916,7 @@ class MongoDBOperator(OperatorProtocol, Object):
                 MongoDBStatuses.INCOMPATIBLE_DB_REL.value, scope="unit", component=self.name
             )
             return False
-        if not self.state.is_sharding_component and rel_name == RelationNames.SHARDING:
+        if not self.state.is_sharding_component and self.state.has_sharding_integration:
             logger.error(
                 "Charm is in replication role: %s. Does not support %s interface.",
                 self.state.app_peer_data.role,

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -913,7 +913,7 @@ class MongoDBOperator(OperatorProtocol, Object):
             )
 
             self.state.statuses.add(
-                MongoDBStatuses.INVALID_DB_REL_ON_SHARD.value, scope="unit", component=self.name
+                MongoDBStatuses.INCOMPATIBLE_DB_REL.value, scope="unit", component=self.name
             )
             return False
         if not self.state.is_sharding_component and rel_name == RelationNames.SHARDING:
@@ -923,7 +923,7 @@ class MongoDBOperator(OperatorProtocol, Object):
                 rel_name,
             )
             self.state.statuses.add(
-                MongoDBStatuses.SHARDING_ON_REPLICA.value, scope="unit", component=self.name
+                MongoDBStatuses.INCOMPATIBLE_SHARDING_REL.value, scope="unit", component=self.name
             )
             return False
         return True
@@ -993,21 +993,16 @@ class MongoDBOperator(OperatorProtocol, Object):
         """Basic checks."""
         statuses = []
         if not self.cluster_manager.is_valid_mongos_integration():
-            statuses.append(MongoDBStatuses.UNSUPPORTED_MONGOS_REL.value)
+            statuses.append(MongoDBStatuses.INCOMPATIBLE_MONGOS_REL.value)
 
         if not self.backup_manager.is_valid_s3_integration():
-            statuses.append(MongoDBStatuses.INVALID_S3_INTEGRATION_STATUS.value)
-
-        if self.state.is_role(MongoDBRoles.REPLICATION) and (
-            self.state.config_server_relation or self.state.shard_relation
-        ):
-            statuses.append(MongoDBStatuses.SHARDING_ON_REPLICA.value)
+            statuses.append(MongoDBStatuses.INCOMPATIBLE_S3_REL.value)
 
         if self.state.client_relations and self.state.is_sharding_component:
-            statuses.append(MongoDBStatuses.INVALID_DB_REL_ON_SHARD.value)
+            statuses.append(MongoDBStatuses.INCOMPATIBLE_DB_REL.value)
 
         if not self.state.is_sharding_component and self.state.has_sharding_integration:
-            statuses.append(MongoDBStatuses.SHARDING_ON_REPLICA.value)
+            statuses.append(MongoDBStatuses.INCOMPATIBLE_SHARDING_REL.value)
         elif rev_status := self.cluster_version_checker.get_cluster_mismatched_revision_status():
             # don't bother checking revision mismatch on sharding interface if replica
             statuses.append(rev_status)

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -916,8 +916,10 @@ class MongoDBOperator(OperatorProtocol, Object):
                 MongoDBStatuses.INVALID_DB_REL.value, scope="unit", component=self.name
             )
             return False
-        if not self.state.is_sharding_component and rel_name in {RelationNames.SHARDING, RelationNames.CONFIG_SERVER}
-        ):
+        if not self.state.is_sharding_component and rel_name in {
+            RelationNames.SHARDING,
+            RelationNames.CONFIG_SERVER,
+        }:
             logger.error(
                 "Charm is in replication role: %s. Does not support %s interface.",
                 self.state.app_peer_data.role,

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -913,7 +913,7 @@ class MongoDBOperator(OperatorProtocol, Object):
             )
 
             self.state.statuses.add(
-                MongoDBStatuses.INCOMPATIBLE_DB_REL.value, scope="unit", component=self.name
+                MongoDBStatuses.INVALID_DB_REL.value, scope="unit", component=self.name
             )
             return False
         if not self.state.is_sharding_component and self.state.has_sharding_integration:
@@ -923,7 +923,7 @@ class MongoDBOperator(OperatorProtocol, Object):
                 rel_name,
             )
             self.state.statuses.add(
-                MongoDBStatuses.INCOMPATIBLE_SHARDING_REL.value, scope="unit", component=self.name
+                MongoDBStatuses.INVALID_SHARDING_REL.value, scope="unit", component=self.name
             )
             return False
         return True
@@ -993,16 +993,16 @@ class MongoDBOperator(OperatorProtocol, Object):
         """Basic checks."""
         statuses = []
         if not self.cluster_manager.is_valid_mongos_integration():
-            statuses.append(MongoDBStatuses.INCOMPATIBLE_MONGOS_REL.value)
+            statuses.append(MongoDBStatuses.INVALID_MONGOS_REL.value)
 
         if not self.backup_manager.is_valid_s3_integration():
-            statuses.append(MongoDBStatuses.INCOMPATIBLE_S3_REL.value)
+            statuses.append(MongoDBStatuses.INVALID_S3_REL.value)
 
         if self.state.client_relations and self.state.is_sharding_component:
-            statuses.append(MongoDBStatuses.INCOMPATIBLE_DB_REL.value)
+            statuses.append(MongoDBStatuses.INVALID_DB_REL.value)
 
         if not self.state.is_sharding_component and self.state.has_sharding_integration:
-            statuses.append(MongoDBStatuses.INCOMPATIBLE_SHARDING_REL.value)
+            statuses.append(MongoDBStatuses.INVALID_SHARDING_REL.value)
         elif rev_status := self.cluster_version_checker.get_cluster_mismatched_revision_status():
             # don't bother checking revision mismatch on sharding interface if replica
             statuses.append(rev_status)

--- a/single_kernel_mongo/managers/sharding.py
+++ b/single_kernel_mongo/managers/sharding.py
@@ -180,6 +180,8 @@ class ConfigServerManager(Object, ManagerStatusProtocol):
         Raises:
             NonDeferrableFailedHookChecksError, DeferrableFailedHookChecksError
         """
+        if not self.state.is_role(MongoDBRoles.CONFIG_SERVER):
+            raise NonDeferrableFailedHookChecksError("is only executed by config-server")
         if not self.state.db_initialised:
             raise DeferrableFailedHookChecksError("db is not initialised.")
         if not self.dependent.is_relation_feasible(self.relation_name):
@@ -196,8 +198,6 @@ class ConfigServerManager(Object, ManagerStatusProtocol):
         ):
             self.state.statuses.add(rev_status, scope="unit", component=self.dependent.name)
             raise DeferrableFailedHookChecksError("Mismatched versions in the cluster")
-        if not self.state.is_role(MongoDBRoles.CONFIG_SERVER):
-            raise NonDeferrableFailedHookChecksError("is only executed by config-server")
 
     def assert_pass_hook_checks(self, relation: Relation, leaving: bool = False) -> None:
         """Runs pre hooks checks and raises the appropriate error if it fails.
@@ -504,6 +504,8 @@ class ShardManager(Object, ManagerStatusProtocol):
 
     def assert_pass_sanity_hook_checks(self, is_leaving: bool) -> None:
         """Returns True if all the sanity hook checks for sharding pass."""
+        if not self.state.is_role(MongoDBRoles.SHARD):
+            raise NonDeferrableFailedHookChecksError("is only executed by shards")
         if not self.state.db_initialised:
             raise DeferrableFailedHookChecksError("db is not initialised.")
         if not self.dependent.is_relation_feasible(self.relation_name):
@@ -524,8 +526,6 @@ class ShardManager(Object, ManagerStatusProtocol):
         ):
             self.state.statuses.add(rev_status, scope="unit", component=self.dependent.name)
             raise DeferrableFailedHookChecksError("Mismatched versions in the cluster")
-        if not self.state.is_role(MongoDBRoles.SHARD):
-            raise NonDeferrableFailedHookChecksError("is only executed by shards")
 
     def assert_pass_hook_checks(self, relation: Relation, is_leaving: bool = False) -> None:
         """Runs the pre-hooks checks, returns True if all pass."""

--- a/tests/integration/mongodb/relations/test_sharding_relations.py
+++ b/tests/integration/mongodb/relations/test_sharding_relations.py
@@ -176,7 +176,7 @@ async def test_cannot_use_db_relation(ops_test: OpsTest, substrate: Substrate) -
             ops_test,
             substrate,
             sharded_component,
-            status="Sharding roles do not support database interface.",
+            status="The database relation cannot be used by sharding components (shards or config servers).",
             timeout=300,
         )
 
@@ -208,7 +208,7 @@ async def test_replication_config_server_relation(ops_test: OpsTest, substrate: 
         ops_test,
         substrate,
         REPLICATION_APP_NAME,
-        status="Sharding interface cannot be used by replicas.",
+        status="The sharding interface cannot be used by replica sets.",
         timeout=300,
     )
 
@@ -232,7 +232,7 @@ async def test_replication_shard_relation(ops_test: OpsTest, substrate: Substrat
         ops_test,
         substrate,
         REPLICATION_APP_NAME,
-        status="Sharding interface cannot be used by rep",
+        status="The sharding interface cannot be used by replica sets.",
         timeout=300,
     )
 
@@ -263,7 +263,7 @@ async def test_replication_mongos_relation(ops_test: OpsTest, substrate: Substra
         ops_test,
         substrate,
         REPLICATION_APP_NAME,
-        status="Relation to mongos not supported",
+        status="The cluster relation can only be used by config servers.",
         timeout=300,
     )
 
@@ -294,14 +294,14 @@ async def test_shard_mongos_relation(ops_test: OpsTest, substrate: Substrate) ->
         ops_test,
         substrate,
         SHARD_ONE_APP_NAME,
-        status="Relation to mongos not supported",
+        status="The cluster relation can only be used by config servers.",
         timeout=300,
     )
     await check_status_detail(
         ops_test,
         SHARD_ONE_APP_NAME,
         status="blocked",
-        message="Relation to mongos not supported, config role must be config-server.",
+        message="The cluster relation can only be used by config servers.",
     )
 
     # clean up relations
@@ -324,14 +324,14 @@ async def test_shard_s3_relation(ops_test: OpsTest, substrate: Substrate) -> Non
         ops_test,
         substrate,
         SHARD_ONE_APP_NAME,
-        status="Relation to s3-integrator is not support",
+        status="The s3-credentials relation can only be used by config servers or replica sets.",
         timeout=300,
     )
     await check_status_detail(
         ops_test,
         SHARD_ONE_APP_NAME,
         status="blocked",
-        message="Relation to s3-integrator is not supported, config role must be config-server.",
+        message="The s3-credentials relation can only be used by config servers or replica sets.",
     )
 
     # clean up relations
@@ -361,7 +361,7 @@ async def test_config_server_tls_replication_relation(
         ops_test,
         substrate,
         REPLICATION_APP_NAME,
-        status="Sharding interface cannot be used by replicas.",
+        status="The sharding interface cannot be used by replica sets.",
         timeout=300,
     )
 

--- a/tests/integration/mongodb/relations/test_sharding_relations.py
+++ b/tests/integration/mongodb/relations/test_sharding_relations.py
@@ -324,7 +324,7 @@ async def test_shard_s3_relation(ops_test: OpsTest, substrate: Substrate) -> Non
         ops_test,
         substrate,
         SHARD_ONE_APP_NAME,
-        status="Invalid s3-credentials relation",
+        status="Invalid s3-credentials relation.",
         timeout=300,
     )
     await check_status_detail(

--- a/tests/integration/mongodb/relations/test_sharding_relations.py
+++ b/tests/integration/mongodb/relations/test_sharding_relations.py
@@ -324,7 +324,7 @@ async def test_shard_s3_relation(ops_test: OpsTest, substrate: Substrate) -> Non
         ops_test,
         substrate,
         SHARD_ONE_APP_NAME,
-        status="The s3-credentials relation can only be used by config servers or replica sets.",
+        status="Invalid s3-credentials relation",
         timeout=300,
     )
     await check_status_detail(

--- a/tests/integration/mongodb/relations/test_sharding_relations.py
+++ b/tests/integration/mongodb/relations/test_sharding_relations.py
@@ -294,7 +294,7 @@ async def test_shard_mongos_relation(ops_test: OpsTest, substrate: Substrate) ->
         ops_test,
         substrate,
         SHARD_ONE_APP_NAME,
-        status="The cluster relation can only be used by config servers.",
+        status="Invalid cluster relation.",
         timeout=300,
     )
     await check_status_detail(

--- a/tests/unit/test_backup_manager.py
+++ b/tests/unit/test_backup_manager.py
@@ -50,22 +50,12 @@ def test_valid_s3_integration(harness: Harness[MongoTestCharm], role: MongoDBRol
     harness.charm.on[ExternalRequirerRelations.S3_CREDENTIALS.value].relation_joined.emit(
         relation=relation
     )
-    assert harness.charm.unit.status != MongoDBStatuses.INCOMPATIBLE_S3_REL.value
+    assert harness.charm.unit.status != MongoDBStatuses.INVALID_S3_REL.value
 
 
-@pytest.mark.parametrize(
-    "role",
-    [
-        MongoDBRoles.SHARD.value,
-        # MongoDBRoles.MONGOS.value,
-        # MongoDBRoles.UNKNOWN.value,
-    ],
-)
-def test_invalid_s3_integration(
-    harness: Harness[MongoTestCharm], backup_manager: BackupManager, role: MongoDBRoles
-):
+def test_invalid_s3_integration(harness: Harness[MongoTestCharm], backup_manager: BackupManager):
     harness.set_leader(True)
-    harness.charm.operator.state.app_peer_data.role = role
+    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.SHARD.value
     relation_id = harness.add_relation(
         ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
     )
@@ -80,7 +70,7 @@ def test_invalid_s3_integration(
         scope=Scope.UNIT, component=backup_manager.name
     ).root
 
-    assert MongoDBStatuses.INCOMPATIBLE_S3_REL.value in statuses
+    assert MongoDBStatuses.INVALID_S3_REL.value in statuses
 
 
 def test_backup_without_rel(harness):

--- a/tests/unit/test_backup_manager.py
+++ b/tests/unit/test_backup_manager.py
@@ -30,9 +30,16 @@ def backup_manager(harness: Harness[MongoTestCharm]) -> BackupManager:
     return harness.charm.operator.backup_manager
 
 
-def test_valid_s3_integration(harness: Harness[MongoTestCharm]):
+@pytest.mark.parametrize(
+    "role",
+    [
+        MongoDBRoles.REPLICATION.value,
+        MongoDBRoles.CONFIG_SERVER.value,
+    ],
+)
+def test_valid_s3_integration(harness: Harness[MongoTestCharm], role: MongoDBRoles):
     harness.set_leader(True)
-    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION.value
+    harness.charm.operator.state.app_peer_data.role = role
     relation_id = harness.add_relation(
         ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
     )
@@ -43,12 +50,22 @@ def test_valid_s3_integration(harness: Harness[MongoTestCharm]):
     harness.charm.on[ExternalRequirerRelations.S3_CREDENTIALS.value].relation_joined.emit(
         relation=relation
     )
-    assert harness.charm.unit.status != MongoDBStatuses.INVALID_S3_INTEGRATION_STATUS.value
+    assert harness.charm.unit.status != MongoDBStatuses.INCOMPATIBLE_S3_REL.value
 
 
-def test_invalid_s3_integration(harness: Harness[MongoTestCharm], backup_manager: BackupManager):
+@pytest.mark.parametrize(
+    "role",
+    [
+        MongoDBRoles.SHARD.value,
+        # MongoDBRoles.MONGOS.value,
+        # MongoDBRoles.UNKNOWN.value,
+    ],
+)
+def test_invalid_s3_integration(
+    harness: Harness[MongoTestCharm], backup_manager: BackupManager, role: MongoDBRoles
+):
     harness.set_leader(True)
-    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.SHARD
+    harness.charm.operator.state.app_peer_data.role = role
     relation_id = harness.add_relation(
         ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
     )
@@ -63,7 +80,7 @@ def test_invalid_s3_integration(harness: Harness[MongoTestCharm], backup_manager
         scope=Scope.UNIT, component=backup_manager.name
     ).root
 
-    assert MongoDBStatuses.INVALID_S3_INTEGRATION_STATUS.value in statuses
+    assert MongoDBStatuses.INCOMPATIBLE_S3_REL.value in statuses
 
 
 def test_backup_without_rel(harness):

--- a/tests/unit/test_backup_manager.py
+++ b/tests/unit/test_backup_manager.py
@@ -53,9 +53,19 @@ def test_valid_s3_integration(harness: Harness[MongoTestCharm], role: MongoDBRol
     assert harness.charm.unit.status != MongoDBStatuses.INVALID_S3_REL.value
 
 
-def test_invalid_s3_integration(harness: Harness[MongoTestCharm], backup_manager: BackupManager):
+@pytest.mark.parametrize(
+    "role",
+    [
+        MongoDBRoles.UNKNOWN.value,
+        MongoDBRoles.SHARD.value,
+        MongoDBRoles.MONGOS.value,
+    ],
+)
+def test_invalid_s3_integration(
+    harness: Harness[MongoTestCharm], backup_manager: BackupManager, role: MongoDBRoles
+):
     harness.set_leader(True)
-    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.SHARD.value
+    harness.charm.operator.state.app_peer_data.role = role
     relation_id = harness.add_relation(
         ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
     )
@@ -88,6 +98,8 @@ def test_list_backup_without_rel(harness):
 def test_s3_credentials_no_db(harness: Harness[MongoTestCharm], mocker):
     """Verifies that when there is no DB that setting credentials is deferred."""
     harness.charm.operator.state.db_initialised = False
+    harness.set_leader(True)
+    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION
     defer = mocker.patch("ops.framework.EventBase.defer")
     mocker.patch(
         "single_kernel_mongo.events.backups.S3Requirer.get_s3_connection_info",

--- a/tests/unit/test_sharding.py
+++ b/tests/unit/test_sharding.py
@@ -350,9 +350,7 @@ def test_shard_manager_prepare_to_add_shard(harness: Harness[MongoTestCharm]):
     assert as_status(statuses[0]) == MaintenanceStatus("Adding shard to config-server")
 
 
-def test_shard_manager_synchronise_cluster_invalid_role(
-    harness: Harness[MongoTestCharm], mock_fs_interactions
-):
+def test_shard_manager_synchronise_cluster_invalid_role(harness: Harness[MongoTestCharm]):
     manager = harness.charm.operator.shard_manager
 
     harness.set_leader(True)
@@ -360,8 +358,7 @@ def test_shard_manager_synchronise_cluster_invalid_role(
     harness.charm.operator.state.db_initialised = True
 
     rel_id = harness.add_relation(RelationNames.SHARDING.value, "config-server")
-
-    relation: Relation = harness.charm.model.get_relation(RelationNames.CONFIG_SERVER.value, rel_id)  # type: ignore[assignment]
+    relation: Relation = harness.charm.model.get_relation(RelationNames.SHARDING.value, rel_id)  # type: ignore[assignment]
 
     with pytest.raises(NonDeferrableFailedHookChecksError) as err:
         manager.synchronise_cluster_secrets(relation)

--- a/tests/unit/test_sharding.py
+++ b/tests/unit/test_sharding.py
@@ -350,6 +350,25 @@ def test_shard_manager_prepare_to_add_shard(harness: Harness[MongoTestCharm]):
     assert as_status(statuses[0]) == MaintenanceStatus("Adding shard to config-server")
 
 
+def test_shard_manager_synchronise_cluster_invalid_role(
+    harness: Harness[MongoTestCharm], mock_fs_interactions
+):
+    manager = harness.charm.operator.shard_manager
+
+    harness.set_leader(True)
+    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION
+    harness.charm.operator.state.db_initialised = True
+
+    rel_id = harness.add_relation(RelationNames.SHARDING.value, "config-server")
+
+    relation: Relation = harness.charm.model.get_relation(RelationNames.CONFIG_SERVER.value, rel_id)  # type: ignore[assignment]
+
+    with pytest.raises(NonDeferrableFailedHookChecksError) as err:
+        manager.synchronise_cluster_secrets(relation)
+
+    assert err.value.args[0] == "is only executed by shards"
+
+
 def test_shard_manager_synchronise_cluster_secrets_success(
     harness: Harness[MongoTestCharm], mocker
 ):

--- a/tests/unit/test_status_handler.py
+++ b/tests/unit/test_status_handler.py
@@ -135,7 +135,7 @@ def test_mongo_get_status_with_error(
         MongoDBRoles.REPLICATION.value,
     ],
 )
-def test_sharding_components_get_status_incompatible_cluster_relation(
+def test_sharding_components_get_status_invalid_cluster_relation(
     harness: Harness[MongoTestCharm], mocker, mock_fs_interactions, role: MongoDBRoles
 ):
     harness.set_leader(True)
@@ -147,10 +147,10 @@ def test_sharding_components_get_status_incompatible_cluster_relation(
     statuses = harness.charm.operator.get_statuses(scope=Scope.UNIT, recompute=True)
     status = next(iter(statuses), None)
 
-    assert status == MongoDBStatuses.INCOMPATIBLE_MONGOS_REL.value
+    assert status == MongoDBStatuses.INVALID_MONGOS_REL.value
 
 
-def test_replica_set_get_status_incompatible_config_server_relation(
+def test_replica_set_get_status_invalid_config_server_relation(
     harness: Harness[MongoTestCharm], mocker, mock_fs_interactions
 ):
     harness.set_leader(True)
@@ -162,7 +162,7 @@ def test_replica_set_get_status_incompatible_config_server_relation(
     statuses = harness.charm.operator.get_statuses(scope=Scope.UNIT, recompute=True)
     status = next(iter(statuses), None)
 
-    assert status == MongoDBStatuses.INCOMPATIBLE_SHARDING_REL.value
+    assert status == MongoDBStatuses.INVALID_SHARDING_REL.value
 
 
 def test_config_server_get_status_invalid_role(
@@ -211,7 +211,7 @@ def test_config_server_get_status_client_relation(
     statuses = harness.charm.operator.get_statuses(scope=Scope.UNIT, recompute=True)
     status = next(iter(statuses), None)
 
-    assert status == MongoDBStatuses.INCOMPATIBLE_DB_REL.value
+    assert status == MongoDBStatuses.INVALID_DB_REL.value
 
 
 def test_config_server_get_status_internal_mongos_not_running(
@@ -400,7 +400,7 @@ def test_shard_get_status_db_not_initialised(
     assert status is None
 
 
-def test_replica_set_get_status_incompatible_sharding_relation(
+def test_replica_set_get_status_invalid_sharding_relation(
     harness: Harness[MongoTestCharm], mocker, mock_fs_interactions
 ):
     harness.set_leader(True)
@@ -412,7 +412,7 @@ def test_replica_set_get_status_incompatible_sharding_relation(
     statuses = harness.charm.operator.get_statuses(scope=Scope.UNIT, recompute=True)
     status = next(iter(statuses), None)
 
-    assert status == MongoDBStatuses.INCOMPATIBLE_SHARDING_REL.value
+    assert status == MongoDBStatuses.INVALID_SHARDING_REL.value
 
 
 def test_shard_get_status_charm_client_relation(
@@ -427,7 +427,7 @@ def test_shard_get_status_charm_client_relation(
     statuses = harness.charm.operator.get_statuses(scope=Scope.UNIT, recompute=True)
     status = next(iter(statuses), None)
 
-    assert status == MongoDBStatuses.INCOMPATIBLE_DB_REL.value
+    assert status == MongoDBStatuses.INVALID_DB_REL.value
 
 
 def test_shard_get_status_charm_missing_relation_not_drained(

--- a/tests/unit/test_status_handler.py
+++ b/tests/unit/test_status_handler.py
@@ -150,7 +150,7 @@ def test_sharding_components_get_status_incompatible_cluster_relation(
     assert status == MongoDBStatuses.INCOMPATIBLE_MONGOS_REL.value
 
 
-def test_replica_set_get_status_incompatible_relation_with_config_server(
+def test_replica_set_get_status_incompatible_config_server_relation(
     harness: Harness[MongoTestCharm], mocker, mock_fs_interactions
 ):
     harness.set_leader(True)
@@ -400,7 +400,7 @@ def test_shard_get_status_db_not_initialised(
     assert status is None
 
 
-def test_replica_set_get_status_incompatible_integration_with_shard(
+def test_replica_set_get_status_incompatible_sharding_relation(
     harness: Harness[MongoTestCharm], mocker, mock_fs_interactions
 ):
     harness.set_leader(True)

--- a/tests/unit/test_status_handler.py
+++ b/tests/unit/test_status_handler.py
@@ -128,7 +128,29 @@ def test_mongo_get_status_with_error(
     assert status == expected_status
 
 
-def test_config_server_get_status_invalid_integration(
+@pytest.mark.parametrize(
+    "role",
+    [
+        MongoDBRoles.SHARD.value,
+        MongoDBRoles.REPLICATION.value,
+    ],
+)
+def test_sharding_components_get_status_incompatible_cluster_relation(
+    harness: Harness[MongoTestCharm], mocker, mock_fs_interactions, role: MongoDBRoles
+):
+    harness.set_leader(True)
+    harness.charm.operator.state.db_initialised = True
+    harness.charm.operator.state.app_peer_data.role = role
+
+    harness.add_relation(RelationNames.CLUSTER.value, "mongos")
+
+    statuses = harness.charm.operator.get_statuses(scope=Scope.UNIT, recompute=True)
+    status = next(iter(statuses), None)
+
+    assert status == MongoDBStatuses.INCOMPATIBLE_MONGOS_REL.value
+
+
+def test_replica_set_get_status_incompatible_relation_with_config_server(
     harness: Harness[MongoTestCharm], mocker, mock_fs_interactions
 ):
     harness.set_leader(True)
@@ -140,7 +162,7 @@ def test_config_server_get_status_invalid_integration(
     statuses = harness.charm.operator.get_statuses(scope=Scope.UNIT, recompute=True)
     status = next(iter(statuses), None)
 
-    assert status == MongoDBStatuses.SHARDING_ON_REPLICA.value
+    assert status == MongoDBStatuses.INCOMPATIBLE_SHARDING_REL.value
 
 
 def test_config_server_get_status_invalid_role(
@@ -189,7 +211,7 @@ def test_config_server_get_status_client_relation(
     statuses = harness.charm.operator.get_statuses(scope=Scope.UNIT, recompute=True)
     status = next(iter(statuses), None)
 
-    assert status == MongoDBStatuses.INVALID_DB_REL_ON_SHARD.value
+    assert status == MongoDBStatuses.INCOMPATIBLE_DB_REL.value
 
 
 def test_config_server_get_status_internal_mongos_not_running(
@@ -378,7 +400,7 @@ def test_shard_get_status_db_not_initialised(
     assert status is None
 
 
-def test_shard_get_status_charm_is_replication(
+def test_replica_set_get_status_incompatible_integration_with_shard(
     harness: Harness[MongoTestCharm], mocker, mock_fs_interactions
 ):
     harness.set_leader(True)
@@ -390,7 +412,7 @@ def test_shard_get_status_charm_is_replication(
     statuses = harness.charm.operator.get_statuses(scope=Scope.UNIT, recompute=True)
     status = next(iter(statuses), None)
 
-    assert status == MongoDBStatuses.SHARDING_ON_REPLICA.value
+    assert status == MongoDBStatuses.INCOMPATIBLE_SHARDING_REL.value
 
 
 def test_shard_get_status_charm_client_relation(
@@ -405,7 +427,7 @@ def test_shard_get_status_charm_client_relation(
     statuses = harness.charm.operator.get_statuses(scope=Scope.UNIT, recompute=True)
     status = next(iter(statuses), None)
 
-    assert status == MongoDBStatuses.INVALID_DB_REL_ON_SHARD.value
+    assert status == MongoDBStatuses.INCOMPATIBLE_DB_REL.value
 
 
 def test_shard_get_status_charm_missing_relation_not_drained(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷 Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update
- [ ] Tooling and CI changes
- [ ] Dependencies upgrade or change

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and scope of this PR (what)
  - the impacted components (where, often match conventional commit scope)
  - explanation/algorithm if require (how)
-->

- Extend the status in `MongoDBStatuses`.
  - Make the `short_message` shorter than 40 characters.
  - Add `check` and `action` when judged necessary
  - Make the variable names, messages and vocabulary consistent
- Remove duplicated check for sharding relation on replica sets

## 📑 Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Either the associated JIRA reference or a paragraph. -->

This PR improves the quality of the message displayed to the operator about the state of the charms

## 🧪 How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Add some UTs and tested it locally

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](../blob/6/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

<img width="863" height="872" alt="image" src="https://github.com/user-attachments/assets/53098bf9-1ce1-4b0b-ac34-73441b006816" />
