### PR TITLE
patch: extend status messages for LDAP

### DIFF
--- a/single_kernel_mongo/config/models.py
+++ b/single_kernel_mongo/config/models.py
@@ -126,7 +126,7 @@ class LdapState(Enum):
     LDAP_SERVERS_MISMATCH = auto()
     WAITING_FOR_DATA = auto()
     WAITING_FOR_CERTS = auto()
-    WAITING_FOR_LDAP_DATA = auto()
+    WAITING_FOR_DATA_AND_CERTS = auto()
     MISSING_BASE_DN = auto()
     MISSING_CERT_CHAIN = auto()
     MISSING_LDAPS_URLS = auto()

--- a/single_kernel_mongo/config/statuses.py
+++ b/single_kernel_mongo/config/statuses.py
@@ -360,71 +360,104 @@ class UpgradeStatuses(Enum):
 class LdapStatuses(Enum):
     """Ldap Statuses."""
 
-    INVALID_LDAP_USER_MAPPING = StatusObject(
-        status="blocked",
-        message="Invalid LdapUserToDnMapping, please update your config.",
+    ACTIVE_IDLE = StatusObject(
+        status="active",
+        message="",
     )
-    INVALID_LDAP_QUERY_TEMPLATE = StatusObject(
-        status="blocked",
-        message="Invalid LDAP Query template, please update your config",
-    )
-    CONFIGURING_LDAP = StatusObject(
-        status="maintenance", message="Configuring LDAP", running="blocking"
-    )
-    INVALID_LDAP_REL_ON_SHARD = StatusObject(
-        status="blocked",
-        message="Cannot integrate LDAP with shard.",
-    )
-    TLS_REQUIRED = StatusObject(
-        status="blocked",
-        message="TLS is mandatory for LDAP transport.",
-    )
-    LDAP_REQUIRED = StatusObject(
-        status="blocked",
-        message="GLauth TLS is integrated but LDAP is not.",
-    )
-    LDAP_SERVERS_MISMATCH = StatusObject(
-        status="blocked",
-        message="mongos and config-server not integrated with the same ldap server.",
-    )
-    WAITING_FOR_DATA = StatusObject(
+    WAITING_FOR_DATA_AND_CERTS = StatusObject(
         status="waiting",
-        message="Waiting for both LDAP data and Glauth certificates.",
+        message="Waiting for LDAP data and certificates.",
+        short_message="LDAP is not ready...",
     )
     WAITING_FOR_CERTS = StatusObject(
         status="waiting",
-        message="Waiting for Glauth certificates.",
+        message="Waiting for LDAP certificates...",
     )
-    WAITING_FOR_LDAP_DATA = StatusObject(
+    WAITING_FOR_DATA = StatusObject(
         status="waiting",
-        message="Missing LDAP data from Glauth.",
+        message="Waiting for LDAP data...",
+    )
+    INVALID_USER_MAPPING = StatusObject(
+        status="blocked",
+        message="Invalid LDAP to DN mapping config.",
+        action="Check the logs and verify the configuration in the ldap relation.",
+        check="LDAP configuration validation failed.",
+    )
+    INVALID_QUERY_TEMPLATE = StatusObject(
+        status="blocked",
+        message="Invalid LDAP query template config.",
+        action="Check the logs and verify the configuration in the ldap relation.",
+        check="LDAP configuration validation failed.",
+    )
+    INVALID_LDAP_REL_ON_SHARD = StatusObject(
+        status="blocked",
+        message="The ldap relation cannot be used by shards.",
+        short_message="Invalid ldap relation.",
+        action="Remove the ldap relation (ldap interface) from this application.",
+        check="Relation validation failed.",
+    )
+    MISSING_CERT_TRANSFERT_REL = StatusObject(
+        status="blocked",
+        message="Missing ldap-certificate-transfer relation.",
+        short_message="TLS is mandatory for LDAP transport.",
+        action="Add the ldap-certificate-transfer relation between LDAP application and this application.",
+        check="Relation validation failed.",
+    )
+    MISSING_LDAP_REL = StatusObject(
+        status="blocked",
+        message="ldap relation is missing between LDAP application and this application.",
+        short_message="Missing ldap relation.",
+        action="Add the ldap relation (ldap interface) to this application.",
+        check="Relation validation failed.",
+    )
+    SERVERS_MISMATCH = StatusObject(
+        status="blocked",
+        message="mongos and config-server are not integrated with the same LDAP server.",
+        short_message="LDAP servers mismatch.",
+        action="Check the logs and verify the LDAP configuration.",
     )
     MISSING_BASE_DN = StatusObject(
         status="blocked",
         message="Missing base DN for LDAP.",
+        action="Check the logs and verify the LDAP configuration.",
+        check="LDAP configuration validation failed.",
     )
     MISSING_CERT_CHAIN = StatusObject(
         status="blocked",
-        message="Missing chain for LDAP.",
+        message="Missing certificate chain for LDAP.",
+        action="Check the logs and verify the LDAP configuration.",
+        check="LDAP configuration validation failed.",
     )
     MISSING_LDAPS_URLS = StatusObject(
         status="blocked",
         message="Missing LDAPS URLs for LDAP.",
+        action="Check the logs and verify the LDAP configuration.",
+        check="LDAP configuration validation failed.",
     )
     LDAPS_NOT_ENABLED = StatusObject(
         status="blocked",
         message="LDAPS not enabled on LDAP application.",
+        action="Enable LDAPS support in the LDAP application (ldaps_enabled=true for GLAuth).",
+        check="LDAP configuration validation failed.",
     )
     UNABLE_TO_BIND = StatusObject(
         status="blocked",
-        message="Could not bind with ldap",
+        message="Failed to bind with LDAP.",
+        action="Check the logs and verify the LDAP configuration.",
+        check="LDAP connection status check failed.",
     )
-    ACTIVE_IDLE = StatusObject(
-        status="active",
-        message="",
+
+    # RUNNING status:
+    CONFIGURING_LDAP = StatusObject(
+        status="maintenance", message="Configuring LDAP...", running="blocking"
     )
 
     @staticmethod
     def on_error_status(err: Exception):
         """On error."""
-        return StatusObject(status="blocked", message=f"{err}")
+        return StatusObject(
+            status="blocked",
+            message=f"{err}",
+            short_message="Error on LDAP.",
+            action="Check the logs and verify the LDAP configuration.",
+        )

--- a/single_kernel_mongo/events/ldap.py
+++ b/single_kernel_mongo/events/ldap.py
@@ -83,7 +83,7 @@ class LDAPEventHandler(Object):
             self.manager.store_ldap_credentials_and_uri(event.relation)
         except (WaitingForLdapDataError, ValidationError) as err:
             self.manager.state.statuses.add(
-                LdapStatuses.WAITING_FOR_LDAP_DATA.value,
+                LdapStatuses.WAITING_FOR_DATA.value,
                 scope="unit",
                 component=self.manager.name,
             )

--- a/single_kernel_mongo/events/lifecycle.py
+++ b/single_kernel_mongo/events/lifecycle.py
@@ -165,13 +165,13 @@ class LifecycleEventsHandler(Object):
             event.defer()
         except InvalidLdapUserToDnMappingError:
             self.dependent.state.statuses.add(
-                LdapStatuses.INVALID_LDAP_USER_MAPPING.value,
+                LdapStatuses.INVALID_USER_MAPPING.value,
                 scope="unit",
                 component=self.dependent.name,
             )
         except InvalidLdapQueryTemplateError:
             self.dependent.state.statuses.add(
-                LdapStatuses.INVALID_LDAP_QUERY_TEMPLATE.value,
+                LdapStatuses.INVALID_QUERY_TEMPLATE.value,
                 scope="unit",
                 component=self.dependent.name,
             )

--- a/single_kernel_mongo/managers/ldap.py
+++ b/single_kernel_mongo/managers/ldap.py
@@ -127,7 +127,7 @@ class LDAPManager(Object, ManagerStatusProtocol):
 
                 if state == LdapState.LDAP_SERVERS_MISMATCH:
                     raise InvalidLdapHashError(
-                        "mongos and config-server not integrated with the same ldap server."
+                        "mongos and config-server are not integrated with the same ldap server."
                     )
 
     def clean_ldap_credentials_and_uri(self) -> None:
@@ -232,26 +232,26 @@ class LDAPManager(Object, ManagerStatusProtocol):
                     f"`juju integrate {self.state.ldap_relation.app.name}:send-ca-cert"  # type: ignore[union-attr]
                     f"{self.charm.app.name}:{ExternalRequirerRelations.LDAP_CERT}`"
                 )
-                return [LdapStatuses.TLS_REQUIRED.value]
+                return [LdapStatuses.MISSING_CERT_TRANSFERT_REL.value]
             case LdapState.MISSING_LDAP_REL:
                 logger.info(
                     "Integrate glauth with ldap using"
                     f"`juju integrate {self.state.ldap_cert_relation.app.name}:ldap {self.charm.app.name}:{ExternalRequirerRelations.LDAP}`"  # type: ignore[union-attr]
                 )
-                return [LdapStatuses.LDAP_REQUIRED.value]
+                return [LdapStatuses.MISSING_LDAP_REL.value]
             case LdapState.LDAP_SERVERS_MISMATCH:
                 logger.error(
                     "Config Server and mongos integrations with LDAP have a different checksum."
                     "This usually means they are not integrated with the same LDAP application."
                 )
-                return [LdapStatuses.LDAP_SERVERS_MISMATCH.value]
+                return [LdapStatuses.SERVERS_MISMATCH.value]
             case LdapState.WAITING_FOR_DATA:
                 return [LdapStatuses.WAITING_FOR_DATA.value]
             case LdapState.WAITING_FOR_CERTS:
                 return [LdapStatuses.WAITING_FOR_CERTS.value]
             case LdapState.WAITING_FOR_LDAP_DATA:
                 logger.info("Waiting for LDAP data.")
-                return [LdapStatuses.WAITING_FOR_LDAP_DATA.value]
+                return [LdapStatuses.WAITING_FOR_DATA.value]
             case LdapState.MISSING_BASE_DN:
                 return [LdapStatuses.MISSING_BASE_DN.value]
             case LdapState.MISSING_CERT_CHAIN:

--- a/single_kernel_mongo/managers/ldap.py
+++ b/single_kernel_mongo/managers/ldap.py
@@ -211,11 +211,11 @@ class LDAPManager(Object, ManagerStatusProtocol):
         ldap_certificate_integration_status = self.state.ldap.ldap_certs_ready()
         match (ldap_relation_status, ldap_certificate_integration_status):
             case False, False:
-                return LdapState.WAITING_FOR_DATA
+                return LdapState.WAITING_FOR_DATA_AND_CERTS
             case True, False:
                 return LdapState.WAITING_FOR_CERTS
             case False, True:
-                return LdapState.WAITING_FOR_LDAP_DATA
+                return LdapState.WAITING_FOR_DATA
             case _:
                 return self.get_ldap_connection_status()
 
@@ -249,9 +249,9 @@ class LDAPManager(Object, ManagerStatusProtocol):
                 return [LdapStatuses.WAITING_FOR_DATA.value]
             case LdapState.WAITING_FOR_CERTS:
                 return [LdapStatuses.WAITING_FOR_CERTS.value]
-            case LdapState.WAITING_FOR_LDAP_DATA:
+            case LdapState.WAITING_FOR_DATA_AND_CERTS:
                 logger.info("Waiting for LDAP data.")
-                return [LdapStatuses.WAITING_FOR_DATA.value]
+                return [LdapStatuses.WAITING_FOR_DATA_AND_CERTS.value]
             case LdapState.MISSING_BASE_DN:
                 return [LdapStatuses.MISSING_BASE_DN.value]
             case LdapState.MISSING_CERT_CHAIN:

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -1026,12 +1026,12 @@ class MongoDBOperator(OperatorProtocol, Object):
 
         if not is_valid_ldapusertodnmapping(self.config.ldap_user_to_dn_mapping):
             logger.error("Invalid LDAP Config - Please refer to the config option description.")
-            charm_statuses.append(LdapStatuses.INVALID_LDAP_USER_MAPPING.value)
+            charm_statuses.append(LdapStatuses.INVALID_USER_MAPPING.value)
         if not is_valid_ldap_options(
             self.config.ldap_user_to_dn_mapping, self.config.ldap_query_template
         ):
             logger.info("Invalid LDAP Config - Please refer to the config option description.")
-            charm_statuses.append(LdapStatuses.INVALID_LDAP_QUERY_TEMPLATE.value)
+            charm_statuses.append(LdapStatuses.INVALID_QUERY_TEMPLATE.value)
 
         if not self.workload.workload_present:
             return [CharmStatuses.MONGODB_NOT_INSTALLED.value]

--- a/tests/integration/helpers/common.py
+++ b/tests/integration/helpers/common.py
@@ -850,8 +850,12 @@ async def check_status_detail(ops_test: OpsTest, app_name: str, status: str, mes
         # juju messes up the string formatting here.
         unit_statuses = json.loads(result["unit"])
 
-        assert unit_statuses[0]["Status"].lower() == status
-        assert unit_statuses[0]["Message"] == message
+        assert (
+            unit_statuses[0]["Status"].lower() == status
+        ), f"unit {unit.name} status is `{unit_statuses[0]['Status'].lower()}`, expected `{status}`"
+        assert (
+            unit_statuses[0]["Message"] == message
+        ), f"unit {unit.name} status message is `{unit_statuses[0]['Message']}`, expected `{message}`"
 
 
 def is_relation_joined(ops_test: OpsTest, endpoint_one: str, endpoint_two: str) -> bool:

--- a/tests/integration/helpers/common.py
+++ b/tests/integration/helpers/common.py
@@ -808,7 +808,7 @@ async def check_all_units_blocked_with_status(
         if status:
             assert (
                 status in unit.workload_status.message
-            ), f"unit {unit.name} not in blocked state, in {unit.workload_status.value}"
+            ), f"unit {unit.name} status is `{unit.workload_status.message}`, expected `{status}`"
 
 
 async def wait_for_mongodb_units_blocked(

--- a/tests/integration/mongodb/ldap/test_ldap.py
+++ b/tests/integration/mongodb/ldap/test_ldap.py
@@ -13,6 +13,7 @@ from yaml import safe_load
 from ...helpers.common import (
     ProcessError,
     check_or_scale_app,
+    check_status_detail,
     deploy_charm,
     execute_on_mongod,
     get_app_name,
@@ -97,8 +98,15 @@ async def test_integrate_ldap_only(ops_test: OpsTest, substrate: Substrate):
         ops_test,
         substrate,
         db_app_name,
-        status="TLS is mandatory for LDAP transport.",
+        status="Missing ldap-certificate-transfer relation.",
         timeout=300,
+    )
+
+    await check_status_detail(
+        ops_test,
+        db_app_name,
+        status="blocked",
+        message="Missing ldap-certificate-transfer relation.",
     )
 
 
@@ -186,11 +194,11 @@ async def test_ldap_user_to_dn_mapping(ops_test: OpsTest, substrate: Substrate):
         assert (
             configuration["security"]["ldap"].get("userToDNMapping", "")
             == '[{"match": "([^@]+)@([^@]+)", "substitution": "cn={0},ou={1},ou=users,dc=glauth,dc=com"}]'
-        ), "Invalid userToDNMapping."
+        ), "Invalid LDAP to DN mapping config."
         assert (
             configuration["security"]["ldap"]["authz"].get("queryTemplate", "")
             == "dc=glauth,dc=com??sub?(&(objectClass=posixGroup)(uniqueMember={USER}))"
-        ), "Invalid ldap Query Template."
+        ), "Invalid LDAP query template."
 
     uri = await generate_mongodb_ldap_client(
         ops_test,
@@ -231,8 +239,14 @@ async def test_remove_ldap_goes_to_blocked(ops_test: OpsTest, substrate: Substra
         ops_test,
         substrate,
         db_app_name,
-        status="GLauth TLS is integrated but LDAP is not.",
+        status="ldap relation is missing between LDAP application and this application.",
         timeout=300,
+    )
+    await check_status_detail(
+        ops_test,
+        db_app_name,
+        status="blocked",
+        message="ldap relation is missing between LDAP application and this application.",
     )
 
     # John should not be able to log in now.
@@ -278,7 +292,7 @@ async def test_remove_ldap_certs_goes_to_blocked(ops_test: OpsTest, substrate: S
         ops_test,
         substrate,
         db_app_name,
-        status="TLS is mandatory for LDAP transport.",
+        status="Missing ldap-certificate-transfer relation.",
         timeout=300,
     )
 

--- a/tests/integration/mongodb/ldap/test_sharding_ldap.py
+++ b/tests/integration/mongodb/ldap/test_sharding_ldap.py
@@ -13,6 +13,7 @@ from yaml import safe_load
 from ...helpers.common import (
     DEPLOYMENT_TIMEOUT,
     ProcessError,
+    check_status_detail,
     execute_on_mongod,
     wait_for_mongodb_units_blocked,
 )
@@ -97,8 +98,14 @@ async def test_integrate_ldap_only(ops_test: OpsTest, substrate: Substrate):
         ops_test,
         substrate,
         db_app_name,
-        status="TLS is mandatory for LDAP transport.",
+        status="Missing ldap-certificate-transfer relation.",
         timeout=300,
+    )
+    await check_status_detail(
+        ops_test,
+        db_app_name,
+        status="blocked",
+        message="Missing ldap-certificate-transfer relation.",
     )
 
 
@@ -200,8 +207,14 @@ async def test_remove_ldap_goes_to_blocked(ops_test: OpsTest, substrate: Substra
         ops_test,
         substrate,
         db_app_name,
-        status="GLauth TLS is integrated but LDAP is not.",
+        status="ldap relation is missing between LDAP application and this application.",
         timeout=300,
+    )
+    await check_status_detail(
+        ops_test,
+        db_app_name,
+        status="blocked",
+        message="ldap relation is missing between LDAP application and this application.",
     )
 
 

--- a/tests/integration/mongos/ldap/test_ldap.py
+++ b/tests/integration/mongos/ldap/test_ldap.py
@@ -12,6 +12,7 @@ from ...helpers.common import (
     DATA_INTEGRATOR_APP_NAME,
     DEPLOYMENT_TIMEOUT,
     check_or_scale_app,
+    check_status_detail,
     deploy_charm,
     execute_on_mongod,
     get_app_name,
@@ -161,9 +162,15 @@ async def test_glauth_only_integrated_with_mongos(ops_test: OpsTest, substrate: 
         ops_test,
         substrate,
         app_name,
-        status="TLS is mandatory for LDAP transport.",
+        status="Missing ldap-certificate-transfer relation.",
         timeout=300,
         subordinate=(substrate == "lxd"),
+    )
+    await check_status_detail(
+        ops_test,
+        app_name,
+        status="blocked",
+        message="Missing ldap-certificate-transfer relation.",
     )
     await ops_test.model.integrate(
         f"{LDAP_CERT_OFFER}:send-ca-cert", f"{app_name}:ldap-certificate-transfer"
@@ -173,9 +180,15 @@ async def test_glauth_only_integrated_with_mongos(ops_test: OpsTest, substrate: 
         ops_test,
         substrate,
         app_name,
-        status="mongos and config-server not integrated with the same ldap server.",
+        status="mongos and config-server are not integrated with the same LDAP server.",
         timeout=600,
         subordinate=(substrate == "lxd"),
+    )
+    await check_status_detail(
+        ops_test,
+        app_name,
+        status="blocked",
+        message="mongos and config-server are not integrated with the same LDAP server.",
     )
 
 
@@ -189,8 +202,14 @@ async def test_glauth_fully_integrated(ops_test: OpsTest, substrate: Substrate):
         ops_test,
         substrate,
         CONFIG_SERVER_APP_NAME,
-        status="TLS is mandatory for LDAP transport.",
+        status="Missing ldap-certificate-transfer relation.",
         timeout=300,
+    )
+    await check_status_detail(
+        ops_test,
+        CONFIG_SERVER_APP_NAME,
+        status="blocked",
+        message="Missing ldap-certificate-transfer relation.",
     )
 
     await ops_test.model.integrate(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -498,7 +498,7 @@ def test_on_config_changed_invalid_ldap_user_to_dn_mapping(harness):
     statuses = harness.charm.operator.state.statuses.get(
         scope=Scope.UNIT, component=harness.charm.operator.name
     )
-    assert statuses[0] == LdapStatuses.INVALID_LDAP_USER_MAPPING.value
+    assert statuses[0] == LdapStatuses.INVALID_USER_MAPPING.value
 
 
 def test_on_config_changed_invalid_ldap_query_template_provided_user(harness):
@@ -521,7 +521,7 @@ def test_on_config_changed_invalid_ldap_query_template_provided_user(harness):
     statuses = harness.charm.operator.state.statuses.get(
         scope=Scope.UNIT, component=harness.charm.operator.name
     )
-    assert statuses[0] == LdapStatuses.INVALID_LDAP_QUERY_TEMPLATE.value
+    assert statuses[0] == LdapStatuses.INVALID_QUERY_TEMPLATE.value
 
 
 def test_on_config_changed_invalid_ldap_query_template_user(harness):
@@ -536,7 +536,7 @@ def test_on_config_changed_invalid_ldap_query_template_user(harness):
     statuses = harness.charm.operator.state.statuses.get(
         scope=Scope.UNIT, component=harness.charm.operator.name
     )
-    assert statuses[0] == LdapStatuses.INVALID_LDAP_QUERY_TEMPLATE.value
+    assert statuses[0] == LdapStatuses.INVALID_QUERY_TEMPLATE.value
 
 
 def test_on_config_changed_valid_ldap_query_template(harness, mocker):

--- a/tests/unit/test_ldap_manager.py
+++ b/tests/unit/test_ldap_manager.py
@@ -131,14 +131,14 @@ def test_ldap_get_status(harness: Harness[MongoTestCharm], mocker, mock_fs_inter
 
     assert as_status(
         harness.charm.operator.ldap_manager.get_statuses(scope=Scope.UNIT, recompute=True)[0]
-    ) == BlockedStatus("Cannot integrate LDAP with shard.")
+    ) == BlockedStatus("The ldap relation cannot be used by shards.")
 
     # Case 3, correct role, but missing ldap_cert_relation
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION
 
     assert as_status(
         harness.charm.operator.ldap_manager.get_statuses(scope=Scope.UNIT, recompute=True)[0]
-    ) == BlockedStatus("TLS is mandatory for LDAP transport.")
+    ) == BlockedStatus("Missing ldap-certificate-transfer relation.")
 
     # Case 4: Both relations good but not valid data.
     ldap_cert_relation_id = harness.add_relation(
@@ -147,7 +147,7 @@ def test_ldap_get_status(harness: Harness[MongoTestCharm], mocker, mock_fs_inter
 
     assert as_status(
         harness.charm.operator.ldap_manager.get_statuses(scope=Scope.UNIT, recompute=True)[0]
-    ) == WaitingStatus("Waiting for both LDAP data and Glauth certificates.")
+    ) == WaitingStatus("Waiting for LDAP data and certificates.")
 
     # Case 5: We received data from LDAP integration but not from cert integration
     harness.update_relation_data(
@@ -171,7 +171,7 @@ def test_ldap_get_status(harness: Harness[MongoTestCharm], mocker, mock_fs_inter
 
     assert as_status(
         harness.charm.operator.ldap_manager.get_statuses(scope=Scope.UNIT, recompute=True)[0]
-    ) == WaitingStatus("Waiting for Glauth certificates.")
+    ) == WaitingStatus("Waiting for LDAP certificates...")
 
     # Case 6: We received data from both integrations
     harness.add_relation_unit(ldap_cert_relation_id, "glauth-k8s/0")
@@ -329,7 +329,7 @@ def test_ldap_full_integration_cycle(
 
     harness.evaluate_status()
 
-    assert harness.model.unit.status == BlockedStatus("TLS is mandatory for LDAP transport.")
+    assert harness.model.unit.status == BlockedStatus("Missing ldap-certificate-transfer relation.")
 
     ldap_cert_relation_id = harness.add_relation(
         ExternalRequirerRelations.LDAP_CERT.value, "glauth-k8s"
@@ -448,7 +448,7 @@ def test_ldaps_mongos_invalid_hash(
     mongos_harness.evaluate_status()
 
     assert mongos_harness.model.unit.status == BlockedStatus(
-        "mongos and config-server not integrated with the same ldap server."
+        "mongos and config-server are not integrated with the same LDAP server."
     )
 
     data = Path("tests/unit/data/mongos.conf").read_text().splitlines()
@@ -477,7 +477,7 @@ def test_ldaps_mongos_invalid_hash(
 
     assert as_status(
         mongos_harness.charm.operator.ldap_manager.get_statuses(scope=Scope.UNIT, recompute=True)[0]
-    ) == BlockedStatus("mongos and config-server not integrated with the same ldap server.")
+    ) == BlockedStatus("mongos and config-server are not integrated with the same LDAP server.")
 
     mocker.patch(
         "single_kernel_mongo.managers.ldap.LDAPManager.get_ldap_connection_status",

--- a/tests/unit/test_ldap_manager.py
+++ b/tests/unit/test_ldap_manager.py
@@ -208,7 +208,7 @@ def test_ldap_get_status(harness: Harness[MongoTestCharm], mocker, mock_fs_inter
     harness.charm.operator.state.ldap.clean_databag()
     assert as_status(
         harness.charm.operator.ldap_manager.get_statuses(scope=Scope.UNIT, recompute=True)[0]
-    ) == WaitingStatus("Missing LDAP data from Glauth.")
+    ) == WaitingStatus("Waiting for LDAP data...")
 
 
 def test_ldap_on_remove_clean_data(harness: Harness[MongoTestCharm], mocker, mock_fs_interactions):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷 Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update
- [ ] Tooling and CI changes
- [ ] Dependencies upgrade or change

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and scope of this PR (what)
  - the impacted components (where, often match conventional commit scope)
  - explanation/algorithm if require (how)
-->

- Extend the status in `LdapStatuses`.
  - Make the short_message shorter than 40 characters.
  - Add check and action when judged necessary
  - Make the variable names, messages and vocabulary consistent

- Improve the assert message for failure on blocked status for units

## 📑 Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Either the associated JIRA reference or a paragraph. -->

This PR improves the quality of the message displayed to the operator about the state of the charms

## 🧪 How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](../blob/6/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
