### PR TITLE
patch: extend mongod statuses

### DIFF
--- a/single_kernel_mongo/config/statuses.py
+++ b/single_kernel_mongo/config/statuses.py
@@ -290,28 +290,34 @@ class ShardStatuses(Enum):
 class MongodStatuses(Enum):
     """MongoD statuses."""
 
+    ACTIVE_IDLE = StatusObject(status="active", message="")
+    PRIMARY = StatusObject(status="active", message="Primary.")
+    SECONDARY = StatusObject(status="active", message="")
+
+    ADDING_MEMBER = StatusObject(status="maintenance", message="Adding member...")
+    REMOVING_MEMBER = StatusObject(status="maintenance", message="Removing member...")
+    SYNCING_MEMBER = StatusObject(status="maintenance", message="Syncing member...")
     WAITING_REPL_SET_INIT = StatusObject(
         status="waiting", message="Waiting for replica set initialisation..."
     )
     WAITING_RECONFIG = StatusObject(
-        status="waiting", message="Waiting to reconfigure replica set..."
+        status="waiting", message="Waiting for replica set reconfiguration..."
     )
     WAITING_ELECTION = StatusObject(status="waiting", message="Waiting for primary re-election...")
-    WAITING_RECONNECT = StatusObject(status="waiting", message="Waiting to reconnect to unit...")
-    MEMBER_BEING_ADDED = StatusObject(status="waiting", message="Member being added...")
-    MEMBER_REMOVING = StatusObject(status="waiting", message="Member is removing...")
-    MEMBER_SYNCING = StatusObject(status="waiting", message="Member is syncing...")
-    PRIMARY = StatusObject(status="active", message="Primary.")
-    SECONDARY = StatusObject(status="active", message="")
-
-    ACTIVE_IDLE = StatusObject(status="active", message="")
-
-    MISSING_CREDENTIALS = StatusObject(status="waiting", message="Missing credentials for mongo")
+    WAITING_RECONNECTION = StatusObject(
+        status="maintenance", message="Waiting for reconnection to mongo..."
+    )
+    WAITING_CREDENTIALS = StatusObject(status="waiting", message="Waiting for mongo credentials...")
 
     @staticmethod
     def replset_status(status: str):
         """When we have an unexpected replica set status."""
-        return StatusObject(status="blocked", message=status)
+        return StatusObject(
+            status="blocked",
+            message=status,
+            short_message="Unexpected error found in replica set.",
+            action="Check logs for more information.",
+        )
 
 
 class UpgradeStatuses(Enum):

--- a/single_kernel_mongo/managers/mongo.py
+++ b/single_kernel_mongo/managers/mongo.py
@@ -521,15 +521,15 @@ class MongoManager(Object, ManagerStatusProtocol):
 
             match replica_status:
                 case "":
-                    return [MongodStatuses.MEMBER_BEING_ADDED.value]
+                    return [MongodStatuses.ADDING_MEMBER.value]
                 case "PRIMARY":
                     charm_statuses.append(MongodStatuses.PRIMARY.value)
                 case "SECONDARY":
                     charm_statuses.append(MongodStatuses.SECONDARY.value)
                 case "STARTUP" | "STARTUP2" | "ROLLBACK" | "RECOVERING":
-                    return [MongodStatuses.MEMBER_SYNCING.value]
+                    return [MongodStatuses.SYNCING_MEMBER.value]
                 case "REMOVED":
-                    return [MongodStatuses.MEMBER_REMOVING.value]
+                    return [MongodStatuses.REMOVING_MEMBER.value]
                 case _:
                     return [MongodStatuses.replset_status(replica_status)]
 
@@ -544,13 +544,13 @@ class MongoManager(Object, ManagerStatusProtocol):
             # AutoReconnect is raised when a connection to the database is lost and an attempt to
             # auto-reconnect will be made by pymongo.
             logger.debug("Got error: %s, while checking replica set status", str(e))
-            return [MongodStatuses.WAITING_RECONNECT.value]
+            return [MongodStatuses.WAITING_RECONNECTION.value]
         except OperationFailure as e:
             logger.warning("Authentication Failed: %s", e, exc_info=True)
             return [MongodStatuses.WAITING_RECONFIG.value]
         except MissingCredentialsError as e:
             logger.warning("Missing credentials: %s", e, exc_info=True)
-            return [MongodStatuses.MISSING_CREDENTIALS]
+            return [MongodStatuses.WAITING_CREDENTIALS.value]
 
     def get_leader_statuses(self) -> list[StatusObject]:
         """Returns statuses that juju leader can retrieve for mongo."""

--- a/tests/unit/test_status_handler.py
+++ b/tests/unit/test_status_handler.py
@@ -4,7 +4,7 @@
 import pytest
 from data_platform_helpers.advanced_statuses.utils import as_status
 from ops import MaintenanceStatus
-from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
+from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
 from pymongo.errors import AutoReconnect, ServerSelectionTimeoutError
 
@@ -26,14 +26,14 @@ from tests.charms.mongos_test_charm.src.charm import MongosTestCharm
 @pytest.mark.parametrize(
     ("replset_status", "expected_status"),
     (
-        ({}, WaitingStatus("Member being added...")),
+        ({}, MaintenanceStatus("Adding member...")),
         ({"10.0.0.10": "PRIMARY"}, ActiveStatus("Primary.")),
         ({"10.0.0.10": "SECONDARY"}, ActiveStatus("")),
-        ({"10.0.0.10": "STARTUP"}, WaitingStatus("Member is syncing...")),
-        ({"10.0.0.10": "STARTUP2"}, WaitingStatus("Member is syncing...")),
-        ({"10.0.0.10": "ROLLBACK"}, WaitingStatus("Member is syncing...")),
-        ({"10.0.0.10": "RECOVERING"}, WaitingStatus("Member is syncing...")),
-        ({"10.0.0.10": "REMOVED"}, WaitingStatus("Member is removing...")),
+        ({"10.0.0.10": "STARTUP"}, MaintenanceStatus("Syncing member...")),
+        ({"10.0.0.10": "STARTUP2"}, MaintenanceStatus("Syncing member...")),
+        ({"10.0.0.10": "ROLLBACK"}, MaintenanceStatus("Syncing member...")),
+        ({"10.0.0.10": "RECOVERING"}, MaintenanceStatus("Syncing member...")),
+        ({"10.0.0.10": "REMOVED"}, MaintenanceStatus("Removing member...")),
         ({"10.0.0.10": "ERROR"}, BlockedStatus("ERROR")),
     ),
 )
@@ -59,25 +59,28 @@ def test_mongo_get_status_no_error_lxd(
 @pytest.mark.parametrize(
     ("replset_status", "expected_status"),
     (
-        ({}, WaitingStatus("Member being added...")),
+        ({}, MaintenanceStatus("Adding member...")),
         ({"mongodb-k8s-0.mongodb-k8s-endpoints": "PRIMARY"}, ActiveStatus("Primary.")),
         ({"mongodb-k8s-0.mongodb-k8s-endpoints": "SECONDARY"}, ActiveStatus("")),
-        ({"mongodb-k8s-0.mongodb-k8s-endpoints": "STARTUP"}, WaitingStatus("Member is syncing...")),
+        (
+            {"mongodb-k8s-0.mongodb-k8s-endpoints": "STARTUP"},
+            MaintenanceStatus("Syncing member..."),
+        ),
         (
             {"mongodb-k8s-0.mongodb-k8s-endpoints": "STARTUP2"},
-            WaitingStatus("Member is syncing..."),
+            MaintenanceStatus("Syncing member..."),
         ),
         (
             {"mongodb-k8s-0.mongodb-k8s-endpoints": "ROLLBACK"},
-            WaitingStatus("Member is syncing..."),
+            MaintenanceStatus("Syncing member..."),
         ),
         (
             {"mongodb-k8s-0.mongodb-k8s-endpoints": "RECOVERING"},
-            WaitingStatus("Member is syncing..."),
+            MaintenanceStatus("Syncing member..."),
         ),
         (
             {"mongodb-k8s-0.mongodb-k8s-endpoints": "REMOVED"},
-            WaitingStatus("Member is removing..."),
+            MaintenanceStatus("Removing member..."),
         ),
         ({"mongodb-k8s-0.mongodb-k8s-endpoints": "ERROR"}, BlockedStatus("ERROR")),
     ),
@@ -107,7 +110,7 @@ def test_mongo_get_status_no_error_microk8s(
             ServerSelectionTimeoutError,
             MongodStatuses.WAITING_ELECTION.value,
         ),
-        (AutoReconnect, MongodStatuses.WAITING_RECONNECT.value),
+        (AutoReconnect, MongodStatuses.WAITING_RECONNECTION.value),
     ),
 )
 def test_mongo_get_status_with_error(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷 Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update
- [ ] Tooling and CI changes
- [ ] Dependencies upgrade or change

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and scope of this PR (what)
  - the impacted components (where, often match conventional commit scope)
  - explanation/algorithm if require (how)
-->

Extend the status in `MongodStatuses`
- Make the short_message shorter than 40 characters.
- Add check and action when judged necessary
- Make the variable names, messages and vocabulary consistent

Some status in seemed more like a `maintenance` than `waiting`. WDYT?

## 📑 Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Either the associated JIRA reference or a paragraph. -->

This PR improves the quality of the message displayed to the operator about the state of the charms

## 🧪 How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Locally + update UT and integration tests

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](../blob/6/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
