### PR TITLE
patch: extend upgrade statuses

### DIFF
--- a/single_kernel_mongo/config/statuses.py
+++ b/single_kernel_mongo/config/statuses.py
@@ -317,21 +317,23 @@ class MongodStatuses(Enum):
 class UpgradeStatuses(Enum):
     """Upgrade statuses."""
 
-    UNHEALTHY_UPGRADE = StatusObject(
-        status="blocked", message="Unhealthy after refresh.", approved_critical_component=True
-    )
-    INCOMPATIBLE_UPGRADE = StatusObject(
-        status="blocked",
-        message="Refresh incompatible. Rollback to previous revision with `juju refresh`",
-        approved_critical_component=True,
-    )
     ACTIVE_IDLE = StatusObject(status="active", message="")
     WAITING_POST_UPGRADE_STATUS = StatusObject(
         status="waiting", message="Waiting for post upgrade checks..."
     )
+    UNHEALTHY_UPGRADE = StatusObject(
+        status="blocked",
+        message="Unhealthy after refresh. Rollback to previous revision with `juju refresh`.",
+        approved_critical_component=True,
+    )
+    INCOMPATIBLE_UPGRADE = StatusObject(
+        status="blocked",
+        message="Refresh incompatible. Rollback to previous revision with `juju refresh`.",
+        approved_critical_component=True,
+    )
     REFRESH_IN_PROGRESS = StatusObject(
         status="maintenance",
-        message="Refreshing. To rollback, `juju refresh` to the previous revision",
+        message="Refreshing...",
         approved_critical_component=True,
     )
 
@@ -348,7 +350,7 @@ class UpgradeStatuses(Enum):
             status="active",
             message=f"MongoDB {unit_workload_version} running; "
             f"Snap revision {unit_workload_container_version}{outdated_str}; "
-            f"Charm revision {current_versions}",
+            f"Charm revision {current_versions}.",
             approved_critical_component=True,
         )
 
@@ -360,7 +362,7 @@ class UpgradeStatuses(Enum):
         outdated_str = " (restart pending)" if outdated else ""
         return StatusObject(
             status="active",
-            message=f"MongoDB {workload_version} running{outdated_str};  Charm revision {charm_version}",
+            message=f"MongoDB {workload_version} running{outdated_str};  Charm revision {charm_version}.",
             approved_critical_component=True,
         )
 
@@ -371,7 +373,7 @@ class UpgradeStatuses(Enum):
         """Returns refreshing status."""
         return StatusObject(
             status="blocked",
-            message=f"Refreshing. {resume_string}To rollback, `juju refresh` to last revision",
+            message=f"Refreshing. {resume_string}To rollback, `juju refresh` to last revision.",
             approved_critical_component=True,
         )
 

--- a/single_kernel_mongo/config/statuses.py
+++ b/single_kernel_mongo/config/statuses.py
@@ -360,6 +360,7 @@ class UpgradeStatuses(Enum):
     REFRESH_IN_PROGRESS = StatusObject(
         status="maintenance",
         message="Refreshing...",
+        action="To rollback, run `juju refresh` to the previous revision.",
         approved_critical_component=True,
     )
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷 Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update
- [ ] Tooling and CI changes
- [ ] Dependencies upgrade or change

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and scope of this PR (what)
  - the impacted components (where, often match conventional commit scope)
  - explanation/algorithm if require (how)
-->

Extend the status in `UpgradeStatuses`
- Make the short_message shorter than 40 characters.
- Add check and action when judged necessary
- Make the variable names, messages and vocabulary consistent

## 📑 Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Either the associated JIRA reference or a paragraph. -->

This PR improves the quality of the message displayed to the operator about the state of the charms

## 🧪 How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Existing tests

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](../blob/6/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
