### PR TITLE
patch: extend sharding statuses

### DIFF
--- a/single_kernel_mongo/config/statuses.py
+++ b/single_kernel_mongo/config/statuses.py
@@ -230,36 +230,66 @@ class ConfigServerStatuses(Enum):
 class ShardStatuses(Enum):
     """Shard statuses."""
 
-    REQUIRES_TLS = StatusObject(status="blocked", message="Shard requires TLS to be enabled.")
-    REQUIRES_NO_TLS = StatusObject(
-        status="blocked", message="Shard has TLS enabled, but config-server does not."
-    )
-    CA_MISMATCH = StatusObject(
-        status="blocked", message="Shard CA and Config-Server CA don't match."
-    )
-
-    MISSING_CONF_SERVER_REL = StatusObject(
-        status="blocked", message="Missing relation to config-server."
-    )
+    ACTIVE_IDLE = StatusObject(status="active", message="")
     SHARD_DRAINED = StatusObject(
-        status="active", message="Shard drained from cluster, ready for removal."
+        status="active",
+        message="Shard drained from cluster, ready for removal.",
     )
-    WAITING_TO_REMOVE = StatusObject(
-        status="waiting", message="Waiting for config-server to remove shard", running="blocking"
+    ADDING_TO_CLUSTER = StatusObject(
+        status="maintenance", message="Adding shard to config-server..."
     )
     SYNCING_PASSWORDS = StatusObject(
-        status="waiting", message="Waiting to sync passwords across the cluster..."
+        status="waiting",
+        message="Waiting for passwords to be synced across the cluster...",
+        short_message="Syncing passwords...",
     )
-    ADDING_TO_CLUSTER = StatusObject(status="maintenance", message="Adding shard to config-server")
-    SHARD_NOT_AWARE = StatusObject(status="blocked", message="Shard is not yet shard aware.")
-    ACTIVE_IDLE = StatusObject(status="active", message="")
+    SHARD_NOT_AWARE = StatusObject(
+        status="waiting",
+        message="Shard is not yet in aware state.",
+    )
+    MISSING_TLS_REL = StatusObject(
+        status="blocked",
+        message="TLS must be enabled in the shard, since it is enabled in the related config-server.",
+        short_message="Missing certificates relation.",
+        check="Relation validation failed.",
+        action="Align the TLS configuration in all the cluster components: add the certificates relation to the shard.",
+    )
+    INVALID_TLS_REL = StatusObject(
+        status="blocked",
+        message="TLS must be disabled in shard, since it is disabled in the related config-server.",
+        short_message="Invalid certificates relation.",
+        check="Relation validation failed.",
+        action="Align the TLS configuration in all the cluster components: remove the certificates relation from the shard.",
+    )
+    CA_MISMATCH = StatusObject(
+        status="blocked",
+        message="Shard CA and config-server CA don't match.",
+        short_message="CA mismatch.",
+        check="TLS configuration validation failed.",
+        action="Verify the certificates relations. Use the same CA for all the cluster components.",
+    )
+    MISSING_SHARDING_REL = StatusObject(
+        status="blocked",
+        message="Missing relation to config-server.",
+        check="Relation validation failed.",
+        action="Add the sharding relation (shards interface) to the shard.",
+    )
 
     # RUNNING status:
     DRAINING_SHARD = StatusObject(
         status="maintenance", message="Draining shard from cluster...", running="blocking"
     )
+    WAITING_TO_REMOVE = StatusObject(
+        status="waiting",
+        message="Waiting for config-server to remove shard...",
+        short_message="Removing shard...",
+        running="blocking",
+    )
     FAILED_TO_DRAIN = StatusObject(
-        status="blocked", message="Failed to drain shard from cluster", running="blocking"
+        status="blocked",
+        message="Failed to drain shard from cluster",
+        action="Check logs for more information.",
+        running="blocking",
     )
 
     @staticmethod
@@ -273,6 +303,9 @@ class ShardStatuses(Enum):
         return StatusObject(
             status="blocked",
             message=f"Charm revision ({current_charms_version}{local_identifier}) is not up-to date with config-server ({config_server_revision}{remote_local_identifier}).",
+            short_message="Charm revision mismatch.",
+            check="Charm version validation failed.",
+            action="Use `juju refresh` to upgrade the charm revision.",
         )
 
     @staticmethod
@@ -284,6 +317,9 @@ class ShardStatuses(Enum):
         return StatusObject(
             status="blocked",
             message=f"Charm revision ({current_charms_version}{local_identifier}) is not up-to date with config-server.",
+            short_message="Charm revision mismatch.",
+            check="Charm version validation failed.",
+            action="Use `juju refresh` to upgrade the charm revision.",
         )
 
 

--- a/single_kernel_mongo/managers/sharding.py
+++ b/single_kernel_mongo/managers/sharding.py
@@ -17,7 +17,6 @@ from typing import TYPE_CHECKING
 from data_platform_helpers.advanced_statuses.models import StatusObject
 from data_platform_helpers.advanced_statuses.protocol import ManagerStatusProtocol
 from data_platform_helpers.advanced_statuses.types import Scope
-from ops import StatusBase
 from ops.framework import Object
 from ops.model import (
     Relation,
@@ -545,29 +544,10 @@ class ShardManager(Object, ManagerStatusProtocol):
                 "Config-server never set up, no need to process broken event."
             )
 
-        shard_has_tls, config_server_has_tls = self.tls_status()
-        match (shard_has_tls, config_server_has_tls):
-            case False, True:
-                self.state.statuses.add(
-                    ShardStatuses.MISSING_TLS_REL.value, scope="unit", component=self.name
-                )
-                raise DeferrableFailedHookChecksError(
-                    "Config-Server uses TLS but shard does not. Please synchronise encryption method."
-                )
-            case True, False:
-                self.state.statuses.add(
-                    ShardStatuses.INVALID_TLS_REL.value, scope="unit", component=self.name
-                )
-                raise DeferrableFailedHookChecksError(
-                    "Shard uses TLS but config-server does not. Please synchronise encryption method."
-                )
-            case _:
-                pass
-
-        if not self.is_ca_compatible():
-            raise DeferrableFailedHookChecksError(
-                "Shard is integrated to a different CA than the config server. Please use the same CA for all cluster components.",
-            )
+        if tls_status := self.get_tls_status():
+            self.state.statuses.add(tls_status, scope="unit", component=self.name)
+            exception_msg = f"{tls_status.message} {tls_status.action}"
+            raise DeferrableFailedHookChecksError(exception_msg)
 
         if is_leaving:
             self.dependent.assert_proceed_on_broken_event(relation)
@@ -956,7 +936,7 @@ class ShardManager(Object, ManagerStatusProtocol):
 
         return False
 
-    def get_tls_status(self) -> StatusBase | None:
+    def get_tls_status(self) -> StatusObject | None:
         """Returns the TLS status of the sharded deployment."""
         shard_has_tls, config_server_has_tls = self.tls_status()
         match (shard_has_tls, config_server_has_tls):

--- a/single_kernel_mongo/managers/sharding.py
+++ b/single_kernel_mongo/managers/sharding.py
@@ -549,14 +549,14 @@ class ShardManager(Object, ManagerStatusProtocol):
         match (shard_has_tls, config_server_has_tls):
             case False, True:
                 self.state.statuses.add(
-                    ShardStatuses.REQUIRES_TLS.value, scope="unit", component=self.name
+                    ShardStatuses.MISSING_TLS_REL.value, scope="unit", component=self.name
                 )
                 raise DeferrableFailedHookChecksError(
                     "Config-Server uses TLS but shard does not. Please synchronise encryption method."
                 )
             case True, False:
                 self.state.statuses.add(
-                    ShardStatuses.REQUIRES_NO_TLS.value, scope="unit", component=self.name
+                    ShardStatuses.INVALID_TLS_REL.value, scope="unit", component=self.name
                 )
                 raise DeferrableFailedHookChecksError(
                     "Shard uses TLS but config-server does not. Please synchronise encryption method."
@@ -578,7 +578,7 @@ class ShardManager(Object, ManagerStatusProtocol):
         self.state.unit_peer_data.drained = False
 
         self.state.statuses.delete(
-            ShardStatuses.MISSING_CONF_SERVER_REL.value, scope="unit", component=self.name
+            ShardStatuses.MISSING_SHARDING_REL.value, scope="unit", component=self.name
         )
         self.state.statuses.add(
             ShardStatuses.ADDING_TO_CLUSTER.value, scope="unit", component=self.name
@@ -961,9 +961,9 @@ class ShardManager(Object, ManagerStatusProtocol):
         shard_has_tls, config_server_has_tls = self.tls_status()
         match (shard_has_tls, config_server_has_tls):
             case False, True:
-                return ShardStatuses.REQUIRES_TLS.value
+                return ShardStatuses.MISSING_TLS_REL.value
             case True, False:
-                return ShardStatuses.REQUIRES_NO_TLS.value
+                return ShardStatuses.INVALID_TLS_REL.value
             case _:
                 pass
 
@@ -993,7 +993,7 @@ class ShardManager(Object, ManagerStatusProtocol):
                 return [ShardStatuses.SHARD_DRAINED.value]
 
             if not self.state.unit_peer_data.drained:
-                return [ShardStatuses.MISSING_CONF_SERVER_REL.value]
+                return [ShardStatuses.MISSING_SHARDING_REL.value]
 
         if self.dependent.cluster_version_checker.get_cluster_mismatched_revision_status():
             # No need to go further if the revision is invalid

--- a/tests/integration/helpers/common.py
+++ b/tests/integration/helpers/common.py
@@ -808,7 +808,7 @@ async def check_all_units_blocked_with_status(
         if status:
             assert (
                 status in unit.workload_status.message
-            ), f"unit {unit.name} not in blocked state, in {unit.workload_status.value}"
+            ), f"unit {unit.name} status is `{unit.workload_status.message}`, expected `{status}`"
 
 
 async def wait_for_mongodb_units_blocked(

--- a/tests/integration/mongodb/tls/test_sharding_tls_inconsistent_rels.py
+++ b/tests/integration/mongodb/tls/test_sharding_tls_inconsistent_rels.py
@@ -107,7 +107,7 @@ async def test_tls_inconsistent_rels(ops_test: OpsTest, substrate: Substrate) ->
         ops_test,
         substrate,
         SHARD_ONE_APP_NAME,
-        status="Shard requires TLS to be enabled",
+        status="TLS must be enabled in the shard, since it is enabled in the related config-server.",
         timeout=TIMEOUT,
     )
 
@@ -141,7 +141,7 @@ async def test_tls_inconsistent_rels(ops_test: OpsTest, substrate: Substrate) ->
         ops_test,
         substrate,
         SHARD_ONE_APP_NAME,
-        status="Shard has TLS enabled, but config-server does not.",
+        status="TLS must be disabled in shard, since it is disabled in the related config-server.",
         timeout=450,
     )
 
@@ -164,6 +164,6 @@ async def test_tls_inconsistent_rels(ops_test: OpsTest, substrate: Substrate) ->
         ops_test,
         substrate,
         SHARD_ONE_APP_NAME,
-        status="Shard CA and Config-Server CA don't match.",
+        status="Shard CA and config-Server CA don't match.",
         timeout=450,
     )

--- a/tests/unit/test_sharding.py
+++ b/tests/unit/test_sharding.py
@@ -347,7 +347,7 @@ def test_shard_manager_prepare_to_add_shard(harness: Harness[MongoTestCharm]):
         scope=Scope.UNIT, component=harness.charm.operator.shard_manager.name
     )
 
-    assert as_status(statuses[0]) == MaintenanceStatus("Adding shard to config-server")
+    assert as_status(statuses[0]) == MaintenanceStatus("Adding shard to config-server...")
 
 
 def test_shard_manager_synchronise_cluster_invalid_role(harness: Harness[MongoTestCharm]):

--- a/tests/unit/test_status_handler.py
+++ b/tests/unit/test_status_handler.py
@@ -442,7 +442,7 @@ def test_shard_get_status_charm_missing_relation_not_drained(
     statuses = harness.charm.operator.shard_manager.get_statuses(scope=Scope.UNIT, recompute=True)
     status = next(iter(statuses), None)
 
-    assert status == ShardStatuses.MISSING_CONF_SERVER_REL.value
+    assert status == ShardStatuses.MISSING_SHARDING_REL.value
 
 
 def test_shard_get_status_charm_missing_relation_drained(
@@ -497,7 +497,7 @@ def test_shard_get_status_tls_status(
 
     harness.add_relation(RelationNames.SHARDING.value, "config-server")
 
-    status_one = ShardStatuses.REQUIRES_TLS.value
+    status_one = ShardStatuses.MISSING_TLS_REL.value
     mocker.patch(
         "single_kernel_mongo.managers.sharding.ShardManager.cluster_password_synced",
         return_value=True,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷 Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update
- [ ] Tooling and CI changes
- [ ] Dependencies upgrade or change

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and scope of this PR (what)
  - the impacted components (where, often match conventional commit scope)
  - explanation/algorithm if require (how)
-->

Extend the status in `ShardStatuses`
- Make the short_message shorter than 40 characters.
- Add check and action when judged necessary
- Make the variable names, messages and vocabulary consistent

## 📑 Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Either the associated JIRA reference or a paragraph. -->

This PR improves the quality of the message displayed to the operator about the state of the charms

## 🧪 How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Existing tests

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](../blob/6/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
