### PR TITLE
patch: rename internal user (add `charmed_` prefix)

### DIFF
--- a/single_kernel_mongo/config/literals.py
+++ b/single_kernel_mongo/config/literals.py
@@ -41,13 +41,13 @@ class MongoPorts(IntEnum):
     MONGOS_PORT = 27018
 
 
-class InternalUsers(str, Enum):
-    """The three allowed internal users."""
+class InternalUsernames(str, Enum):
+    """The allowed internal usernames."""
 
-    OPERATOR = "operator"
-    BACKUP = "backup"
-    MONITOR = "monitor"
-    LOGROTATE = "logrotate"
+    CHARMED_OPERATOR = "charmed_operator"
+    CHARMED_BACKUP = "charmed_backup"
+    CHARMED_MONITOR = "charmed_monitor"
+    CHARMED_LOGROTATE = "charmed_logrotate"
 
 
 class UnitState(str, Enum):
@@ -59,7 +59,9 @@ class UnitState(str, Enum):
     OUTDATED = "outdated"  # Machines only
 
 
-SECRETS_APP = [f"{user}-password" for user in InternalUsers] + ["keyfile"]
+# SECRETS_APP = [f"{user}-password" for user in InternalUsernames] + ["keyfile"]
+
+SECRETS_APP = [f"{user.replace('_', '-')}-password" for user in InternalUsernames] + ["keyfile"]
 
 
 @dataclass(frozen=True)

--- a/single_kernel_mongo/config/literals.py
+++ b/single_kernel_mongo/config/literals.py
@@ -59,8 +59,6 @@ class UnitState(str, Enum):
     OUTDATED = "outdated"  # Machines only
 
 
-# SECRETS_APP = [f"{user}-password" for user in InternalUsernames] + ["keyfile"]
-
 SECRETS_APP = [f"{user.replace('_', '-')}-password" for user in InternalUsernames] + ["keyfile"]
 
 

--- a/single_kernel_mongo/core/abstract_upgrades.py
+++ b/single_kernel_mongo/core/abstract_upgrades.py
@@ -48,7 +48,7 @@ from single_kernel_mongo.state.charm_state import CharmState
 from single_kernel_mongo.utils.helpers import mongodb_only
 from single_kernel_mongo.utils.mongo_config import MongoConfiguration
 from single_kernel_mongo.utils.mongo_connection import MongoConnection
-from single_kernel_mongo.utils.mongodb_users import OperatorUser
+from single_kernel_mongo.utils.mongodb_users import CharmedOperatorUser
 
 if TYPE_CHECKING:
     from single_kernel_mongo.core.kubernetes_upgrades import KubernetesUpgrade
@@ -577,7 +577,7 @@ class GenericMongoDBUpgradeManager(ManagerStatusProtocol, Generic[T], Object, AB
             config_server_hosts = self.state.app_peer_data.mongos_hosts
             mongodb_configurations = [
                 self.state.mongodb_config_for_user(
-                    OperatorUser,
+                    CharmedOperatorUser,
                     hosts=set(config_server_hosts),
                     replset=self.state.config_server_name,
                 )
@@ -689,7 +689,7 @@ class GenericMongoDBUpgradeManager(ManagerStatusProtocol, Generic[T], Object, AB
         shard_hosts = shard_entry["host"].split("/")[1]
         parsed_ips = {host.split(":")[0] for host in shard_hosts.split(",")}
         return self.state.mongodb_config_for_user(
-            OperatorUser, parsed_ips, replset=shard_entry[SHARD_NAME_INDEX]
+            CharmedOperatorUser, parsed_ips, replset=shard_entry[SHARD_NAME_INDEX]
         )
 
     def get_cluster_mongos(self) -> MongoConfiguration:
@@ -698,7 +698,7 @@ class GenericMongoDBUpgradeManager(ManagerStatusProtocol, Generic[T], Object, AB
             self.state.mongos_config
             if self.state.is_role(MongoDBRoles.CONFIG_SERVER)
             else self.state.mongos_config_for_user(
-                OperatorUser, hosts=set(self.state.shard_state.mongos_hosts)
+                CharmedOperatorUser, hosts=set(self.state.shard_state.mongos_hosts)
             )
         )
 
@@ -852,7 +852,7 @@ class GenericMongoDBUpgradeManager(ManagerStatusProtocol, Generic[T], Object, AB
         for replica_set_config in self.get_all_replica_set_configs_in_cluster():
             for single_host in replica_set_config.hosts:
                 single_replica_config = self.state.mongodb_config_for_user(
-                    OperatorUser,
+                    CharmedOperatorUser,
                     hosts={single_host},
                     replset=replica_set_config.replset,
                     standalone=True,

--- a/single_kernel_mongo/events/password_actions.py
+++ b/single_kernel_mongo/events/password_actions.py
@@ -19,7 +19,7 @@ from single_kernel_mongo.exceptions import (
     WorkloadServiceError,
 )
 from single_kernel_mongo.utils.event_helpers import fail_action_with_error_log
-from single_kernel_mongo.utils.mongodb_users import CharmedOperatorUser, CharmUsers
+from single_kernel_mongo.utils.mongodb_users import CharmedOperatorUser, CharmUsernames
 
 if TYPE_CHECKING:
     from single_kernel_mongo.abstract_charm import AbstractMongoCharm
@@ -59,12 +59,12 @@ class PasswordActionEvents(Object):
         action = "set-password"
         username = event.params.get(PasswordActionParameter.USERNAME, CharmedOperatorUser.username)
         password = event.params.get(PasswordActionParameter.PASSWORD)
-        if username not in CharmUsers:
+        if username not in CharmUsernames:
             fail_action_with_error_log(
                 logger,
                 event,
                 action,
-                f"The action can be run only for users used by the charm: {', '.join(CharmUsers)} not {username}",
+                f"The action can be run only for users used by the charm: {', '.join(CharmUsernames)} not {username}",
             )
             return
         if isinstance(password, str) and password.strip() == "":
@@ -88,12 +88,12 @@ class PasswordActionEvents(Object):
         action = "get-password"
         username = event.params.get(PasswordActionParameter.USERNAME, CharmedOperatorUser.username)
         # breakpoint()
-        if username not in CharmUsers:
+        if username not in CharmUsernames:
             fail_action_with_error_log(
                 logger,
                 event,
                 action,
-                f"The action can be run only for users used by the charm: {', '.join(CharmUsers)} not {username}",
+                f"The action can be run only for users used by the charm: {', '.join(CharmUsernames)} not {username}",
             )
             return
 

--- a/single_kernel_mongo/events/password_actions.py
+++ b/single_kernel_mongo/events/password_actions.py
@@ -19,7 +19,7 @@ from single_kernel_mongo.exceptions import (
     WorkloadServiceError,
 )
 from single_kernel_mongo.utils.event_helpers import fail_action_with_error_log
-from single_kernel_mongo.utils.mongodb_users import CharmUsers, OperatorUser
+from single_kernel_mongo.utils.mongodb_users import CharmedOperatorUser, CharmUsers
 
 if TYPE_CHECKING:
     from single_kernel_mongo.abstract_charm import AbstractMongoCharm
@@ -57,7 +57,7 @@ class PasswordActionEvents(Object):
         Set the password for a specific user, if no passwords are passed, generate them.
         """
         action = "set-password"
-        username = event.params.get(PasswordActionParameter.USERNAME, OperatorUser.username)
+        username = event.params.get(PasswordActionParameter.USERNAME, CharmedOperatorUser.username)
         password = event.params.get(PasswordActionParameter.PASSWORD)
         if username not in CharmUsers:
             fail_action_with_error_log(
@@ -86,7 +86,7 @@ class PasswordActionEvents(Object):
 
     def _get_password_action(self, event: ActionEvent) -> None:
         action = "get-password"
-        username = event.params.get(PasswordActionParameter.USERNAME, OperatorUser.username)
+        username = event.params.get(PasswordActionParameter.USERNAME, CharmedOperatorUser.username)
         # breakpoint()
         if username not in CharmUsers:
             fail_action_with_error_log(

--- a/single_kernel_mongo/managers/config.py
+++ b/single_kernel_mongo/managers/config.py
@@ -29,7 +29,11 @@ from single_kernel_mongo.core.structured_config import MongoConfigModel, MongoDB
 from single_kernel_mongo.core.workload import WorkloadBase
 from single_kernel_mongo.exceptions import WorkloadServiceError
 from single_kernel_mongo.state.charm_state import CharmState
-from single_kernel_mongo.utils.mongodb_users import BackupUser, LogRotateUser, MonitorUser
+from single_kernel_mongo.utils.mongodb_users import (
+    CharmedBackupUser,
+    CharmedLogRotateUser,
+    CharmedMonitorUser,
+)
 from single_kernel_mongo.workload import (
     get_logrotate_workload_for_substrate,
     get_mongodb_exporter_workload_for_substrate,
@@ -136,7 +140,7 @@ class BackupConfigManager(CommonConfigManager):
             logger.info("Not starting PBM yet. Shard not added to config-server")
             return
 
-        if not self.state.get_user_password(BackupUser):
+        if not self.state.get_user_password(CharmedBackupUser):
             logger.info("No password found.")
             return
 
@@ -185,7 +189,7 @@ class LogRotateConfigManager(CommonConfigManager):
             logger.info("DB is not initialised.")
             return
 
-        if not self.state.get_user_password(LogRotateUser):
+        if not self.state.get_user_password(CharmedLogRotateUser):
             logger.info("No password found.")
             return
 
@@ -232,7 +236,7 @@ class MongoDBExporterConfigManager(CommonConfigManager):
         if not self.state.db_initialised:
             return
 
-        if not self.state.get_user_password(MonitorUser):
+        if not self.state.get_user_password(CharmedMonitorUser):
             return
 
         if not self.workload.active() or self.get_environment() != self.state.monitor_config.uri:

--- a/single_kernel_mongo/managers/mongo.py
+++ b/single_kernel_mongo/managers/mongo.py
@@ -49,11 +49,11 @@ from single_kernel_mongo.utils.mongo_config import (
 from single_kernel_mongo.utils.mongo_connection import MongoConnection, NotReadyError
 from single_kernel_mongo.utils.mongodb_users import (
     OPERATOR_ROLE,
-    BackupUser,
-    LogRotateUser,
+    CharmedBackupUser,
+    CharmedLogRotateUser,
+    CharmedMonitorUser,
+    CharmedOperatorUser,
     MongoDBUser,
-    MonitorUser,
-    OperatorUser,
 )
 
 if TYPE_CHECKING:
@@ -129,12 +129,12 @@ class MongoManager(Object, ManagerStatusProtocol):
 
     def initialise_charm_admin_users(self) -> None:
         """First initialisation of each user."""
-        self.initialise_operator_user()
-        self.initialise_user(MonitorUser)
-        self.initialise_user(BackupUser)
-        self.initialise_user(LogRotateUser)
+        self.initialise_charmed_operator_user()
+        self.initialise_user(CharmedMonitorUser)
+        self.initialise_user(CharmedBackupUser)
+        self.initialise_user(CharmedLogRotateUser)
 
-    def initialise_operator_user(self):
+    def initialise_charmed_operator_user(self):
         """Creates initial admin user for MongoDB.
 
         Initial admin user can be created only through localhost connection.
@@ -145,7 +145,7 @@ class MongoManager(Object, ManagerStatusProtocol):
         It is needed to install mongodb-clients inside charm container to make
         this function work correctly.
         """
-        if self.state.app_peer_data.is_user_created(OperatorUser.username):
+        if self.state.app_peer_data.is_user_created(CharmedOperatorUser.username):
             return
         config = self.state.mongo_config
         cmd = [
@@ -160,7 +160,7 @@ class MongoManager(Object, ManagerStatusProtocol):
             '})"',
         ]
         self.workload.run_bin_command("mongodb://localhost/admin", cmd, input=config.password)
-        self.state.app_peer_data.set_user_created(OperatorUser.username)
+        self.state.app_peer_data.set_user_created(CharmedOperatorUser.username)
 
     def initialise_user(self, user: MongoDBUser):
         """Creates a user and sets its role on the MongoDB database."""

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -101,10 +101,10 @@ from single_kernel_mongo.utils.helpers import (
 )
 from single_kernel_mongo.utils.mongo_connection import MongoConnection, NotReadyError
 from single_kernel_mongo.utils.mongodb_users import (
-    BackupUser,
-    LogRotateUser,
-    MonitorUser,
-    OperatorUser,
+    CharmedBackupUser,
+    CharmedLogRotateUser,
+    CharmedMonitorUser,
+    CharmedOperatorUser,
     get_user_from_username,
 )
 from single_kernel_mongo.workload import (
@@ -469,7 +469,12 @@ class MongoDBOperator(OperatorProtocol, Object):
             self.state.set_keyfile(self.workload.generate_keyfile())
 
         # Sets the password for the system users
-        for user in (OperatorUser, BackupUser, MonitorUser, LogRotateUser):
+        for user in (
+            CharmedOperatorUser,
+            CharmedBackupUser,
+            CharmedMonitorUser,
+            CharmedLogRotateUser,
+        ):
             if not self.state.get_user_password(user):
                 self.state.set_user_password(user, self.workload.generate_password())
 
@@ -697,16 +702,18 @@ class MongoDBOperator(OperatorProtocol, Object):
             )
 
         secret_id = self.mongo_manager.set_user_password(user, new_password)
-        if user == BackupUser:
+        if user == CharmedBackupUser:
             # Update and restart PBM Agent.
             self.backup_manager.configure_and_restart()
-        if user == MonitorUser:
+        if user == CharmedMonitorUser:
             # Update and restart mongodb exporter.
             self.mongodb_exporter_config_manager.configure_and_restart()
-        if user == LogRotateUser:
+        if user == CharmedLogRotateUser:
             # Update and restart logrotate.
             self.logrotate_config_manager.configure_and_restart()
-        if user in (OperatorUser, BackupUser) and self.state.is_role(MongoDBRoles.CONFIG_SERVER):
+        if user in (CharmedOperatorUser, CharmedBackupUser) and self.state.is_role(
+            MongoDBRoles.CONFIG_SERVER
+        ):
             self.config_server_manager.update_credentials(
                 user.password_key_name,
                 new_password,

--- a/single_kernel_mongo/managers/sharding.py
+++ b/single_kernel_mongo/managers/sharding.py
@@ -62,9 +62,9 @@ from single_kernel_mongo.state.tls_state import SECRET_CA_LABEL
 from single_kernel_mongo.utils.mongo_connection import MongoConnection, NotReadyError
 from single_kernel_mongo.utils.mongo_error_codes import MongoErrorCodes
 from single_kernel_mongo.utils.mongodb_users import (
-    BackupUser,
+    CharmedBackupUser,
+    CharmedOperatorUser,
     MongoDBUser,
-    OperatorUser,
 )
 from single_kernel_mongo.workload.mongodb_workload import MongoDBWorkload
 
@@ -108,10 +108,10 @@ class ConfigServerManager(Object, ManagerStatusProtocol):
             )
         relation_data = {
             AppShardingComponentKeys.OPERATOR_PASSWORD.value: self.state.get_user_password(
-                OperatorUser
+                CharmedOperatorUser
             ),
             AppShardingComponentKeys.BACKUP_PASSWORD.value: self.state.get_user_password(
-                BackupUser
+                CharmedBackupUser
             ),
             AppShardingComponentKeys.KEY_FILE.value: self.state.get_keyfile(),
             AppShardingComponentKeys.HOST.value: json.dumps(sorted(self.state.internal_hosts)),
@@ -473,8 +473,8 @@ class ConfigServerManager(Object, ManagerStatusProtocol):
             if not hosts:
                 return unreachable_hosts
 
-            # use a URI that is not dependent on the operator password, as we are not guaranteed
-            # that the shard has received the password yet.
+            # use a URI that is not dependent on the charmed_operator password, as we are
+            # not guaranteed that the shard has received the password yet.
             # To check if the shard is ready, we check the entire replica set for readiness
             uri = f"mongodb://{','.join(hosts)}"
             if not self.dependent.mongo_manager.mongod_ready(uri, direct=False):
@@ -650,7 +650,7 @@ class ShardManager(Object, ManagerStatusProtocol):
         self.state.app_peer_data.mongos_hosts = self.state.shard_state.mongos_hosts
 
     def handle_secret_changed(self, secret_label: str | None) -> None:
-        """Update operator and backup user passwords when rotation occurs.
+        """Update charmed_operator and chamed_backup user passwords when rotation occurs.
 
         Changes in secrets do not re-trigger a relation changed event, so it is necessary to listen
         to secret changes events.
@@ -676,7 +676,9 @@ class ShardManager(Object, ManagerStatusProtocol):
             backup_password = self.state.shard_state.backup_password
 
             if not operator_password or not backup_password:
-                raise WaitingForSecretsError("Missing operator password or backup password")
+                raise WaitingForSecretsError(
+                    "Missing charmed_operator password or chamed_backup password"
+                )
             self.sync_cluster_passwords(operator_password, backup_password)
 
         # Add the certificate if it is present
@@ -765,8 +767,8 @@ class ShardManager(Object, ManagerStatusProtocol):
                     raise NotReadyError
 
         try:
-            self.update_password(user=OperatorUser, new_password=operator_password)
-            self.update_password(user=BackupUser, new_password=backup_password)
+            self.update_password(user=CharmedOperatorUser, new_password=operator_password)
+            self.update_password(user=CharmedBackupUser, new_password=backup_password)
         except (NotReadyError, PyMongoError, ServerSelectionTimeoutError):
             # RelationChangedEvents will only update passwords when the relation is first joined,
             # otherwise all other password changes result in a Secret Changed Event.
@@ -893,7 +895,7 @@ class ShardManager(Object, ManagerStatusProtocol):
             )
             return False
 
-        config = self.state.mongos_config_for_user(OperatorUser, set(mongos_hosts))
+        config = self.state.mongos_config_for_user(CharmedOperatorUser, set(mongos_hosts))
 
         drained = shard_name not in self.dependent.mongo_manager.get_draining_shards(
             config=config, shard_name=shard_name

--- a/single_kernel_mongo/managers/upgrade.py
+++ b/single_kernel_mongo/managers/upgrade.py
@@ -33,7 +33,7 @@ from single_kernel_mongo.exceptions import (
     UnhealthyUpgradeError,
 )
 from single_kernel_mongo.utils.mongo_connection import MongoConnection
-from single_kernel_mongo.utils.mongodb_users import LogRotateUser
+from single_kernel_mongo.utils.mongodb_users import CharmedLogRotateUser
 
 T = TypeVar("T", bound=OperatorProtocol)
 
@@ -67,11 +67,11 @@ class MongoUpgradeManager(Generic[T], GenericMongoDBUpgradeManager[T]):
             # If the user was not existing yet, create it.
             # This user was added after the first stable release so we have to
             # create it on upgrade if necessary.
-            if not self.state.get_user_password(LogRotateUser):
+            if not self.state.get_user_password(CharmedLogRotateUser):
                 self.state.set_user_password(
-                    LogRotateUser, self.dependent.workload.generate_password()
+                    CharmedLogRotateUser, self.dependent.workload.generate_password()
                 )
-                self.dependent.mongo_manager.initialise_user(LogRotateUser)
+                self.dependent.mongo_manager.initialise_user(CharmedLogRotateUser)
         try:
             # Start services.
             self.dependent.install_workloads()
@@ -114,11 +114,11 @@ class MongoUpgradeManager(Generic[T], GenericMongoDBUpgradeManager[T]):
             # If the user was not existing yet, create it.
             # This user was added after the first stable release so we have to
             # create it on upgrade if necessary.
-            if not self.state.get_user_password(LogRotateUser):
+            if not self.state.get_user_password(CharmedLogRotateUser):
                 self.state.set_user_password(
-                    LogRotateUser, self.dependent.workload.generate_password()
+                    CharmedLogRotateUser, self.dependent.workload.generate_password()
                 )
-                self.dependent.mongo_manager.initialise_user(LogRotateUser)
+                self.dependent.mongo_manager.initialise_user(CharmedLogRotateUser)
                 self.dependent.logrotate_config_manager.configure_and_restart()
             self.state.app_upgrade_peer_data.upgrade_resumed = False
             self.dependent.cross_app_version_checker.set_version_across_all_relations()  # type: ignore

--- a/single_kernel_mongo/state/charm_state.py
+++ b/single_kernel_mongo/state/charm_state.py
@@ -79,11 +79,11 @@ from single_kernel_mongo.utils.mongo_config import MongoConfiguration
 from single_kernel_mongo.utils.mongo_connection import MongoConnection
 from single_kernel_mongo.utils.mongo_error_codes import MongoErrorCodes
 from single_kernel_mongo.utils.mongodb_users import (
-    BackupUser,
-    LogRotateUser,
+    CharmedBackupUser,
+    CharmedLogRotateUser,
+    CharmedMonitorUser,
+    CharmedOperatorUser,
     MongoDBUser,
-    MonitorUser,
-    OperatorUser,
     RoleNames,
 )
 
@@ -809,35 +809,35 @@ class CharmState(Object, StatusesStateProtocol):
 
     @property
     def backup_config(self) -> MongoConfiguration:
-        """Mongo Configuration for the backup user."""
-        return self.mongodb_config_for_user(BackupUser, standalone=True)
+        """Mongo Configuration for the charmed_backup user."""
+        return self.mongodb_config_for_user(CharmedBackupUser, standalone=True)
 
     @property
     def monitor_config(self) -> MongoConfiguration:
-        """Mongo Configuration for the monitoring user."""
-        return self.mongodb_config_for_user(MonitorUser, hosts=self.internal_hosts)
+        """Mongo Configuration for the charmed_monitor user."""
+        return self.mongodb_config_for_user(CharmedMonitorUser, hosts=self.internal_hosts)
 
     @property
     def logrotate_config(self) -> MongoConfiguration:
-        """Mongo Configuration for the logrotate user."""
-        return self.mongodb_config_for_user(LogRotateUser, standalone=True)
+        """Mongo Configuration for the charmed_logrotate user."""
+        return self.mongodb_config_for_user(CharmedLogRotateUser, standalone=True)
 
     @property
     def operator_config(self) -> MongoConfiguration:
-        """Mongo Configuration for the operator user."""
-        return self.mongodb_config_for_user(OperatorUser, hosts=self.internal_hosts)
+        """Mongo Configuration for the charmed_operator user."""
+        return self.mongodb_config_for_user(CharmedOperatorUser, hosts=self.internal_hosts)
 
     @property
     def remote_mongos_config(self) -> MongoConfiguration:
         """Mongos Configuration for the remote mongos server."""
         mongos_hosts = self.app_peer_data.mongos_hosts
-        return self.mongos_config_for_user(OperatorUser, set(mongos_hosts))
+        return self.mongos_config_for_user(CharmedOperatorUser, set(mongos_hosts))
 
     @property
     def mongos_config(self) -> MongoConfiguration:
         """Mongos Configuration for the admin mongos user."""
         if self.charm_role.name == CharmKind.MONGOD:
-            return self.mongos_config_for_user(OperatorUser, self.internal_hosts)
+            return self.mongos_config_for_user(CharmedOperatorUser, self.internal_hosts)
         username, password = self.get_user_credentials()
         database = self.app_peer_data.database
         port: int | None = MongoPorts.MONGOS_PORT.value

--- a/single_kernel_mongo/state/config_server_state.py
+++ b/single_kernel_mongo/state/config_server_state.py
@@ -18,8 +18,8 @@ class AppShardingComponentKeys(str, Enum):
     """Config Server State Model for the application."""
 
     DATABASE = "database"
-    OPERATOR_PASSWORD = "operator-password"
-    BACKUP_PASSWORD = "backup-password"
+    OPERATOR_PASSWORD = "charmed-operator-password"
+    BACKUP_PASSWORD = "charmed-backup-password"
     HOST = "host"
     KEY_FILE = "key-file"
     INT_CA_SECRET = "int-ca-secret"
@@ -31,8 +31,8 @@ class AppShardingComponentKeys(str, Enum):
 
 
 SECRETS_FIELDS = [
-    "operator-password",
-    "backup-password",
+    "charmed-operator-password",
+    "charmed-backup-password",
     "key-file",
     "int-ca-secret",
     "backup-ca-secret",

--- a/single_kernel_mongo/state/models.py
+++ b/single_kernel_mongo/state/models.py
@@ -20,7 +20,7 @@ class ConfigServerData(ProviderData, RequirerData):  # type: ignore[misc]
         "tls-ca",
         "uris",
         "key-file",
-        "operator-password",
-        "backup-password",
+        "charmed-operator-password",
+        "charmed-backup-password",
         "int-ca-secret",
     ]

--- a/single_kernel_mongo/utils/mongodb_users.py
+++ b/single_kernel_mongo/utils/mongodb_users.py
@@ -171,7 +171,7 @@ CharmedLogRotateUser = MongoDBUser(
 )
 
 
-CharmUsers = (
+CharmUsernames = (
     CharmedOperatorUser.username,
     CharmedBackupUser.username,
     CharmedMonitorUser.username,

--- a/single_kernel_mongo/utils/mongodb_users.py
+++ b/single_kernel_mongo/utils/mongodb_users.py
@@ -7,7 +7,7 @@ from typing import Any, NewType, TypedDict
 
 from pydantic import BaseModel, Field, computed_field
 
-from single_kernel_mongo.config.literals import LOCALHOST, InternalUsers
+from single_kernel_mongo.config.literals import LOCALHOST, InternalUsernames
 
 
 class DBPrivilege(TypedDict, total=False):
@@ -95,7 +95,7 @@ class MongoDBUser(BaseModel):
     @property
     def password_key_name(self) -> str:
         """Returns the key name for the password of the user."""
-        return f"{self.username}-password"
+        return f"{self.username.replace('_', '-')}-password"
 
     # DEPRECATE: All the following methods are for backward compatibility and
     # will be deprecated soon
@@ -128,14 +128,14 @@ class MongoDBUser(BaseModel):
         return self.hosts
 
 
-OperatorUser = MongoDBUser(
-    username=InternalUsers.OPERATOR,
+CharmedOperatorUser = MongoDBUser(
+    username=InternalUsernames.CHARMED_OPERATOR,
     database_name=SystemDBS.ADMIN,
     roles={RoleNames.DEFAULT},
 )
 
-MonitorUser = MongoDBUser(
-    username=InternalUsers.MONITOR,
+CharmedMonitorUser = MongoDBUser(
+    username=InternalUsernames.CHARMED_MONITOR,
     database_name=SystemDBS.ADMIN,
     roles={RoleNames.MONITOR},
     privileges={
@@ -153,16 +153,16 @@ MonitorUser = MongoDBUser(
     hosts={LOCALHOST},  # MongoDB Exporter can only connect to one replica.
 )
 
-BackupUser = MongoDBUser(
-    username=InternalUsers.BACKUP,
+CharmedBackupUser = MongoDBUser(
+    username=InternalUsernames.CHARMED_BACKUP,
     roles={RoleNames.BACKUP},
     privileges={"resource": {"anyResource": True}, "actions": ["anyAction"]},
     mongodb_role="pbmAnyAction",
     hosts={LOCALHOST},  # pbm cannot make a direct connection if multiple hosts are used
 )
 
-LogRotateUser = MongoDBUser(
-    username=InternalUsers.LOGROTATE,
+CharmedLogRotateUser = MongoDBUser(
+    username=InternalUsernames.CHARMED_LOGROTATE,
     database_name=SystemDBS.ADMIN,
     roles={RoleNames.LOGROTATE},
     privileges={"resource": {"cluster": True}, "actions": ["logRotate"]},
@@ -172,21 +172,21 @@ LogRotateUser = MongoDBUser(
 
 
 CharmUsers = (
-    OperatorUser.username,
-    BackupUser.username,
-    MonitorUser.username,
-    LogRotateUser.username,
+    CharmedOperatorUser.username,
+    CharmedBackupUser.username,
+    CharmedMonitorUser.username,
+    CharmedLogRotateUser.username,
 )
 
 
 def get_user_from_username(username: str) -> MongoDBUser:
     """Returns the key name for the password of the user."""
-    if username == OperatorUser.username:
-        return OperatorUser
-    if username == MonitorUser.username:
-        return MonitorUser
-    if username == BackupUser.username:
-        return BackupUser
-    if username == LogRotateUser.username:
-        return LogRotateUser
+    if username == CharmedOperatorUser.username:
+        return CharmedOperatorUser
+    if username == CharmedMonitorUser.username:
+        return CharmedMonitorUser
+    if username == CharmedBackupUser.username:
+        return CharmedBackupUser
+    if username == CharmedLogRotateUser.username:
+        return CharmedLogRotateUser
     raise ValueError(f"Unknown user: {username}")

--- a/tests/charms/mongodb_k8s_test_charm/actions.yaml
+++ b/tests/charms/mongodb_k8s_test_charm/actions.yaml
@@ -8,8 +8,8 @@ get-password:
   params:
     username:
       type: string
-      description: The username, the default value 'operator'.
-        Possible values - operator, backup, monitor.
+      description: The username, the default value 'charmed_operator'.
+        Possible values - charmed_operator, charmed_backup, charmed_monitor, charmed_logrotate.
 
 set-password:
   description: Change the admin user's password, which is used by charm.
@@ -17,8 +17,8 @@ set-password:
   params:
     username:
       type: string
-      description: The username, the default value 'operator'.
-        Possible values - operator, backup, monitor.
+      description: The username, the default value 'charmed_operator'.
+        Possible values - charmed_operator, charmed_backup, charmed_monitor, charmed_logrotate.
     password:
       type: string
       description: The password will be auto-generated if this option is not specified.

--- a/tests/charms/mongodb_test_charm/actions.yaml
+++ b/tests/charms/mongodb_test_charm/actions.yaml
@@ -8,8 +8,8 @@ get-password:
   params:
     username:
       type: string
-      description: The username, the default value 'operator'.
-        Possible values - operator, backup, monitor.
+      description: The username, the default value 'charmed_operator'.
+        Possible values - charmed_operator, charmed_backup, charmed_monitor, charmed_logrotate.
 
 set-password:
   description: Change the admin user's password, which is used by charm.
@@ -17,8 +17,8 @@ set-password:
   params:
     username:
       type: string
-      description: The username, the default value 'operator'.
-        Possible values - operator, backup, monitor.
+      description: The username, the default value 'charmed_operator'.
+        Possible values - charmed_operator, charmed_backup, charmed_monitor, charmed_logrotate.
     password:
       type: string
       description: The password will be auto-generated if this option is not specified.

--- a/tests/integration/applications/continuous_write_charm/src/charm.py
+++ b/tests/integration/applications/continuous_write_charm/src/charm.py
@@ -111,7 +111,7 @@ class ContinuousWritesApplication(CharmBase):
             logger.warning("No database configured.")
             return
 
-        logger.info("Running start continuous write with {db_name=} and {collection_name=}")
+        logger.info(f"Running start continuous write with {db_name=} and {collection_name=}")
         self._stop_continuous_writes(db_name, collection_name)
 
         uris: str = self._database_config.get("uris", "")

--- a/tests/integration/helpers/common.py
+++ b/tests/integration/helpers/common.py
@@ -41,8 +41,8 @@ UNIT_IDS = [0, 1, 2]
 SERIES = "noble"
 TIMEOUT = 15 * 60
 DEPLOYMENT_TIMEOUT = 2000
-OPERATOR_USERNAME = "operator"
-OPERATOR_PASSWORD = "operator-password"
+CHARMED_OPERATOR_USERNAME = "charmed_operator"
+CHARMED_OPERATOR_PASSWORD = "operator-password"
 
 CONTINUOUS_WRITE_APPLICATION = "continuous-write"
 # Keep in sync with tests/integration/applications/continuous_write_charm/src/charm.py
@@ -200,7 +200,7 @@ async def generate_mongodb_client(
     app_name: str,
     mongos: bool,
     hosts: list[str] | None = None,
-    username: str = "operator",
+    username: str = CHARMED_OPERATOR_USERNAME,
     password: str | None = None,
     unit: JujuUnit | None = None,
 ):
@@ -235,7 +235,7 @@ async def mongodb_uri(
     app_name: str,
     unit_ids: list[int] | None = None,
     port: int = MONGOD_PORT,
-    username: str = "operator",
+    username: str = CHARMED_OPERATOR_USERNAME,
     password: str | None = None,
     hostnames: bool = False,
 ) -> str:
@@ -323,7 +323,11 @@ async def destroy_cluster(
 
 
 def unit_uri(
-    ip_address: str, password: str, app: str, username: str = "operator", mongos: bool = False
+    ip_address: str,
+    password: str,
+    app: str,
+    username: str = CHARMED_OPERATOR_USERNAME,
+    mongos: bool = False,
 ) -> str:
     """Generates URI that is used by MongoDB to connect to a single replica.
 
@@ -339,7 +343,7 @@ def unit_uri(
 
 async def get_password(
     ops_test: OpsTest,
-    username="operator",
+    username=CHARMED_OPERATOR_USERNAME,
     app_name: str | None = None,
     unit: JujuUnit | None = None,
 ) -> str:
@@ -422,7 +426,7 @@ async def get_direct_mongo_client(
     ip_address = await get_address_of_unit(ops_test, substrate, get_unit_id(unit.name), app_name)
     match username, password:
         case None, None:
-            username = "operator"
+            username = CHARMED_OPERATOR_USERNAME
             password = await get_password(ops_test, app_name=app_name, unit=unit)
         case _, None:
             raise Exception("Please provide username and password")
@@ -460,7 +464,7 @@ async def get_leader_id(ops_test: OpsTest, app_name=None) -> int:
 async def set_password(
     ops_test: OpsTest,
     unit_id: int,
-    username: str = "operator",
+    username: str = CHARMED_OPERATOR_USERNAME,
     password: str = "secret",
     app_name: str | None = None,
 ) -> dict[str, any]:

--- a/tests/integration/helpers/common.py
+++ b/tests/integration/helpers/common.py
@@ -43,6 +43,8 @@ TIMEOUT = 15 * 60
 DEPLOYMENT_TIMEOUT = 2000
 CHARMED_OPERATOR_USERNAME = "charmed_operator"
 CHARMED_OPERATOR_PASSWORD = "operator-password"
+CHARMED_BACKUP_USERNAME = "charmed_backup"
+CHARMED_MONITOR_USERNAME = "charmed_monitor"
 
 CONTINUOUS_WRITE_APPLICATION = "continuous-write"
 # Keep in sync with tests/integration/applications/continuous_write_charm/src/charm.py

--- a/tests/integration/helpers/ha.py
+++ b/tests/integration/helpers/ha.py
@@ -32,6 +32,7 @@ from tenacity import (
 )
 
 from ..helpers.common import (
+    CHARMED_OPERATOR_USERNAME,
     CONTINUOUS_WRITE_APPLICATION,
     DEFAULT_DATABASE_NAME,
     DEFAULT_REPLICATION_COLL_NAME,
@@ -238,7 +239,7 @@ async def fetch_primary(
 ) -> str | None:
     """Returns IP address of current replica set primary."""
     password = await get_password(
-        ops_test, username="charmed_operator", app_name=app_name, unit=online_unit
+        ops_test, username=CHARMED_OPERATOR_USERNAME, app_name=app_name, unit=online_unit
     )
 
     uri = await generate_mongodb_client(

--- a/tests/integration/helpers/ha.py
+++ b/tests/integration/helpers/ha.py
@@ -238,7 +238,7 @@ async def fetch_primary(
 ) -> str | None:
     """Returns IP address of current replica set primary."""
     password = await get_password(
-        ops_test, username="operator", app_name=app_name, unit=online_unit
+        ops_test, username="charmed_operator", app_name=app_name, unit=online_unit
     )
 
     uri = await generate_mongodb_client(

--- a/tests/integration/helpers/tls.py
+++ b/tests/integration/helpers/tls.py
@@ -72,7 +72,7 @@ async def mongo_tls_command(
             for unit in ops_test.model.applications[app_name].units
         ]
         replica_set_hosts = [f"{host}:{port}" for host in replica_set_hosts]
-        username = "operator"
+        username = "charmed_operator"
         password = await get_password(ops_test, app_name=app_name)
         hosts = ",".join(replica_set_hosts)
         extra_args = f"?replicaSet={app_name}" if not mongos else ""

--- a/tests/integration/helpers/tls.py
+++ b/tests/integration/helpers/tls.py
@@ -11,6 +11,7 @@ from pytest_operator.plugin import OpsTest
 from tenacity import RetryError, Retrying, stop_after_attempt, wait_exponential
 
 from ..helpers.common import (
+    CHARMED_OPERATOR_USERNAME,
     MONGOD_PORT,
     MONGOS_APP_NAME,
     MONGOS_PORT,
@@ -72,7 +73,7 @@ async def mongo_tls_command(
             for unit in ops_test.model.applications[app_name].units
         ]
         replica_set_hosts = [f"{host}:{port}" for host in replica_set_hosts]
-        username = "charmed_operator"
+        username = CHARMED_OPERATOR_USERNAME
         password = await get_password(ops_test, app_name=app_name)
         hosts = ",".join(replica_set_hosts)
         extra_args = f"?replicaSet={app_name}" if not mongos else ""

--- a/tests/integration/helpers/upgrade.py
+++ b/tests/integration/helpers/upgrade.py
@@ -95,7 +95,7 @@ async def refresh_with_juju(ops_test: OpsTest, app_name: str, channel: str) -> N
 async def set_fcv(
     ops_test: OpsTest, substrate: Substrate, app_name: str, fcv: str, port: int = MONGOD_PORT
 ) -> None:
-    password = await get_password(ops_test, username="operator", app_name=app_name)
+    password = await get_password(ops_test, username="charmed_operator", app_name=app_name)
     replica_set_hosts = [
         await get_address_of_unit(ops_test, substrate, int(unit.name.split("/")[1]), app_name)
         for unit in ops_test.model.applications[app_name].units
@@ -103,7 +103,7 @@ async def set_fcv(
     replica_set_hosts = [f"{host}:{port}" for host in replica_set_hosts]
 
     hosts = ",".join(replica_set_hosts)
-    replica_set_uri = f"mongodb://operator:{password}@{hosts}/admin?replicaSet={app_name}"
+    replica_set_uri = f"mongodb://charmed_operator:{password}@{hosts}/admin?replicaSet={app_name}"
 
     admin_mongod_cmd = (
         f"db.adminCommand({{setFeatureCompatibilityVersion: '{fcv}', confirm: true}})"

--- a/tests/integration/helpers/upgrade.py
+++ b/tests/integration/helpers/upgrade.py
@@ -7,7 +7,6 @@ import logging
 from pytest_operator.plugin import OpsTest
 
 from ..helpers.common import (
-    CHARMED_OPERATOR_USERNAME,
     MONGOD_PORT,
     execute_on_mongod,
     find_unit,
@@ -94,19 +93,17 @@ async def refresh_with_juju(ops_test: OpsTest, app_name: str, channel: str) -> N
 
 
 async def set_fcv(
-    ops_test: OpsTest, substrate: Substrate, app_name: str, fcv: str, port: int = MONGOD_PORT
+    ops_test: OpsTest, substrate: Substrate, app_name: str, fcv: str, username: str
 ) -> None:
-    password = await get_password(ops_test, username=CHARMED_OPERATOR_USERNAME, app_name=app_name)
+    password = await get_password(ops_test, username=username, app_name=app_name)
     replica_set_hosts = [
         await get_address_of_unit(ops_test, substrate, int(unit.name.split("/")[1]), app_name)
         for unit in ops_test.model.applications[app_name].units
     ]
-    replica_set_hosts = [f"{host}:{port}" for host in replica_set_hosts]
+    replica_set_hosts = [f"{host}:{MONGOD_PORT}" for host in replica_set_hosts]
 
     hosts = ",".join(replica_set_hosts)
-    replica_set_uri = (
-        f"mongodb://{CHARMED_OPERATOR_USERNAME}:{password}@{hosts}/admin?replicaSet={app_name}"
-    )
+    replica_set_uri = f"mongodb://{username}:{password}@{hosts}/admin?replicaSet={app_name}"
 
     admin_mongod_cmd = (
         f"db.adminCommand({{setFeatureCompatibilityVersion: '{fcv}', confirm: true}})"

--- a/tests/integration/helpers/upgrade.py
+++ b/tests/integration/helpers/upgrade.py
@@ -7,6 +7,7 @@ import logging
 from pytest_operator.plugin import OpsTest
 
 from ..helpers.common import (
+    CHARMED_OPERATOR_USERNAME,
     MONGOD_PORT,
     execute_on_mongod,
     find_unit,
@@ -95,7 +96,7 @@ async def refresh_with_juju(ops_test: OpsTest, app_name: str, channel: str) -> N
 async def set_fcv(
     ops_test: OpsTest, substrate: Substrate, app_name: str, fcv: str, port: int = MONGOD_PORT
 ) -> None:
-    password = await get_password(ops_test, username="charmed_operator", app_name=app_name)
+    password = await get_password(ops_test, username=CHARMED_OPERATOR_USERNAME, app_name=app_name)
     replica_set_hosts = [
         await get_address_of_unit(ops_test, substrate, int(unit.name.split("/")[1]), app_name)
         for unit in ops_test.model.applications[app_name].units
@@ -103,7 +104,9 @@ async def set_fcv(
     replica_set_hosts = [f"{host}:{port}" for host in replica_set_hosts]
 
     hosts = ",".join(replica_set_hosts)
-    replica_set_uri = f"mongodb://charmed_operator:{password}@{hosts}/admin?replicaSet={app_name}"
+    replica_set_uri = (
+        f"mongodb://{CHARMED_OPERATOR_USERNAME}:{password}@{hosts}/admin?replicaSet={app_name}"
+    )
 
     admin_mongod_cmd = (
         f"db.adminCommand({{setFeatureCompatibilityVersion: '{fcv}', confirm: true}})"

--- a/tests/integration/mongodb/backups/test_backups.py
+++ b/tests/integration/mongodb/backups/test_backups.py
@@ -20,6 +20,7 @@ from ...helpers.backups import (
     set_credentials,
 )
 from ...helpers.common import (
+    CHARMED_BACKUP_USERNAME,
     DEPLOYMENT_TIMEOUT,
     TIMEOUT,
     UNIT_IDS,
@@ -404,10 +405,10 @@ async def test_update_backup_password(ops_test: OpsTest) -> None:
         ops_test.model.wait_for_idle(apps=[db_app_name], status="active", idle_period=15),
     )
 
-    parameters = {"username": "charmed_backup"}
+    parameters = {"username": CHARMED_BACKUP_USERNAME}
     action = await db_unit.run_action("set-password", **parameters)
     action = await action.wait()
-    assert action.status == "completed", "failed to set charmed_backup password"
+    assert action.status == "completed", "failed to set {CHARMED_BACKUP_USERNAME} user password"
 
     # wait for charm to be idle after setting password
     await asyncio.gather(

--- a/tests/integration/mongodb/backups/test_backups.py
+++ b/tests/integration/mongodb/backups/test_backups.py
@@ -404,10 +404,10 @@ async def test_update_backup_password(ops_test: OpsTest) -> None:
         ops_test.model.wait_for_idle(apps=[db_app_name], status="active", idle_period=15),
     )
 
-    parameters = {"username": "backup"}
+    parameters = {"username": "charmed_backup"}
     action = await db_unit.run_action("set-password", **parameters)
     action = await action.wait()
-    assert action.status == "completed", "failed to set backup password"
+    assert action.status == "completed", "failed to set charmed_backup password"
 
     # wait for charm to be idle after setting password
     await asyncio.gather(

--- a/tests/integration/mongodb/backups/test_sharding_backups.py
+++ b/tests/integration/mongodb/backups/test_sharding_backups.py
@@ -14,6 +14,7 @@ from ...helpers.backups import (
     set_credentials,
 )
 from ...helpers.common import (
+    CHARMED_BACKUP_USERNAME,
     DEPLOYMENT_TIMEOUT,
     TIMEOUT,
     find_unit,
@@ -147,21 +148,21 @@ async def test_rotate_backup_password(ops_test: OpsTest) -> None:
     new_password = "new-password"
 
     shard_backup_password = await get_password(
-        ops_test, username="charmed_backup", app_name=SHARD_ONE_APP_NAME
+        ops_test, username=CHARMED_BACKUP_USERNAME, app_name=SHARD_ONE_APP_NAME
     )
     assert (
         shard_backup_password != new_password
     ), "shard-one is incorrectly already set to the new password."
 
     shard_backup_password = await get_password(
-        ops_test, username="charmed_backup", app_name=SHARD_TWO_APP_NAME
+        ops_test, username=CHARMED_BACKUP_USERNAME, app_name=SHARD_TWO_APP_NAME
     )
     assert (
         shard_backup_password != new_password
     ), "shard-two is incorrectly already set to the new password."
 
     await set_password(
-        ops_test, unit_id=config_leader_id, username="charmed_backup", password=new_password
+        ops_test, unit_id=config_leader_id, username=CHARMED_BACKUP_USERNAME, password=new_password
     )
     await ops_test.model.wait_for_idle(
         apps=[CONFIG_SERVER_APP_NAME, SHARD_ONE_APP_NAME, SHARD_TWO_APP_NAME],
@@ -170,7 +171,7 @@ async def test_rotate_backup_password(ops_test: OpsTest) -> None:
         status="active",
     )
     config_svr_backup_password = await get_password(
-        ops_test, username="charmed_backup", app_name=CONFIG_SERVER_APP_NAME
+        ops_test, username=CHARMED_BACKUP_USERNAME, app_name=CONFIG_SERVER_APP_NAME
     )
 
     assert (
@@ -178,12 +179,12 @@ async def test_rotate_backup_password(ops_test: OpsTest) -> None:
     ), "Application config-srver did not rotate password"
 
     shard_backup_password = await get_password(
-        ops_test, username="charmed_backup", app_name=SHARD_ONE_APP_NAME
+        ops_test, username=CHARMED_BACKUP_USERNAME, app_name=SHARD_ONE_APP_NAME
     )
     assert shard_backup_password == new_password, "Application shard-one did not rotate password"
 
     shard_backup_password = await get_password(
-        ops_test, username="charmed_backup", app_name=SHARD_TWO_APP_NAME
+        ops_test, username=CHARMED_BACKUP_USERNAME, app_name=SHARD_TWO_APP_NAME
     )
     assert shard_backup_password == new_password, "Application shard-two did not rotate password"
 

--- a/tests/integration/mongodb/backups/test_sharding_backups.py
+++ b/tests/integration/mongodb/backups/test_sharding_backups.py
@@ -147,20 +147,22 @@ async def test_rotate_backup_password(ops_test: OpsTest) -> None:
     new_password = "new-password"
 
     shard_backup_password = await get_password(
-        ops_test, username="backup", app_name=SHARD_ONE_APP_NAME
+        ops_test, username="charmed_backup", app_name=SHARD_ONE_APP_NAME
     )
     assert (
         shard_backup_password != new_password
     ), "shard-one is incorrectly already set to the new password."
 
     shard_backup_password = await get_password(
-        ops_test, username="backup", app_name=SHARD_TWO_APP_NAME
+        ops_test, username="charmed_backup", app_name=SHARD_TWO_APP_NAME
     )
     assert (
         shard_backup_password != new_password
     ), "shard-two is incorrectly already set to the new password."
 
-    await set_password(ops_test, unit_id=config_leader_id, username="backup", password=new_password)
+    await set_password(
+        ops_test, unit_id=config_leader_id, username="charmed_backup", password=new_password
+    )
     await ops_test.model.wait_for_idle(
         apps=[CONFIG_SERVER_APP_NAME, SHARD_ONE_APP_NAME, SHARD_TWO_APP_NAME],
         idle_period=20,
@@ -168,7 +170,7 @@ async def test_rotate_backup_password(ops_test: OpsTest) -> None:
         status="active",
     )
     config_svr_backup_password = await get_password(
-        ops_test, username="backup", app_name=CONFIG_SERVER_APP_NAME
+        ops_test, username="charmed_backup", app_name=CONFIG_SERVER_APP_NAME
     )
 
     assert (
@@ -176,12 +178,12 @@ async def test_rotate_backup_password(ops_test: OpsTest) -> None:
     ), "Application config-srver did not rotate password"
 
     shard_backup_password = await get_password(
-        ops_test, username="backup", app_name=SHARD_ONE_APP_NAME
+        ops_test, username="charmed_backup", app_name=SHARD_ONE_APP_NAME
     )
     assert shard_backup_password == new_password, "Application shard-one did not rotate password"
 
     shard_backup_password = await get_password(
-        ops_test, username="backup", app_name=SHARD_TWO_APP_NAME
+        ops_test, username="charmed_backup", app_name=SHARD_TWO_APP_NAME
     )
     assert shard_backup_password == new_password, "Application shard-two did not rotate password"
 

--- a/tests/integration/mongodb/test_charm.py
+++ b/tests/integration/mongodb/test_charm.py
@@ -228,24 +228,24 @@ async def test_set_password_action(ops_test: OpsTest, substrate: Substrate) -> N
 
 
 @pytest.mark.abort_on_fail
-async def test_monitor_user(ops_test: OpsTest, substrate: Substrate) -> None:
-    """Test verifies that the monitor user can perform operations such as 'rs.conf()'."""
+async def test_charmed_monitor_user(ops_test: OpsTest, substrate: Substrate) -> None:
+    """Test verifies that the charmed_monitor user can perform operations such as 'rs.conf()'."""
     app_name = await get_app_name(ops_test)
-    password = await get_password(ops_test, username="monitor")
+    password = await get_password(ops_test, username="charmed_monitor")
     replica_set_hosts = [
         await get_address_of_unit(ops_test, substrate, int(unit.name.split("/")[1]), app_name)
         for unit in ops_test.model.applications[app_name].units
     ]
 
     hosts = ",".join(replica_set_hosts)
-    replica_set_uri = f"mongodb://monitor:{password}@{hosts}/admin?replicaSet={app_name}"
+    replica_set_uri = f"mongodb://charmed_monitor:{password}@{hosts}/admin?replicaSet={app_name}"
 
     admin_mongod_cmd = "rs.conf()"
 
     result = await execute_on_mongod(
         ops_test, app_name, substrate, replica_set_uri, admin_mongod_cmd
     )
-    assert result.succeeded, "Failed to get conf with monitor user."
+    assert result.succeeded, "Failed to get conf with charmed_monitor user."
 
 
 async def test_only_leader_can_set_while_all_can_read_password_secret(
@@ -258,13 +258,15 @@ async def test_only_leader_can_set_while_all_can_read_password_secret(
     non_leaders.remove(leader_id)
 
     password = "blablabla"
-    await set_password(ops_test, unit_id=non_leaders[0], username="monitor", password=password)
-    password1 = await get_password(ops_test, username="monitor")
+    await set_password(
+        ops_test, unit_id=non_leaders[0], username="charmed_monitor", password=password
+    )
+    password1 = await get_password(ops_test, username="charmed_monitor")
     assert password1 != password
 
-    await set_password(ops_test, unit_id=leader_id, username="monitor", password=password)
+    await set_password(ops_test, unit_id=leader_id, username="charmed_monitor", password=password)
     for _ in UNIT_IDS:
-        password2 = await get_password(ops_test, username="monitor")
+        password2 = await get_password(ops_test, username="charmed_monitor")
         assert password2 == password
 
 
@@ -276,10 +278,12 @@ async def test_reset_and_get_password_secret_same_as_cli(ops_test: OpsTest) -> N
 
     # Resetting existing password
     leader_id = await get_leader_id(ops_test)
-    await set_password(ops_test, unit_id=leader_id, username="monitor", password=new_password)
+    await set_password(
+        ops_test, unit_id=leader_id, username="charmed_monitor", password=new_password
+    )
 
     # Getting back the pw programmatically
-    password = await get_password(ops_test, username="monitor")
+    password = await get_password(ops_test, username="charmed_monitor")
 
     secret_label = f"{app_name}.app"
 
@@ -290,16 +294,16 @@ async def test_reset_and_get_password_secret_same_as_cli(ops_test: OpsTest) -> N
 
     assert password == new_password
 
-    assert data["content"]["Data"]["monitor-password"] == password
+    assert data["content"]["Data"]["charmed-monitor-password"] == password
 
 
 async def test_empty_password(ops_test: OpsTest) -> None:
     """Test that the password can't be set to an empty string."""
     leader_id = await get_leader_id(ops_test)
 
-    password1 = await get_password(ops_test, username="monitor")
-    await set_password(ops_test, unit_id=leader_id, username="monitor", password="")
-    password2 = await get_password(ops_test, username="monitor")
+    password1 = await get_password(ops_test, username="charmed_monitor")
+    await set_password(ops_test, unit_id=leader_id, username="charmed_monitor", password="")
+    password2 = await get_password(ops_test, username="charmed_monitor")
 
     # The password remained unchanged
     assert password1 == password2
@@ -309,11 +313,13 @@ async def test_empty_password(ops_test: OpsTest) -> None:
 async def test_no_password_change_on_invalid_password(ops_test: OpsTest) -> None:
     """Test that in general, there is no change when password validation fails."""
     leader_id = await get_leader_id(ops_test)
-    password1 = await get_password(ops_test, username="monitor")
+    password1 = await get_password(ops_test, username="charmed_monitor")
 
     # The password has to be minimum 3 characters
-    await set_password(ops_test, unit_id=leader_id, username="monitor", password="ca" * 1000000)
-    password2 = await get_password(ops_test, username="monitor")
+    await set_password(
+        ops_test, unit_id=leader_id, username="charmed_monitor", password="ca" * 1000000
+    )
+    password2 = await get_password(ops_test, username="charmed_monitor")
 
     # The password didn't change
     assert password1 == password2

--- a/tests/integration/mongodb/test_charm.py
+++ b/tests/integration/mongodb/test_charm.py
@@ -19,6 +19,7 @@ from pytest_operator.plugin import OpsTest
 from tenacity import RetryError
 
 from ..helpers.common import (
+    CHARMED_MONITOR_USERNAME,
     DEFAULT_COLLECTION_NAME,
     DEFAULT_DATABASE_NAME,
     DEPLOYMENT_TIMEOUT,
@@ -231,21 +232,23 @@ async def test_set_password_action(ops_test: OpsTest, substrate: Substrate) -> N
 async def test_charmed_monitor_user(ops_test: OpsTest, substrate: Substrate) -> None:
     """Test verifies that the charmed_monitor user can perform operations such as 'rs.conf()'."""
     app_name = await get_app_name(ops_test)
-    password = await get_password(ops_test, username="charmed_monitor")
+    password = await get_password(ops_test, username=CHARMED_MONITOR_USERNAME)
     replica_set_hosts = [
         await get_address_of_unit(ops_test, substrate, int(unit.name.split("/")[1]), app_name)
         for unit in ops_test.model.applications[app_name].units
     ]
 
     hosts = ",".join(replica_set_hosts)
-    replica_set_uri = f"mongodb://charmed_monitor:{password}@{hosts}/admin?replicaSet={app_name}"
+    replica_set_uri = (
+        f"mongodb://{CHARMED_MONITOR_USERNAME}:{password}@{hosts}/admin?replicaSet={app_name}"
+    )
 
     admin_mongod_cmd = "rs.conf()"
 
     result = await execute_on_mongod(
         ops_test, app_name, substrate, replica_set_uri, admin_mongod_cmd
     )
-    assert result.succeeded, "Failed to get conf with charmed_monitor user."
+    assert result.succeeded, f"Failed to get conf with {CHARMED_MONITOR_USERNAME} user."
 
 
 async def test_only_leader_can_set_while_all_can_read_password_secret(
@@ -259,14 +262,16 @@ async def test_only_leader_can_set_while_all_can_read_password_secret(
 
     password = "blablabla"
     await set_password(
-        ops_test, unit_id=non_leaders[0], username="charmed_monitor", password=password
+        ops_test, unit_id=non_leaders[0], username=CHARMED_MONITOR_USERNAME, password=password
     )
-    password1 = await get_password(ops_test, username="charmed_monitor")
+    password1 = await get_password(ops_test, username=CHARMED_MONITOR_USERNAME)
     assert password1 != password
 
-    await set_password(ops_test, unit_id=leader_id, username="charmed_monitor", password=password)
+    await set_password(
+        ops_test, unit_id=leader_id, username=CHARMED_MONITOR_USERNAME, password=password
+    )
     for _ in UNIT_IDS:
-        password2 = await get_password(ops_test, username="charmed_monitor")
+        password2 = await get_password(ops_test, username=CHARMED_MONITOR_USERNAME)
         assert password2 == password
 
 
@@ -279,11 +284,11 @@ async def test_reset_and_get_password_secret_same_as_cli(ops_test: OpsTest) -> N
     # Resetting existing password
     leader_id = await get_leader_id(ops_test)
     await set_password(
-        ops_test, unit_id=leader_id, username="charmed_monitor", password=new_password
+        ops_test, unit_id=leader_id, username=CHARMED_MONITOR_USERNAME, password=new_password
     )
 
     # Getting back the pw programmatically
-    password = await get_password(ops_test, username="charmed_monitor")
+    password = await get_password(ops_test, username=CHARMED_MONITOR_USERNAME)
 
     secret_label = f"{app_name}.app"
 
@@ -301,9 +306,9 @@ async def test_empty_password(ops_test: OpsTest) -> None:
     """Test that the password can't be set to an empty string."""
     leader_id = await get_leader_id(ops_test)
 
-    password1 = await get_password(ops_test, username="charmed_monitor")
-    await set_password(ops_test, unit_id=leader_id, username="charmed_monitor", password="")
-    password2 = await get_password(ops_test, username="charmed_monitor")
+    password1 = await get_password(ops_test, username=CHARMED_MONITOR_USERNAME)
+    await set_password(ops_test, unit_id=leader_id, username=CHARMED_MONITOR_USERNAME, password="")
+    password2 = await get_password(ops_test, username=CHARMED_MONITOR_USERNAME)
 
     # The password remained unchanged
     assert password1 == password2
@@ -313,13 +318,13 @@ async def test_empty_password(ops_test: OpsTest) -> None:
 async def test_no_password_change_on_invalid_password(ops_test: OpsTest) -> None:
     """Test that in general, there is no change when password validation fails."""
     leader_id = await get_leader_id(ops_test)
-    password1 = await get_password(ops_test, username="charmed_monitor")
+    password1 = await get_password(ops_test, username=CHARMED_MONITOR_USERNAME)
 
     # The password has to be minimum 3 characters
     await set_password(
-        ops_test, unit_id=leader_id, username="charmed_monitor", password="ca" * 1000000
+        ops_test, unit_id=leader_id, username=CHARMED_MONITOR_USERNAME, password="ca" * 1000000
     )
-    password2 = await get_password(ops_test, username="charmed_monitor")
+    password2 = await get_password(ops_test, username=CHARMED_MONITOR_USERNAME)
 
     # The password didn't change
     assert password1 == password2

--- a/tests/integration/mongodb/test_major_upgrades.py
+++ b/tests/integration/mongodb/test_major_upgrades.py
@@ -264,7 +264,7 @@ async def test_restore_backup_7_to_8(
 
     backup_id = most_recent_backup.split()[0]
 
-    await set_fcv(ops_test, substrate, MONGODB_EIGHT, "7.0", "operator")
+    await set_fcv(ops_test, substrate, MONGODB_EIGHT, "7.0", CHARMED_OPERATOR_USERNAME)
 
     leader_unit_eight = await find_unit(ops_test, leader=True, app_name=MONGODB_EIGHT)
     action = await leader_unit_eight.run_action(action_name="restore", **{"backup-id": backup_id})

--- a/tests/integration/mongodb/test_major_upgrades.py
+++ b/tests/integration/mongodb/test_major_upgrades.py
@@ -9,7 +9,7 @@ import pytest
 from pytest_operator.plugin import OpsTest
 from tenacity import RetryError, Retrying, stop_after_attempt, wait_fixed
 
-from single_kernel_mongo.utils.mongodb_users import CharmUsers
+from single_kernel_mongo.utils.mongodb_users import CharmUsernames
 
 from ..helpers.backups import S3_APP_NAME, count_logical_backups
 from ..helpers.common import (
@@ -34,6 +34,8 @@ MONGODB_SEVEN = "mongodb-seven"
 MONGODB_EIGHT = "mongodb-eight"
 
 logger = getLogger(__name__)
+
+username_mapping = {user.replace("charmed_", ""): user for user in CharmUsernames}
 
 
 @pytest.mark.abort_on_fail
@@ -140,13 +142,13 @@ async def test_deploy_mongodb_7(
         apps=[S3_APP_NAME, MONGODB_SEVEN], timeout=TIMEOUT, status="active"
     )
 
-    for user in CharmUsers:
-        password = await get_password(ops_test, username=user, app_name=MONGODB_SIX)
+    for rel6_username, _ in username_mapping.items():
+        password = await get_password(ops_test, username=rel6_username, app_name=MONGODB_SIX)
         leader_unit = await find_unit(ops_test, leader=True, app_name=MONGODB_SEVEN)
         await set_password(
             ops_test,
             unit_id=get_unit_id(leader_unit.name),
-            username=user,
+            username=rel6_username,
             password=password,
             app_name=MONGODB_SEVEN,
         )
@@ -233,13 +235,13 @@ async def test_deploy_mongodb_8(
         apps=[S3_APP_NAME, MONGODB_EIGHT], timeout=TIMEOUT, status="active"
     )
 
-    for user in CharmUsers:
-        password = await get_password(ops_test, username=user, app_name=MONGODB_SIX)
+    for rel6_username, rel8_username in username_mapping.items():
+        password = await get_password(ops_test, username=rel6_username, app_name=MONGODB_SIX)
         leader_unit = await find_unit(ops_test, leader=True, app_name=MONGODB_EIGHT)
         await set_password(
             ops_test,
             unit_id=get_unit_id(leader_unit.name),
-            username=user,
+            username=rel8_username,
             password=password,
             app_name=MONGODB_EIGHT,
         )

--- a/tests/integration/mongodb/test_major_upgrades.py
+++ b/tests/integration/mongodb/test_major_upgrades.py
@@ -13,6 +13,7 @@ from single_kernel_mongo.utils.mongodb_users import CharmUsernames
 
 from ..helpers.backups import S3_APP_NAME, count_logical_backups
 from ..helpers.common import (
+    CHARMED_OPERATOR_USERNAME,
     DEPLOYMENT_TIMEOUT,
     TIMEOUT,
     count_writes,
@@ -169,7 +170,7 @@ async def test_restore_backup_6_to_7(
 
     backup_id = most_recent_backup.split()[0]
 
-    await set_fcv(ops_test, substrate, MONGODB_SEVEN, "6.0")
+    await set_fcv(ops_test, substrate, MONGODB_SEVEN, "6.0", "operator")
 
     leader_unit_seven = await find_unit(ops_test, leader=True, app_name=MONGODB_SEVEN)
     action = await leader_unit_seven.run_action(action_name="restore", **{"backup-id": backup_id})
@@ -180,7 +181,7 @@ async def test_restore_backup_6_to_7(
 
     await ops_test.model.wait_for_idle(apps=[MONGODB_SEVEN], timeout=TIMEOUT, status="active")
 
-    await set_fcv(ops_test, substrate, MONGODB_SEVEN, "7.0")
+    await set_fcv(ops_test, substrate, MONGODB_SEVEN, "7.0", "operator")
 
 
 @pytest.mark.abort_on_fail
@@ -263,7 +264,7 @@ async def test_restore_backup_7_to_8(
 
     backup_id = most_recent_backup.split()[0]
 
-    await set_fcv(ops_test, substrate, MONGODB_EIGHT, "7.0")
+    await set_fcv(ops_test, substrate, MONGODB_EIGHT, "7.0", "operator")
 
     leader_unit_eight = await find_unit(ops_test, leader=True, app_name=MONGODB_EIGHT)
     action = await leader_unit_eight.run_action(action_name="restore", **{"backup-id": backup_id})
@@ -274,7 +275,7 @@ async def test_restore_backup_7_to_8(
 
     await ops_test.model.wait_for_idle(apps=[MONGODB_EIGHT], timeout=TIMEOUT, status="active")
 
-    await set_fcv(ops_test, substrate, MONGODB_EIGHT, "8.0")
+    await set_fcv(ops_test, substrate, MONGODB_EIGHT, "8.0", CHARMED_OPERATOR_USERNAME)
 
     leader_unit_six = await find_unit(ops_test, leader=True, app_name=MONGODB_SIX)
     leader_unit_eight = await find_unit(ops_test, leader=True, app_name=MONGODB_EIGHT)

--- a/tests/integration/mongodb/test_metrics.py
+++ b/tests/integration/mongodb/test_metrics.py
@@ -66,7 +66,7 @@ async def test_endpoints_new_password(ops_test: OpsTest, substrate: Substrate):
     app_name = await get_app_name(ops_test)
     application = ops_test.model.applications[app_name]
     leader_unit = await find_unit(ops_test, leader=True)
-    action = await leader_unit.run_action("set-password", **{"username": "monitor"})
+    action = await leader_unit.run_action("set-password", **{"username": "charmed_monitor"})
     action = await action.wait()
     # wait for non-leader units to receive relation changed event.
     time.sleep(3)

--- a/tests/integration/mongodb/test_metrics.py
+++ b/tests/integration/mongodb/test_metrics.py
@@ -9,6 +9,7 @@ from juju.unit import Unit as JujuUnit
 from pytest_operator.plugin import OpsTest
 
 from ..helpers.common import (
+    CHARMED_MONITOR_USERNAME,
     DEPLOYMENT_TIMEOUT,
     UNIT_IDS,
     check_or_scale_app,
@@ -66,7 +67,7 @@ async def test_endpoints_new_password(ops_test: OpsTest, substrate: Substrate):
     app_name = await get_app_name(ops_test)
     application = ops_test.model.applications[app_name]
     leader_unit = await find_unit(ops_test, leader=True)
-    action = await leader_unit.run_action("set-password", **{"username": "charmed_monitor"})
+    action = await leader_unit.run_action("set-password", **{"username": CHARMED_MONITOR_USERNAME})
     action = await action.wait()
     # wait for non-leader units to receive relation changed event.
     time.sleep(3)

--- a/tests/integration/mongodb/test_sharding.py
+++ b/tests/integration/mongodb/test_sharding.py
@@ -8,9 +8,9 @@ from pymongo import MongoClient
 from pytest_operator.plugin import OpsTest
 
 from ..helpers.common import (
+    CHARMED_OPERATOR_PASSWORD,
+    CHARMED_OPERATOR_USERNAME,
     DEPLOYMENT_TIMEOUT,
-    OPERATOR_PASSWORD,
-    OPERATOR_USERNAME,
     TIMEOUT,
     deploy_charm,
     find_unit,
@@ -151,14 +151,14 @@ async def test_cluster_active(ops_test: OpsTest, substrate: Substrate) -> None:
 
 
 @pytest.mark.abort_on_fail
-async def test_set_operator_password(ops_test: OpsTest):
-    """Tests that the cluster can safely set the operator password."""
+async def test_set_charmed_operator_password(ops_test: OpsTest):
+    """Tests that the cluster can safely set the charmed_operator password."""
     for cluster_app_name in CLUSTER_APPS:
         operator_password = await get_password(
-            ops_test, username=OPERATOR_USERNAME, app_name=cluster_app_name
+            ops_test, username=CHARMED_OPERATOR_USERNAME, app_name=cluster_app_name
         )
         assert (
-            operator_password != OPERATOR_PASSWORD
+            operator_password != CHARMED_OPERATOR_PASSWORD
         ), f"{cluster_app_name} is incorrectly already set to the new password."
 
     # rotate password and verify that no unit goes into error as a result of password rotation
@@ -166,8 +166,8 @@ async def test_set_operator_password(ops_test: OpsTest):
     await set_password(
         ops_test,
         unit_id=config_leader_id,
-        username=OPERATOR_USERNAME,
-        password=OPERATOR_PASSWORD,
+        username=CHARMED_OPERATOR_USERNAME,
+        password=CHARMED_OPERATOR_PASSWORD,
     )
     await ops_test.model.wait_for_idle(
         apps=CLUSTER_APPS,
@@ -177,10 +177,10 @@ async def test_set_operator_password(ops_test: OpsTest):
 
     for cluster_app_name in CLUSTER_APPS:
         operator_password = await get_password(
-            ops_test, username=OPERATOR_USERNAME, app_name=cluster_app_name
+            ops_test, username=CHARMED_OPERATOR_USERNAME, app_name=cluster_app_name
         )
         assert (
-            operator_password == OPERATOR_PASSWORD
+            operator_password == CHARMED_OPERATOR_PASSWORD
         ), f"{cluster_app_name} did not rotate to new password."
 
 

--- a/tests/integration/mongodb/test_sharding_major_upgrades.py
+++ b/tests/integration/mongodb/test_sharding_major_upgrades.py
@@ -9,7 +9,7 @@ import pytest
 from pytest_operator.plugin import OpsTest
 from tenacity import RetryError, Retrying, stop_after_attempt, wait_fixed
 
-from single_kernel_mongo.utils.mongodb_users import CharmUsers
+from single_kernel_mongo.utils.mongodb_users import CharmUsernames
 from tests.integration.helpers.sharding import (
     deploy_cluster_components,
     integrate_sharding_components,
@@ -46,6 +46,8 @@ SHARD_ONE_EIGHT = "shard-one-eight"
 SHARD_TWO_EIGHT = "shard-two-eight"
 
 logger = getLogger(__name__)
+
+username_mapping = {user.replace("charmed_", ""): user for user in CharmUsernames}
 
 
 @pytest.mark.abort_on_fail
@@ -199,13 +201,13 @@ async def test_deploy_mongodb_7(ops_test: OpsTest, substrate: Substrate, mongodb
         apps=[S3_APP_NAME, CONFIG_SERVER_SEVEN], timeout=TIMEOUT, status="active"
     )
 
-    for user in CharmUsers:
-        password = await get_password(ops_test, username=user, app_name=CONFIG_SERVER_SIX)
+    for rel6_username, _ in username_mapping.items():
+        password = await get_password(ops_test, username=rel6_username, app_name=CONFIG_SERVER_SIX)
         leader_unit = await find_unit(ops_test, leader=True, app_name=CONFIG_SERVER_SEVEN)
         await set_password(
             ops_test,
             unit_id=get_unit_id(leader_unit.name),
-            username=user,
+            username=rel6_username,
             password=password,
             app_name=CONFIG_SERVER_SEVEN,
         )
@@ -317,13 +319,13 @@ async def test_deploy_mongodb_8(
         apps=[S3_APP_NAME, CONFIG_SERVER_EIGHT], timeout=TIMEOUT, status="active"
     )
 
-    for user in CharmUsers:
-        password = await get_password(ops_test, username=user, app_name=CONFIG_SERVER_SIX)
+    for rel6_username, rel8_username in username_mapping.items():
+        password = await get_password(ops_test, username=rel6_username, app_name=CONFIG_SERVER_SIX)
         leader_unit = await find_unit(ops_test, leader=True, app_name=CONFIG_SERVER_EIGHT)
         await set_password(
             ops_test,
             unit_id=get_unit_id(leader_unit.name),
-            username=user,
+            username=rel8_username,
             password=password,
             app_name=CONFIG_SERVER_EIGHT,
         )

--- a/tests/integration/mongodb/test_sharding_major_upgrades.py
+++ b/tests/integration/mongodb/test_sharding_major_upgrades.py
@@ -352,7 +352,7 @@ async def test_restore_backup_7_to_8(
 
     backup_id = most_recent_backup.split()[0]
 
-    await set_fcv(ops_test, substrate, CONFIG_SERVER_EIGHT, "7.0", "operator")
+    await set_fcv(ops_test, substrate, CONFIG_SERVER_EIGHT, "7.0", CHARMED_OPERATOR_USERNAME)
 
     leader_unit_eight = await find_unit(ops_test, leader=True, app_name=CONFIG_SERVER_EIGHT)
     action = await leader_unit_eight.run_action(

--- a/tests/integration/mongodb/test_sharding_major_upgrades.py
+++ b/tests/integration/mongodb/test_sharding_major_upgrades.py
@@ -117,7 +117,7 @@ async def test_deploy_mongodb_6(
     await deploy_application(ops_test, application_path=application_path, app_name=application_name)
 
     mongos_uri: str = await mongodb_uri(
-        ops_test, substrate, app_name=CONFIG_SERVER_SIX, port=MONGOS_PORT
+        ops_test, substrate, app_name=CONFIG_SERVER_SIX, port=MONGOS_PORT, username="operator"
     )
     await ops_test.model.applications[application_name].set_config({"mongos-uri": mongos_uri})
 

--- a/tests/integration/mongodb/test_sharding_major_upgrades.py
+++ b/tests/integration/mongodb/test_sharding_major_upgrades.py
@@ -18,6 +18,7 @@ from tests.integration.helpers.upgrade import set_fcv
 
 from ..helpers.backups import S3_APP_NAME, count_logical_backups
 from ..helpers.common import (
+    CHARMED_OPERATOR_USERNAME,
     DEPLOYMENT_TIMEOUT,
     MONGOS_PORT,
     TIMEOUT,
@@ -228,7 +229,7 @@ async def test_restore_backup_6_to_7(
 
     backup_id = most_recent_backup.split()[0]
 
-    await set_fcv(ops_test, substrate, CONFIG_SERVER_SEVEN, "6.0")
+    await set_fcv(ops_test, substrate, CONFIG_SERVER_SEVEN, "6.0", "operator")
 
     leader_unit_seven = await find_unit(ops_test, leader=True, app_name=CONFIG_SERVER_SEVEN)
     action = await leader_unit_seven.run_action(
@@ -245,7 +246,7 @@ async def test_restore_backup_6_to_7(
 
     await ops_test.model.wait_for_idle(apps=[CONFIG_SERVER_SEVEN], timeout=TIMEOUT, status="active")
 
-    await set_fcv(ops_test, substrate, CONFIG_SERVER_SEVEN, "7.0")
+    await set_fcv(ops_test, substrate, CONFIG_SERVER_SEVEN, "7.0", "operator")
 
 
 @pytest.mark.abort_on_fail
@@ -351,7 +352,7 @@ async def test_restore_backup_7_to_8(
 
     backup_id = most_recent_backup.split()[0]
 
-    await set_fcv(ops_test, substrate, CONFIG_SERVER_EIGHT, "7.0")
+    await set_fcv(ops_test, substrate, CONFIG_SERVER_EIGHT, "7.0", "operator")
 
     leader_unit_eight = await find_unit(ops_test, leader=True, app_name=CONFIG_SERVER_EIGHT)
     action = await leader_unit_eight.run_action(
@@ -368,7 +369,7 @@ async def test_restore_backup_7_to_8(
 
     await ops_test.model.wait_for_idle(apps=[CONFIG_SERVER_EIGHT], timeout=TIMEOUT, status="active")
 
-    await set_fcv(ops_test, substrate, CONFIG_SERVER_EIGHT, "8.0")
+    await set_fcv(ops_test, substrate, CONFIG_SERVER_EIGHT, "8.0", CHARMED_OPERATOR_USERNAME)
 
     leader_unit_six = await find_unit(ops_test, leader=True, app_name=CONFIG_SERVER_SIX)
     leader_unit_eight = await find_unit(ops_test, leader=True, app_name=CONFIG_SERVER_SEVEN)

--- a/tests/integration/mongodb/upgrades/test_upgrade.py
+++ b/tests/integration/mongodb/upgrades/test_upgrade.py
@@ -145,19 +145,19 @@ async def test_upgrade_password_change_fail(
     leader_unit = await find_unit(ops_test, leader=True, app_name=app_name)
     leader_id = leader_unit.name.split("/")[1]
     current_password = await get_password(
-        ops_test, username="operator", app_name=app_name, unit=leader_unit
+        ops_test, username="charmed_operator", app_name=app_name, unit=leader_unit
     )
 
     await refresh_charm(ops_test, substrate, app_name, mongodb_charm, mongod_resource)
     await ops_test.model.wait_for_idle(apps=[app_name], timeout=1000, idle_period=120)
 
     action = await ops_test.model.units.get(f"{app_name}/{leader_id}").run_action(
-        "set-password", **{"username": "operator", "password": "new-password"}
+        "set-password", **{"username": "charmed_operator", "password": "new-password"}
     )
     action = await action.wait()
 
     assert "Cannot set passwords while an upgrade is in progress" == action.message
     after_action_password = await get_password(
-        ops_test, username="operator", app_name=app_name, unit=leader_unit
+        ops_test, username="charmed_operator", app_name=app_name, unit=leader_unit
     )
     assert current_password == after_action_password

--- a/tests/integration/mongodb/upgrades/test_upgrade.py
+++ b/tests/integration/mongodb/upgrades/test_upgrade.py
@@ -8,6 +8,7 @@ import pytest
 from pytest_operator.plugin import OpsTest
 
 from ...helpers.common import (
+    CHARMED_OPERATOR_USERNAME,
     DEPLOYMENT_TIMEOUT,
     deploy_charm,
     find_unit,
@@ -145,19 +146,19 @@ async def test_upgrade_password_change_fail(
     leader_unit = await find_unit(ops_test, leader=True, app_name=app_name)
     leader_id = leader_unit.name.split("/")[1]
     current_password = await get_password(
-        ops_test, username="charmed_operator", app_name=app_name, unit=leader_unit
+        ops_test, username=CHARMED_OPERATOR_USERNAME, app_name=app_name, unit=leader_unit
     )
 
     await refresh_charm(ops_test, substrate, app_name, mongodb_charm, mongod_resource)
     await ops_test.model.wait_for_idle(apps=[app_name], timeout=1000, idle_period=120)
 
     action = await ops_test.model.units.get(f"{app_name}/{leader_id}").run_action(
-        "set-password", **{"username": "charmed_operator", "password": "new-password"}
+        "set-password", **{"username": CHARMED_OPERATOR_USERNAME, "password": "new-password"}
     )
     action = await action.wait()
 
     assert "Cannot set passwords while an upgrade is in progress" == action.message
     after_action_password = await get_password(
-        ops_test, username="charmed_operator", app_name=app_name, unit=leader_unit
+        ops_test, username=CHARMED_OPERATOR_USERNAME, app_name=app_name, unit=leader_unit
     )
     assert current_password == after_action_password

--- a/tests/unit/helpers.py
+++ b/tests/unit/helpers.py
@@ -10,7 +10,7 @@ class MongoConfigurationFactory(factory.Factory):
 
     hosts = {LOCALHOST}
     database = "abadcafe"
-    username = "operator"
+    username = "charmed_operator"
     password = "deadbeef"
     roles: set[str] = set()
     tls_external = False

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -417,7 +417,7 @@ def test_start_mongod_error_initialising_users(
     mocker.patch("single_kernel_mongo.utils.mongo_connection.MongoConnection.init_replset")
     defer = mocker.patch("ops.framework.EventBase.defer")
     init_operator_user = mocker.patch(
-        "single_kernel_mongo.managers.mongo.MongoManager.initialise_operator_user"
+        "single_kernel_mongo.managers.mongo.MongoManager.initialise_charmed_operator_user"
     )
     init_user = mocker.patch("single_kernel_mongo.managers.mongo.MongoManager.initialise_user")
     # presets
@@ -637,14 +637,14 @@ def test_on_secret_changed_unknown(harness: Harness[MongoTestCharm], mocker):
 
 
 def test_connect_to_mongo_exporter_on_set_password(harness, mocker, mock_fs_interactions):
-    """Test configure_and_restart is called when the password is set for 'monitor' user."""
+    """Test configure_and_restart is called when the password is set for charmed_monitor user."""
     mocker.patch("single_kernel_mongo.utils.mongo_connection.MongoConnection.set_user_password")
     connect_exporter = mocker.patch(
         "single_kernel_mongo.managers.config.MongoDBExporterConfigManager.configure_and_restart"
     )
     harness.set_leader(True)
 
-    harness.run_action("set-password", {"username": "monitor"})
+    harness.run_action("set-password", {"username": "charmed_monitor"})
     connect_exporter.assert_called()
 
 
@@ -658,7 +658,7 @@ def test_event_auto_reset_password_secrets_when_no_pw_value_shipped(
     )
     harness.set_leader(True)
 
-    params = {"username": "monitor"}
+    params = {"username": "charmed_monitor"}
     output = harness.run_action("get-password", params)
 
     pw1 = output.results["password"]
@@ -694,14 +694,14 @@ def test_connect_mongodb_exporter_success(
     password = harness.charm.operator.state.get_user_password(CharmedMonitorUser)
 
     uri_template = (
-        "mongodb://monitor:{password}@{mongodb_hostname}:27017/admin?replicaSet=mongodb-k8s"
+        "mongodb://charmed_monitor:{password}@{mongodb_hostname}:27017/admin?replicaSet=mongodb-k8s"
     )
 
     env = harness.charm.operator.mongodb_exporter_config_manager.get_environment()
 
     assert env == uri_template.format(password=password, mongodb_hostname=mongodb_hostname)
 
-    params = {"username": "monitor", "password": "mongo123"}
+    params = {"username": "charmed_monitor", "password": "mongo123"}
     harness.run_action("set-password", params)
 
     password = harness.charm.operator.state.get_user_password(CharmedMonitorUser)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -15,7 +15,11 @@ from single_kernel_mongo.exceptions import (
     WorkloadNotReadyError,
     WorkloadServiceError,
 )
-from single_kernel_mongo.utils.mongodb_users import BackupUser, MonitorUser, OperatorUser
+from single_kernel_mongo.utils.mongodb_users import (
+    CharmedBackupUser,
+    CharmedMonitorUser,
+    CharmedOperatorUser,
+)
 from tests.charms.mongodb_test_charm.src.charm import MongoTestCharm
 
 PEER_ADDR = {"private-address": "127.4.5.6"}
@@ -281,22 +285,22 @@ def test_on_config_changed_upgrade_in_progress(harness, mocker):
 def test_on_leader_elected(harness):
     state = harness.charm.operator.state
     assert state.get_keyfile() is None
-    assert state.get_user_password(MonitorUser) == ""
-    assert state.get_user_password(OperatorUser) == ""
-    assert state.get_user_password(BackupUser) == ""
+    assert state.get_user_password(CharmedMonitorUser) == ""
+    assert state.get_user_password(CharmedOperatorUser) == ""
+    assert state.get_user_password(CharmedBackupUser) == ""
     harness.set_leader(True)
     assert len(state.get_keyfile()) == 1024
-    assert len(state.get_user_password(MonitorUser)) == 32
-    assert len(state.get_user_password(OperatorUser)) == 32
-    assert len(state.get_user_password(BackupUser)) == 32
+    assert len(state.get_user_password(CharmedMonitorUser)) == 32
+    assert len(state.get_user_password(CharmedOperatorUser)) == 32
+    assert len(state.get_user_password(CharmedBackupUser)) == 32
 
 
 def test_on_leader_elected_dont_rotate_if_present(harness):
     state = harness.charm.operator.state
     harness.set_leader(True)
-    operator_password = state.get_user_password(OperatorUser)
+    operator_password = state.get_user_password(CharmedOperatorUser)
     harness.charm.on.leader_elected.emit()
-    assert state.get_user_password(OperatorUser) == operator_password
+    assert state.get_user_password(CharmedOperatorUser) == operator_password
 
 
 def test_on_secret_changed(harness: Harness[MongoTestCharm], mocker, mock_fs_interactions):
@@ -309,7 +313,7 @@ def test_on_secret_changed(harness: Harness[MongoTestCharm], mocker, mock_fs_int
     secret = harness.charm.operator.state.secrets.get(scope=Scope.APP)
     # breakpoint()
     content = secret.get_content()
-    content["monitor-password"] = password
+    content["charmed-monitor-password"] = password
     secret.set_content(content)
 
     harness.charm.operator.update_secrets_and_restart(secret_label, secret.get_info().id)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -17,11 +17,6 @@ from single_kernel_mongo.exceptions import (
     WorkloadNotReadyError,
     WorkloadServiceError,
 )
-from single_kernel_mongo.utils.mongodb_users import (
-    CharmedBackupUser,
-    CharmedMonitorUser,
-    CharmedOperatorUser,
-)
 from single_kernel_mongo.utils.mongo_connection import NotReadyError
 from single_kernel_mongo.utils.mongodb_users import (
     CharmedBackupUser,
@@ -696,7 +691,7 @@ def test_connect_mongodb_exporter_success(
     else:
         harness.charm.on.start.emit()
 
-    password = harness.charm.operator.state.get_user_password(MonitorUser)
+    password = harness.charm.operator.state.get_user_password(CharmedMonitorUser)
 
     uri_template = (
         "mongodb://monitor:{password}@{mongodb_hostname}:27017/admin?replicaSet=mongodb-k8s"
@@ -709,7 +704,7 @@ def test_connect_mongodb_exporter_success(
     params = {"username": "monitor", "password": "mongo123"}
     harness.run_action("set-password", params)
 
-    password = harness.charm.operator.state.get_user_password(MonitorUser)
+    password = harness.charm.operator.state.get_user_password(CharmedMonitorUser)
 
     new_uri = harness.charm.operator.mongodb_exporter_config_manager.get_environment()
 

--- a/tests/unit/test_charm_state.py
+++ b/tests/unit/test_charm_state.py
@@ -4,7 +4,11 @@ from ops.testing import Harness
 from single_kernel_mongo.config.literals import Scope
 from single_kernel_mongo.config.relations import PeerRelationNames
 from single_kernel_mongo.core.structured_config import MongoDBRoles
-from single_kernel_mongo.utils.mongodb_users import BackupUser, MonitorUser, OperatorUser
+from single_kernel_mongo.utils.mongodb_users import (
+    CharmedBackupUser,
+    CharmedMonitorUser,
+    CharmedOperatorUser,
+)
 from tests.charms.mongodb_test_charm.src.charm import MongoTestCharm
 
 PEER_ADDR = {"private-address": "127.4.5.6"}
@@ -41,10 +45,14 @@ def test_users_secrets(harness: Harness[MongoTestCharm]):
 
     state = harness.charm.operator.state
     assert state.operator_config.password == state.secrets.get_for_key(
-        Scope.APP, "operator-password"
+        Scope.APP, "charmed-operator-password"
     )
-    assert state.monitor_config.password == state.secrets.get_for_key(Scope.APP, "monitor-password")
-    assert state.backup_config.password == state.secrets.get_for_key(Scope.APP, "backup-password")
+    assert state.monitor_config.password == state.secrets.get_for_key(
+        Scope.APP, "charmed-monitor-password"
+    )
+    assert state.backup_config.password == state.secrets.get_for_key(
+        Scope.APP, "charmed-backup-password"
+    )
 
 
 def test_app_peer_data(harness: Harness[MongoTestCharm]):
@@ -59,12 +67,12 @@ def test_app_peer_data(harness: Harness[MongoTestCharm]):
     assert len(state.get_keyfile() or "") == 1024
     assert state.app_peer_data.replica_set == "mongodb"
 
-    assert not state.app_peer_data.is_user_created(MonitorUser.username)
-    assert not state.app_peer_data.is_user_created(BackupUser.username)
-    assert not state.app_peer_data.is_user_created(OperatorUser.username)
+    assert not state.app_peer_data.is_user_created(CharmedMonitorUser.username)
+    assert not state.app_peer_data.is_user_created(CharmedBackupUser.username)
+    assert not state.app_peer_data.is_user_created(CharmedOperatorUser.username)
 
-    state.app_peer_data.set_user_created(MonitorUser.username)
-    assert state.app_peer_data.is_user_created(MonitorUser.username)
+    state.app_peer_data.set_user_created(CharmedMonitorUser.username)
+    assert state.app_peer_data.is_user_created(CharmedMonitorUser.username)
 
     assert not state.app_peer_data.external_connectivity
     state.app_peer_data.external_connectivity = True

--- a/tests/unit/test_cluster_manager.py
+++ b/tests/unit/test_cluster_manager.py
@@ -299,16 +299,16 @@ def test_cluster_requirer_share_credentials_to_clients(
 
     # Upgrade in progress
     with pytest.raises(DeferrableFailedHookChecksError):
-        manager.share_credentials_to_clients("operator", "password")
+        manager.share_credentials_to_clients("charmed_operator", "password")
 
     mocker.patch(
         "single_kernel_mongo.state.charm_state.CharmState.upgrade_in_progress",
         new_callable=mocker.PropertyMock(return_value=False),
     )
 
-    manager.share_credentials_to_clients("operator", "password")
+    manager.share_credentials_to_clients("charmed_operator", "password")
 
-    assert manager.state.secrets.get_for_key(Scope.APP, "username") == "operator"
+    assert manager.state.secrets.get_for_key(Scope.APP, "username") == "charmed_operator"
     assert manager.state.secrets.get_for_key(Scope.APP, "password") == "password"
 
 
@@ -327,7 +327,7 @@ def test_cluster_requirer_update_mongos_and_restart(
 
     mongos_harness.update_relation_data(rel_id_proxy, "test-application", {"database": "test-db"})
 
-    manager.share_credentials_to_clients("operator", "password")
+    manager.share_credentials_to_clients("charmed_operator", "password")
 
     data = Path("tests/unit/data/mongos.conf").read_text().splitlines()
 
@@ -350,7 +350,7 @@ def test_cluster_requirer_update_mongos_and_restart(
 
     for relation in operator.state.client_relations:
         data = relation.data[mongos_harness.charm.app]
-        assert data["username"] == "operator"
+        assert data["username"] == "charmed_operator"
         assert data["password"] == "password"
         assert data["database"] == "test-db"
         assert (
@@ -359,7 +359,7 @@ def test_cluster_requirer_update_mongos_and_restart(
         )
         assert (
             data["uris"]
-            == "mongodb://operator:password@%2Fvar%2Fsnap%2Fcharmed-mongodb%2Fcommon%2Fvar%2Fmongodb-27018.sock/test-db?authSource=admin"
+            == "mongodb://charmed_operator:password@%2Fvar%2Fsnap%2Fcharmed-mongodb%2Fcommon%2Fvar%2Fmongodb-27018.sock/test-db?authSource=admin"
         )
 
 
@@ -450,7 +450,7 @@ def test_cluster_requirer_remove_users_and_cleanup_mongo(
     )  # type: ignore[assignment]
     mongos_harness.add_relation_unit(rel_id_cluster, "mongodb/0")
 
-    manager.share_credentials_to_clients("operator", "password")
+    manager.share_credentials_to_clients("charmed_operator", "password")
 
     data = Path("tests/unit/data/mongos.conf").read_text().splitlines()
 
@@ -509,7 +509,7 @@ def test_cluster_requirer_is_ca_compatible(
     mongos_harness.add_relation(ExternalRequirerRelations.TLS.value, "self-signed-certificates")
 
     # Ensure some credentials are present
-    manager.share_credentials_to_clients("operator", "password")
+    manager.share_credentials_to_clients("charmed_operator", "password")
 
     data = Path("tests/unit/data/mongos.conf").read_text().splitlines()
 
@@ -576,7 +576,7 @@ def test_cluster_requirer_tls_status(
         mongos_harness.add_relation(ExternalRequirerRelations.TLS.value, "self-signed-certificates")
 
     # Ensure some credentials are present
-    manager.share_credentials_to_clients("operator", "password")
+    manager.share_credentials_to_clients("charmed_operator", "password")
 
     data = Path("tests/unit/data/mongos.conf").read_text().splitlines()
 
@@ -647,7 +647,7 @@ def test_cluster_requirer_get_tls_statuses(
         )
 
     # Ensure some credentials are present
-    manager.share_credentials_to_clients("operator", "password")
+    manager.share_credentials_to_clients("charmed_operator", "password")
 
     data = Path("tests/unit/data/mongos.conf").read_text().splitlines()
 

--- a/tests/unit/test_mongo_manager.py
+++ b/tests/unit/test_mongo_manager.py
@@ -9,9 +9,9 @@ from single_kernel_mongo.exceptions import SetPasswordError
 from single_kernel_mongo.utils.mongo_connection import NotReadyError
 from single_kernel_mongo.utils.mongodb_users import (
     OPERATOR_ROLE,
-    BackupUser,
-    MonitorUser,
-    OperatorUser,
+    CharmedBackupUser,
+    CharmedMonitorUser,
+    CharmedOperatorUser,
 )
 from tests.charms.mongodb_test_charm.src.charm import MongoTestCharm
 
@@ -19,9 +19,9 @@ from tests.charms.mongodb_test_charm.src.charm import MongoTestCharm
 def test_set_user_password(harness: Harness[MongoTestCharm], mocker):
     harness.set_leader(True)
     mocker.patch("single_kernel_mongo.utils.mongo_connection.MongoConnection.set_user_password")
-    harness.charm.operator.mongo_manager.set_user_password(OperatorUser, "deadbeef")
+    harness.charm.operator.mongo_manager.set_user_password(CharmedOperatorUser, "deadbeef")
 
-    assert harness.charm.operator.state.get_user_password(OperatorUser) == "deadbeef"
+    assert harness.charm.operator.state.get_user_password(CharmedOperatorUser) == "deadbeef"
 
 
 def test_set_user_not_ready(harness: Harness[MongoTestCharm], mocker):
@@ -30,11 +30,11 @@ def test_set_user_not_ready(harness: Harness[MongoTestCharm], mocker):
         "single_kernel_mongo.utils.mongo_connection.MongoConnection.set_user_password",
         side_effect=NotReadyError,
     )
-    old_password = harness.charm.operator.state.get_user_password(OperatorUser)
+    old_password = harness.charm.operator.state.get_user_password(CharmedOperatorUser)
     with pytest.raises(SetPasswordError):
-        harness.charm.operator.mongo_manager.set_user_password(OperatorUser, "deadbeef")
+        harness.charm.operator.mongo_manager.set_user_password(CharmedOperatorUser, "deadbeef")
 
-    assert harness.charm.operator.state.get_user_password(OperatorUser) == old_password
+    assert harness.charm.operator.state.get_user_password(CharmedOperatorUser) == old_password
 
 
 def test_set_user_pymongo_error(harness: Harness[MongoTestCharm], mocker):
@@ -43,11 +43,11 @@ def test_set_user_pymongo_error(harness: Harness[MongoTestCharm], mocker):
         "single_kernel_mongo.utils.mongo_connection.MongoConnection.set_user_password",
         side_effect=PyMongoError,
     )
-    old_password = harness.charm.operator.state.get_user_password(OperatorUser)
+    old_password = harness.charm.operator.state.get_user_password(CharmedOperatorUser)
     with pytest.raises(SetPasswordError):
-        harness.charm.operator.mongo_manager.set_user_password(OperatorUser, "deadbeef")
+        harness.charm.operator.mongo_manager.set_user_password(CharmedOperatorUser, "deadbeef")
 
-    assert harness.charm.operator.state.get_user_password(OperatorUser) == old_password
+    assert harness.charm.operator.state.get_user_password(CharmedOperatorUser) == old_password
 
 
 def test_initialise_replica_set_operation_failure(harness: Harness[MongoTestCharm], mocker):
@@ -60,7 +60,7 @@ def test_initialise_replica_set_operation_failure(harness: Harness[MongoTestChar
         harness.charm.operator.mongo_manager.initialise_replica_set()
 
 
-@pytest.mark.parametrize(("user"), (MonitorUser, BackupUser))
+@pytest.mark.parametrize(("user"), (CharmedMonitorUser, CharmedBackupUser))
 def test_initialise_user(harness: Harness[MongoTestCharm], mocker, user):
     harness.set_leader(True)
     mock_create_role = mocker.patch(
@@ -71,7 +71,9 @@ def test_initialise_user(harness: Harness[MongoTestCharm], mocker, user):
     )
 
     getattr(harness.charm.operator.mongo_manager, "initialise_user")(user)
-    config = getattr(harness.charm.operator.state, f"{user.username}_config")
+    config = getattr(
+        harness.charm.operator.state, f"{user.username.replace('charmed_', '')}_config"
+    )
 
     mock_create_role.assert_called_with(role_name=user.mongodb_role, privileges=user.privileges)
     mock_create_user.assert_called_with(config.username, config.password, config.supported_roles)
@@ -79,19 +81,19 @@ def test_initialise_user(harness: Harness[MongoTestCharm], mocker, user):
     assert harness.charm.operator.state.app_peer_data.is_user_created(user.username)
 
 
-def test_initialise_operator_user(harness: Harness[MongoTestCharm], mocker):
+def test_initialise_charmed_operator_user(harness: Harness[MongoTestCharm], mocker):
     harness.set_leader(True)
     mock_create_user = mocker.patch(
         "single_kernel_mongo.core.vm_workload.VMWorkload.run_bin_command"
     )
 
-    getattr(harness.charm.operator.mongo_manager, "initialise_operator_user")()
+    getattr(harness.charm.operator.mongo_manager, "initialise_charmed_operator_user")()
     config = getattr(harness.charm.operator.state, "operator_config")
     cmd = [
         "--quiet",
         "--eval",
         '"db.createUser({'
-        f"  user: 'operator',"
+        f"  user: 'charmed_operator',"
         "  pwd: passwordPrompt(),"
         f"  roles: {OPERATOR_ROLE},"
         "  mechanisms: ['SCRAM-SHA-256'],"
@@ -101,4 +103,4 @@ def test_initialise_operator_user(harness: Harness[MongoTestCharm], mocker):
 
     mock_create_user.assert_called_with("mongodb://localhost/admin", cmd, input=config.password)
 
-    assert harness.charm.operator.state.app_peer_data.is_user_created(OperatorUser.username)
+    assert harness.charm.operator.state.app_peer_data.is_user_created(CharmedOperatorUser.username)

--- a/tests/unit/test_mongo_manager.py
+++ b/tests/unit/test_mongo_manager.py
@@ -82,7 +82,9 @@ def test_initialise_user(harness: Harness[MongoTestCharm], mocker, user):
     assert harness.charm.operator.state.app_peer_data.is_user_created(user.username)
 
 
-def test_initialise_charmed_operator_user(harness: Harness[MongoTestCharm], mocker, substrate: Substrate):
+def test_initialise_charmed_operator_user(
+    harness: Harness[MongoTestCharm], mocker, substrate: Substrate
+):
     harness.set_leader(True)
     if substrate == "lxd":
         mock_create_user = mocker.patch(

--- a/tests/unit/test_mongodb_config.py
+++ b/tests/unit/test_mongodb_config.py
@@ -18,7 +18,7 @@ def test_configuration_ok():
     assert config.formatted_auth_source == {"authSource": "admin"}
 
     assert config.uri == (
-        "mongodb://operator:deadbeef@127.0.0.1:27017/abadcafe?replicaSet=cafebabe&authSource=admin"
+        "mongodb://charmed_operator:deadbeef@127.0.0.1:27017/abadcafe?replicaSet=cafebabe&authSource=admin"
     )
 
     assert config.supported_roles == []
@@ -61,4 +61,4 @@ def test_valid_formatted():
 
 def test_standalone():
     config = MongoConfigurationFactory.build(standalone=True)
-    assert config.uri == "mongodb://operator:deadbeef@localhost:27017/?authSource=admin"
+    assert config.uri == "mongodb://charmed_operator:deadbeef@localhost:27017/?authSource=admin"

--- a/tests/unit/test_mongodb_users.py
+++ b/tests/unit/test_mongodb_users.py
@@ -5,10 +5,10 @@ import pytest
 from parameterized import parameterized
 
 from single_kernel_mongo.utils.mongodb_users import (
-    BackupUser,
+    CharmedBackupUser,
+    CharmedMonitorUser,
+    CharmedOperatorUser,
     MongoDBUser,
-    MonitorUser,
-    OperatorUser,
     get_user_from_username,
 )
 
@@ -22,7 +22,7 @@ RANDOM_USER = MongoDBUser(
 )
 
 
-@parameterized.expand([[BackupUser], [MonitorUser], [OperatorUser]])
+@parameterized.expand([[CharmedBackupUser], [CharmedMonitorUser], [CharmedOperatorUser]])
 def test_users_username(user: MongoDBUser):
     assert user.username == user.get_username()
     assert user.database_name == user.get_database_name()

--- a/tests/unit/test_password_actions.py
+++ b/tests/unit/test_password_actions.py
@@ -6,9 +6,9 @@ from ops.testing import ActionFailed, Harness
 
 from single_kernel_mongo.core.structured_config import MongoDBRoles
 from single_kernel_mongo.utils.mongodb_users import (
-    BackupUser,
-    MonitorUser,
-    OperatorUser,
+    CharmedBackupUser,
+    CharmedMonitorUser,
+    CharmedOperatorUser,
 )
 from tests.charms.mongodb_test_charm.src.charm import MongoTestCharm
 
@@ -42,7 +42,7 @@ def test_get_password_action_fail(harness: Harness[MongoTestCharm], mocker):
 
 @pytest.mark.parametrize(
     ("user", "password"),
-    ((MonitorUser, None), (OperatorUser, "deadbeef"), (BackupUser, "cafe")),
+    ((CharmedMonitorUser, None), (CharmedOperatorUser, "deadbeef"), (CharmedBackupUser, "cafe")),
 )
 def test_get_password_action_succeed(harness: Harness[MongoTestCharm], mocker, user, password):
     harness.set_leader(True)
@@ -73,9 +73,9 @@ def test_get_password_action_succeed(harness: Harness[MongoTestCharm], mocker, u
     else:
         assert len(output_password) == 32
 
-    if user == BackupUser:
+    if user == CharmedBackupUser:
         mock_pbm_connect.assert_called()
-    if user == MonitorUser:
+    if user == CharmedMonitorUser:
         mock_exporter_connect.assert_called()
     mock_mongo_connection.assert_called_with(user.username, output_password)
 
@@ -101,10 +101,10 @@ def test_get_password_action_success(harness: Harness[MongoTestCharm], mocker):
     mocker.patch("single_kernel_mongo.utils.mongo_connection.MongoConnection.set_user_password")
 
     output = harness.run_action(
-        "set-password", params={"username": "monitor", "password": "deadbeef"}
+        "set-password", params={"username": "charmed_monitor", "password": "deadbeef"}
     )
 
-    output_get_password = harness.run_action("get-password", {"username": "monitor"})
+    output_get_password = harness.run_action("get-password", {"username": "charmed_monitor"})
 
     assert output.results["password"] == output_get_password.results["password"]
 

--- a/tests/unit/test_sharding.py
+++ b/tests/unit/test_sharding.py
@@ -21,7 +21,7 @@ from single_kernel_mongo.exceptions import (
     WaitingForSecretsError,
 )
 from single_kernel_mongo.utils.mongo_connection import NotReadyError
-from single_kernel_mongo.utils.mongodb_users import BackupUser, OperatorUser
+from single_kernel_mongo.utils.mongodb_users import CharmedBackupUser, CharmedOperatorUser
 from tests.charms.mongodb_test_charm.src.charm import MongoTestCharm
 
 ############################
@@ -49,8 +49,8 @@ def test_config_server_database_requested(harness: Harness[MongoTestCharm], mock
     assert data.get("database") == "unused"
     assert data.get("username") == "unused"
     assert data.get("password") == "unused"
-    assert data.get("operator-password") is not None
-    assert data.get("backup-password") is not None
+    assert data.get("charmed-operator-password") is not None
+    assert data.get("charmed-backup-password") is not None
     assert data.get("host") == '["10.0.0.10"]'
 
 
@@ -151,9 +151,9 @@ def test_config_server_update_credentials(harness: Harness[MongoTestCharm]):
         rel_id, "shard0", {"requested-secrets": '["unused"]', "database": "unused"}
     )
 
-    manager.update_credentials("operator-password", "deadbeef")
+    manager.update_credentials("charmed-operator-password", "deadbeef")
 
-    assert manager.data_interface.as_dict(rel_id).get("operator-password") == "deadbeef"
+    assert manager.data_interface.as_dict(rel_id).get("charmed-operator-password") == "deadbeef"
 
 
 def test_config_server_update_ca_secret(harness: Harness[MongoTestCharm]):
@@ -371,8 +371,8 @@ def test_shard_manager_synchronise_cluster_secrets_success(
         "config-server",
         {
             "key-file": "deadbeef",
-            "operator-password": "test-operator",
-            "backup-password": "test-backup",
+            "charmed-operator-password": "test-operator",
+            "charmed-backup-password": "test-backup",
             "username": "unused",
             "password": "unused",
         },
@@ -404,8 +404,8 @@ def test_shard_manager_synchronise_cluster_secrets_no_keyfile(
         rel_id,
         "config-server",
         {
-            "operator-password": "test-operator",
-            "backup-password": "test-backup",
+            "charmed-operator-password": "test-operator",
+            "charmed-backup-password": "test-backup",
             "username": "unused",
             "password": "unused",
         },
@@ -442,8 +442,8 @@ def test_shard_manager_synchronise_cluster_secrets_no_ca_cert_waiting_for_both_c
         {
             "key-file": "feeddead",
             "int-ca-secret": "deadbeef",
-            "operator-password": "test-operator",
-            "backup-password": "test-backup",
+            "charmed-operator-password": "test-operator",
+            "charmed-backup-password": "test-backup",
             "username": "unused",
             "password": "unused",
         },
@@ -478,8 +478,8 @@ def test_shard_manager_synchronise_cluster_secrets_mongod_not_ready(
         "config-server",
         {
             "key-file": "feeddead",
-            "operator-password": "test-operator",
-            "backup-password": "test-backup",
+            "charmed-operator-password": "test-operator",
+            "charmed-backup-password": "test-backup",
             "username": "unused",
             "password": "unused",
         },
@@ -511,9 +511,9 @@ def test_shard_manager_sync_cluster_passwords(harness: Harness[MongoTestCharm], 
 
     manager.sync_cluster_passwords("test-operator", "test-backup")
 
-    mock_set_user_password.assert_any_call("operator", "test-operator")
-    mock_set_user_password.assert_any_call("backup", "test-backup")
+    mock_set_user_password.assert_any_call("charmed_operator", "test-operator")
+    mock_set_user_password.assert_any_call("charmed_backup", "test-backup")
     patch_config_and_restart.assert_called()
 
-    assert manager.state.get_user_password(OperatorUser) == "test-operator"
-    assert manager.state.get_user_password(BackupUser) == "test-backup"
+    assert manager.state.get_user_password(CharmedOperatorUser) == "test-operator"
+    assert manager.state.get_user_password(CharmedBackupUser) == "test-backup"


### PR DESCRIPTION
# NOT READY FOR REVIEW

<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷 Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update
- [ ] Tooling and CI changes
- [ ] Dependencies upgrade or change

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and scope of this PR (what)
  - the impacted components (where, often match conventional commit scope)
  - explanation/algorithm if require (how)
-->

This PR renames the internal mongoDB usernames:
`operator` -> `charmed_operator`
`backup` -> `charmed_backup`
`logrotate` -> `charmed_logrotate`
`monitor` -> `charmed_monitor`

## 📑 Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Either the associated JIRA reference or a paragraph. -->

Standardized operator user names

## 🧪 How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](../blob/6/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
