### PR TITLE
patch: extend statuses port

### DIFF
--- a/single_kernel_mongo/config/statuses.py
+++ b/single_kernel_mongo/config/statuses.py
@@ -21,24 +21,43 @@ class MongoDBStatuses(Enum):
     """MongoDB related statuses."""
 
     # STATE statuses:
-    WAITING_FOR_MONGODB_START = StatusObject(status="waiting", message="Waiting to start mongod...")
+    WAITING_FOR_MONGODB_START = StatusObject(
+        status="waiting",
+        message="Waiting for mongod to start...",
+        check="MongoDB process status check.",
+    )
     WAITING_FOR_EXPORTER_START = StatusObject(
-        status="waiting", message="Waiting to start mongodb-exporter..."
+        status="waiting",
+        message="Waiting for mongodb-exporter to start...",
+        check="MongoDB Exporter status check.",
     )
-    SHARDING_ON_REPLICA = StatusObject(
-        status="blocked", message="Sharding interface cannot be used by replicas."
-    )
-    UNSUPPORTED_MONGOS_REL = StatusObject(
+    INVALID_SHARDING_REL = StatusObject(
         status="blocked",
-        message="Relation to mongos not supported, config role must be config-server.",
+        message="The sharding interface cannot be used by replica sets.",
+        short_message="Invalid sharding relation.",
+        check="Relation validation.",
+        action="Remove the relation on the shards interface (config-server or sharding relation) from this application.",
     )
-    INVALID_S3_INTEGRATION_STATUS = StatusObject(
+    INVALID_MONGOS_REL = StatusObject(
         status="blocked",
-        message="Relation to s3-integrator is not supported, config role must be config-server.",
+        message="The cluster relation can only be used by config servers.",
+        short_message="Invalid cluster relation.",
+        check="Relation validation.",
+        action="Remove the cluster relation (config-server interface) from this application.",
     )
-
-    INVALID_DB_REL_ON_SHARD = StatusObject(
-        status="blocked", message="Sharding roles do not support database interface."
+    INVALID_S3_REL = StatusObject(
+        status="blocked",
+        message="The s3-credentials relation can only be used by config servers or replica sets.",
+        short_message="Invalid s3-credentials relation.",
+        check="Relation validation.",
+        action="Remove the s3-credentials relation (s3 interface) from this application.",
+    )
+    INVALID_DB_REL = StatusObject(
+        status="blocked",
+        message="The database relation cannot be used by sharding components (shards or config servers).",
+        short_message="Invalid database relation.",
+        check="Relation validation.",
+        action="Remove the database relation (mongodb_client interface) from this application.",
     )
 
     # RUNNING statuses:
@@ -167,20 +186,28 @@ class BackupStatuses(Enum):
 class ConfigServerStatuses(Enum):
     """Config server statuses."""
 
-    # todo consider this status to be put in charm
-    MONGOS_NOT_RUNNING = StatusObject(status="blocked", message="Internal mongos is not running.")
-    MISSING_SHARDING_REL = StatusObject(status="blocked", message="Missing relation to shard(s).")
-    SYNCING_PASSWORDS = StatusObject(
-        status="waiting", message="Waiting to sync passwords across the cluster..."
-    )
     ACTIVE_IDLE = StatusObject(status="active", message="")
+    SYNCING_PASSWORDS = StatusObject(
+        status="waiting",
+        message="Waiting for passwords to be synced across the cluster...",
+        short_message="Syncing passwords...",
+    )
+    # todo consider this status to be put in charm
+    MONGOS_NOT_RUNNING = StatusObject(status="waiting", message="Internal mongos is not running...")
+    MISSING_CONF_SERVER_REL = StatusObject(
+        status="blocked",
+        message="Missing relation to shard(s).",
+        check="Relation validation failed.",
+        action="Add the config-server relation to the config-server.",
+    )
 
     @staticmethod
     def adding_shard(shard: str) -> StatusObject:
         """Returns add shard status."""
         return StatusObject(
             status="maintenance",
-            message=f"Adding shard {shard} to config-server.",
+            message=f"Adding shard {shard} to config-server...",
+            short_message="Adding shard to config-server...",
             running="blocking",
         )
 
@@ -188,14 +215,26 @@ class ConfigServerStatuses(Enum):
     def draining_shard(shard: str) -> StatusObject:
         """Returns draining shard status based on shard."""
         return StatusObject(
-            status="maintenance", message=f"Draining shard {shard}", running="async"
+            status="maintenance",
+            message=f"Draining shard {shard}...",
+            short_message="Draining shard...",
+            running="async",
         )
 
     @staticmethod
     def unreachable_shards(unreachable_shards: list[str]) -> StatusObject:
         """Returns unreachable shard status based on list."""
-        unreachable = ", ".join(unreachable_shards)
-        return StatusObject(status="blocked", message=f"Shards: {unreachable} are unreachable.")
+        msg = (
+            f"Shards: {unreachable_shards[0]} is unreachable."
+            if len(unreachable_shards) == 1
+            else f"Shards: {', '.join(unreachable_shards)} are unreachable."
+        )
+        return StatusObject(
+            status="blocked",
+            message=msg,
+            short_message="Unreachable shards.",
+            action="Check logs for more information.",
+        )
 
     @staticmethod
     def waiting_for_shard_upgrade(
@@ -271,28 +310,34 @@ class ShardStatuses(Enum):
 class MongodStatuses(Enum):
     """MongoD statuses."""
 
+    ACTIVE_IDLE = StatusObject(status="active", message="")
+    PRIMARY = StatusObject(status="active", message="Primary.")
+    SECONDARY = StatusObject(status="active", message="")
+
+    ADDING_MEMBER = StatusObject(status="maintenance", message="Adding member...")
+    REMOVING_MEMBER = StatusObject(status="maintenance", message="Removing member...")
+    SYNCING_MEMBER = StatusObject(status="maintenance", message="Syncing member...")
     WAITING_REPL_SET_INIT = StatusObject(
         status="waiting", message="Waiting for replica set initialisation..."
     )
     WAITING_RECONFIG = StatusObject(
-        status="waiting", message="Waiting to reconfigure replica set..."
+        status="waiting", message="Waiting for replica set reconfiguration..."
     )
     WAITING_ELECTION = StatusObject(status="waiting", message="Waiting for primary re-election...")
-    WAITING_RECONNECT = StatusObject(status="waiting", message="Waiting to reconnect to unit...")
-    MEMBER_BEING_ADDED = StatusObject(status="waiting", message="Member being added...")
-    MEMBER_REMOVING = StatusObject(status="waiting", message="Member is removing...")
-    MEMBER_SYNCING = StatusObject(status="waiting", message="Member is syncing...")
-    PRIMARY = StatusObject(status="active", message="Primary.")
-    SECONDARY = StatusObject(status="active", message="")
-
-    ACTIVE_IDLE = StatusObject(status="active", message="")
-
-    MISSING_CREDENTIALS = StatusObject(status="waiting", message="Missing credentials for mongo")
+    WAITING_RECONNECTION = StatusObject(
+        status="maintenance", message="Waiting for reconnection to mongo..."
+    )
+    WAITING_CREDENTIALS = StatusObject(status="waiting", message="Waiting for mongo credentials...")
 
     @staticmethod
     def replset_status(status: str):
         """When we have an unexpected replica set status."""
-        return StatusObject(status="blocked", message=status)
+        return StatusObject(
+            status="blocked",
+            message=status,
+            short_message="Unexpected error found in replica set.",
+            action="Check logs for more information.",
+        )
 
 
 class UpgradeStatuses(Enum):

--- a/single_kernel_mongo/core/structured_config.py
+++ b/single_kernel_mongo/core/structured_config.py
@@ -120,7 +120,7 @@ class MongoDBCharmConfig(MongoConfigModel):
     @field_validator("role", mode="before")
     @classmethod
     def invalid_role_to_unknown(cls, v: str) -> MongoDBRoles:
-        """If the value is neither none or nodeport, returns unknown."""
+        """If the value is neither replication, config-server, or shard, returns unknown."""
         if v not in MongoDBRoles.valid_roles():
             return MongoDBRoles.UNKNOWN
         return MongoDBRoles(v)

--- a/single_kernel_mongo/events/backups.py
+++ b/single_kernel_mongo/events/backups.py
@@ -90,7 +90,7 @@ class BackupEventsHandler(Object):
                 "Shard does not support S3 relations. Please relate s3-integrator to config-server only."
             )
             self.manager.state.statuses.add(
-                MongoDBStatuses.INVALID_S3_INTEGRATION_STATUS.value,
+                MongoDBStatuses.INVALID_S3_REL.value,
                 scope="unit",
                 component=self.manager.name,
             )
@@ -108,7 +108,7 @@ class BackupEventsHandler(Object):
                 "Shard does not support s3 relations, please relate s3-integrator to config-server only."
             )
             self.manager.state.statuses.add(
-                MongoDBStatuses.INVALID_S3_INTEGRATION_STATUS.value,
+                MongoDBStatuses.INVALID_S3_REL.value,
                 scope="unit",
                 component=self.manager.name,
             )

--- a/single_kernel_mongo/managers/backups.py
+++ b/single_kernel_mongo/managers/backups.py
@@ -246,7 +246,11 @@ class BackupManager(Object, BackupConfigManager, ManagerStatusProtocol):
 
         Only replica sets and config_servers can integrate to s3-integrator.
         """
-        return (self.state.s3_relation is None) or (not self.state.is_role(MongoDBRoles.SHARD))
+        return (
+            self.state.s3_relation is None
+            or self.state.is_role(MongoDBRoles.REPLICATION)
+            or self.state.is_role(MongoDBRoles.CONFIG_SERVER)
+        )
 
     def cleanup_certs_and_restart(self, relation: Relation) -> None:
         """On relation broken event, we need to remove the certificate from the trust store."""

--- a/single_kernel_mongo/managers/cluster.py
+++ b/single_kernel_mongo/managers/cluster.py
@@ -66,7 +66,7 @@ class ClusterProvider(Object):
 
         if not self.is_valid_mongos_integration():
             self.state.statuses.add(
-                MongoDBStatuses.UNSUPPORTED_MONGOS_REL.value,
+                MongoDBStatuses.INVALID_MONGOS_REL.value,
                 scope="unit",
                 component=self.dependent.name,
             )

--- a/single_kernel_mongo/managers/mongo.py
+++ b/single_kernel_mongo/managers/mongo.py
@@ -506,15 +506,15 @@ class MongoManager(Object, ManagerStatusProtocol):
 
             match replica_status:
                 case "":
-                    return [MongodStatuses.MEMBER_BEING_ADDED.value]
+                    return [MongodStatuses.ADDING_MEMBER.value]
                 case "PRIMARY":
                     charm_statuses.append(MongodStatuses.PRIMARY.value)
                 case "SECONDARY":
                     charm_statuses.append(MongodStatuses.SECONDARY.value)
                 case "STARTUP" | "STARTUP2" | "ROLLBACK" | "RECOVERING":
-                    return [MongodStatuses.MEMBER_SYNCING.value]
+                    return [MongodStatuses.SYNCING_MEMBER.value]
                 case "REMOVED":
-                    return [MongodStatuses.MEMBER_REMOVING.value]
+                    return [MongodStatuses.REMOVING_MEMBER.value]
                 case _:
                     return [MongodStatuses.replset_status(replica_status)]
 
@@ -529,13 +529,13 @@ class MongoManager(Object, ManagerStatusProtocol):
             # AutoReconnect is raised when a connection to the database is lost and an attempt to
             # auto-reconnect will be made by pymongo.
             logger.debug("Got error: %s, while checking replica set status", str(e))
-            return [MongodStatuses.WAITING_RECONNECT.value]
+            return [MongodStatuses.WAITING_RECONNECTION.value]
         except OperationFailure as e:
             logger.warning("Authentication Failed: %s", e, exc_info=True)
             return [MongodStatuses.WAITING_RECONFIG.value]
         except MissingCredentialsError as e:
             logger.warning("Missing credentials: %s", e, exc_info=True)
-            return [MongodStatuses.MISSING_CREDENTIALS]
+            return [MongodStatuses.WAITING_CREDENTIALS.value]
 
     def get_leader_statuses(self) -> list[StatusObject]:
         """Returns statuses that juju leader can retrieve for mongo."""

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -913,17 +913,20 @@ class MongoDBOperator(OperatorProtocol, Object):
             )
 
             self.state.statuses.add(
-                MongoDBStatuses.INVALID_DB_REL_ON_SHARD.value, scope="unit", component=self.name
+                MongoDBStatuses.INVALID_DB_REL.value, scope="unit", component=self.name
             )
             return False
-        if not self.state.is_sharding_component and rel_name == RelationNames.SHARDING:
+        if not self.state.is_sharding_component and rel_name in {
+            RelationNames.SHARDING,
+            RelationNames.CONFIG_SERVER,
+        }:
             logger.error(
                 "Charm is in replication role: %s. Does not support %s interface.",
                 self.state.app_peer_data.role,
                 rel_name,
             )
             self.state.statuses.add(
-                MongoDBStatuses.SHARDING_ON_REPLICA.value, scope="unit", component=self.name
+                MongoDBStatuses.INVALID_SHARDING_REL.value, scope="unit", component=self.name
             )
             return False
         return True
@@ -993,21 +996,16 @@ class MongoDBOperator(OperatorProtocol, Object):
         """Basic checks."""
         statuses = []
         if not self.cluster_manager.is_valid_mongos_integration():
-            statuses.append(MongoDBStatuses.UNSUPPORTED_MONGOS_REL.value)
+            statuses.append(MongoDBStatuses.INVALID_MONGOS_REL.value)
 
         if not self.backup_manager.is_valid_s3_integration():
-            statuses.append(MongoDBStatuses.INVALID_S3_INTEGRATION_STATUS.value)
-
-        if self.state.is_role(MongoDBRoles.REPLICATION) and (
-            self.state.config_server_relation or self.state.shard_relation
-        ):
-            statuses.append(MongoDBStatuses.SHARDING_ON_REPLICA.value)
+            statuses.append(MongoDBStatuses.INVALID_S3_REL.value)
 
         if self.state.client_relations and self.state.is_sharding_component:
-            statuses.append(MongoDBStatuses.INVALID_DB_REL_ON_SHARD.value)
+            statuses.append(MongoDBStatuses.INVALID_DB_REL.value)
 
         if not self.state.is_sharding_component and self.state.has_sharding_integration:
-            statuses.append(MongoDBStatuses.SHARDING_ON_REPLICA.value)
+            statuses.append(MongoDBStatuses.INVALID_SHARDING_REL.value)
         elif rev_status := self.cluster_version_checker.get_cluster_mismatched_revision_status():
             # don't bother checking revision mismatch on sharding interface if replica
             statuses.append(rev_status)

--- a/single_kernel_mongo/managers/sharding.py
+++ b/single_kernel_mongo/managers/sharding.py
@@ -180,6 +180,8 @@ class ConfigServerManager(Object, ManagerStatusProtocol):
         Raises:
             NonDeferrableFailedHookChecksError, DeferrableFailedHookChecksError
         """
+        if not self.state.is_role(MongoDBRoles.CONFIG_SERVER):
+            raise NonDeferrableFailedHookChecksError("is only executed by config-server")
         if not self.state.db_initialised:
             raise DeferrableFailedHookChecksError("db is not initialised.")
         if not self.dependent.is_relation_feasible(self.relation_name):
@@ -196,8 +198,6 @@ class ConfigServerManager(Object, ManagerStatusProtocol):
         ):
             self.state.statuses.add(rev_status, scope="unit", component=self.dependent.name)
             raise DeferrableFailedHookChecksError("Mismatched versions in the cluster")
-        if not self.state.is_role(MongoDBRoles.CONFIG_SERVER):
-            raise NonDeferrableFailedHookChecksError("is only executed by config-server")
 
     def assert_pass_hook_checks(self, relation: Relation, leaving: bool = False) -> None:
         """Runs pre hooks checks and raises the appropriate error if it fails.
@@ -296,8 +296,8 @@ class ConfigServerManager(Object, ManagerStatusProtocol):
             charm_statuses["unit"].append(ConfigServerStatuses.MONGOS_NOT_RUNNING.value)
 
         if not self.state.config_server_relation:
-            charm_statuses["unit"].append(ConfigServerStatuses.MISSING_SHARDING_REL.value)
-            charm_statuses["app"].append(ConfigServerStatuses.MISSING_SHARDING_REL.value)
+            charm_statuses["unit"].append(ConfigServerStatuses.MISSING_CONF_SERVER_REL.value)
+            charm_statuses["app"].append(ConfigServerStatuses.MISSING_CONF_SERVER_REL.value)
             # return as other statuses require shard(s) to compute
             return charm_statuses[scope]
 
@@ -349,7 +349,7 @@ class ConfigServerManager(Object, ManagerStatusProtocol):
             return
 
         self.state.statuses.delete(
-            ConfigServerStatuses.MISSING_SHARDING_REL.value, scope="unit", component=self.name
+            ConfigServerStatuses.MISSING_CONF_SERVER_REL.value, scope="unit", component=self.name
         )
 
         self.charm.status_handler.set_running_status(
@@ -506,6 +506,8 @@ class ShardManager(Object, ManagerStatusProtocol):
 
     def assert_pass_sanity_hook_checks(self, is_leaving: bool) -> None:
         """Returns True if all the sanity hook checks for sharding pass."""
+        if not self.state.is_role(MongoDBRoles.SHARD):
+            raise NonDeferrableFailedHookChecksError("is only executed by shards")
         if not self.state.db_initialised:
             raise DeferrableFailedHookChecksError("db is not initialised.")
         if not self.dependent.is_relation_feasible(self.relation_name):
@@ -526,8 +528,6 @@ class ShardManager(Object, ManagerStatusProtocol):
         ):
             self.state.statuses.add(rev_status, scope="unit", component=self.dependent.name)
             raise DeferrableFailedHookChecksError("Mismatched versions in the cluster")
-        if not self.state.is_role(MongoDBRoles.SHARD):
-            raise NonDeferrableFailedHookChecksError("is only executed by shards")
 
     def assert_pass_hook_checks(self, relation: Relation, is_leaving: bool = False) -> None:
         """Runs the pre-hooks checks, returns True if all pass."""

--- a/tests/integration/helpers/common.py
+++ b/tests/integration/helpers/common.py
@@ -808,7 +808,7 @@ async def check_all_units_blocked_with_status(
         if status:
             assert (
                 status in unit.workload_status.message
-            ), f"unit {unit.name} not in blocked state, in {unit.workload_status.value}"
+            ), f"unit {unit.name} status is `{unit.workload_status.message}`, expected `{status}`"
 
 
 async def wait_for_mongodb_units_blocked(

--- a/tests/integration/mongodb/relations/test_sharding_relations.py
+++ b/tests/integration/mongodb/relations/test_sharding_relations.py
@@ -176,7 +176,7 @@ async def test_cannot_use_db_relation(ops_test: OpsTest, substrate: Substrate) -
             ops_test,
             substrate,
             sharded_component,
-            status="Sharding roles do not support database interface.",
+            status="The database relation cannot be used by sharding components (shards or config servers).",
             timeout=300,
         )
 
@@ -208,7 +208,7 @@ async def test_replication_config_server_relation(ops_test: OpsTest, substrate: 
         ops_test,
         substrate,
         REPLICATION_APP_NAME,
-        status="Sharding interface cannot be used by replicas.",
+        status="The sharding interface cannot be used by replica sets.",
         timeout=300,
     )
 
@@ -232,7 +232,7 @@ async def test_replication_shard_relation(ops_test: OpsTest, substrate: Substrat
         ops_test,
         substrate,
         REPLICATION_APP_NAME,
-        status="Sharding interface cannot be used by rep",
+        status="The sharding interface cannot be used by replica sets.",
         timeout=300,
     )
 
@@ -263,7 +263,7 @@ async def test_replication_mongos_relation(ops_test: OpsTest, substrate: Substra
         ops_test,
         substrate,
         REPLICATION_APP_NAME,
-        status="Relation to mongos not supported",
+        status="The cluster relation can only be used by config servers.",
         timeout=300,
     )
 
@@ -294,14 +294,14 @@ async def test_shard_mongos_relation(ops_test: OpsTest, substrate: Substrate) ->
         ops_test,
         substrate,
         SHARD_ONE_APP_NAME,
-        status="Relation to mongos not supported",
+        status="Invalid cluster relation.",
         timeout=300,
     )
     await check_status_detail(
         ops_test,
         SHARD_ONE_APP_NAME,
         status="blocked",
-        message="Relation to mongos not supported, config role must be config-server.",
+        message="The cluster relation can only be used by config servers.",
     )
 
     # clean up relations
@@ -324,14 +324,14 @@ async def test_shard_s3_relation(ops_test: OpsTest, substrate: Substrate) -> Non
         ops_test,
         substrate,
         SHARD_ONE_APP_NAME,
-        status="Relation to s3-integrator is not support",
+        status="Invalid s3-credentials relation.",
         timeout=300,
     )
     await check_status_detail(
         ops_test,
         SHARD_ONE_APP_NAME,
         status="blocked",
-        message="Relation to s3-integrator is not supported, config role must be config-server.",
+        message="The s3-credentials relation can only be used by config servers or replica sets.",
     )
 
     # clean up relations
@@ -361,7 +361,7 @@ async def test_config_server_tls_replication_relation(
         ops_test,
         substrate,
         REPLICATION_APP_NAME,
-        status="Sharding interface cannot be used by replicas.",
+        status="The sharding interface cannot be used by replica sets.",
         timeout=300,
     )
 

--- a/tests/unit/test_backup_manager.py
+++ b/tests/unit/test_backup_manager.py
@@ -30,25 +30,41 @@ def backup_manager(harness: Harness[MongoTestCharm]) -> BackupManager:
     return harness.charm.operator.backup_manager
 
 
-def test_valid_s3_integration(harness: Harness[MongoTestCharm]):
+@pytest.mark.parametrize(
+    "role",
+    [
+        MongoDBRoles.REPLICATION,
+        MongoDBRoles.CONFIG_SERVER,
+    ],
+)
+def test_valid_s3_integration(harness: Harness[MongoTestCharm], role: MongoDBRoles):
     harness.set_leader(True)
-    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION
+    harness.charm.operator.state.app_peer_data.role = role
     relation_id = harness.add_relation(
         ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
     )
     harness.add_relation_unit(relation_id, "s3-integrator/0")
-
     relation: Relation = harness.charm.operator.state.s3_relation
 
     harness.charm.on[ExternalRequirerRelations.S3_CREDENTIALS.value].relation_joined.emit(
         relation=relation
     )
-    assert harness.charm.unit.status != MongoDBStatuses.INVALID_S3_INTEGRATION_STATUS
+    assert harness.charm.unit.status != MongoDBStatuses.INVALID_S3_REL
 
 
-def test_invalid_s3_integration(harness: Harness[MongoTestCharm], backup_manager: BackupManager):
+@pytest.mark.parametrize(
+    "role",
+    [
+        MongoDBRoles.UNKNOWN,
+        MongoDBRoles.SHARD,
+        MongoDBRoles.MONGOS,
+    ],
+)
+def test_invalid_s3_integration(
+    harness: Harness[MongoTestCharm], backup_manager: BackupManager, role: MongoDBRoles
+):
     harness.set_leader(True)
-    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.SHARD
+    harness.charm.operator.state.app_peer_data.role = role
     relation_id = harness.add_relation(
         ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
     )
@@ -63,7 +79,7 @@ def test_invalid_s3_integration(harness: Harness[MongoTestCharm], backup_manager
         scope=Scope.UNIT, component=backup_manager.name
     ).root
 
-    assert MongoDBStatuses.INVALID_S3_INTEGRATION_STATUS.value in statuses
+    assert MongoDBStatuses.INVALID_S3_REL.value in statuses
 
 
 def test_backup_without_rel(harness):
@@ -80,6 +96,8 @@ def test_list_backup_without_rel(harness):
 
 def test_s3_credentials_no_db(harness: Harness[MongoTestCharm], mocker):
     """Verifies that when there is no DB that setting credentials is deferred."""
+    harness.set_leader(True)
+    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION
     harness.charm.operator.state.db_initialised = False
     defer = mocker.patch("ops.framework.EventBase.defer")
     mocker.patch(

--- a/tests/unit/test_sharding.py
+++ b/tests/unit/test_sharding.py
@@ -350,6 +350,22 @@ def test_shard_manager_prepare_to_add_shard(harness: Harness[MongoTestCharm]):
     assert as_status(statuses[0]) == MaintenanceStatus("Adding shard to config-server")
 
 
+def test_shard_manager_synchronise_cluster_invalid_role(harness: Harness[MongoTestCharm]):
+    manager = harness.charm.operator.shard_manager
+
+    harness.set_leader(True)
+    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION
+    harness.charm.operator.state.db_initialised = True
+
+    rel_id = harness.add_relation(RelationNames.SHARDING.value, "config-server")
+    relation: Relation = harness.charm.model.get_relation(RelationNames.SHARDING.value, rel_id)  # type: ignore[assignment]
+
+    with pytest.raises(NonDeferrableFailedHookChecksError) as err:
+        manager.synchronise_cluster_secrets(relation)
+
+    assert err.value.args[0] == "is only executed by shards"
+
+
 def test_shard_manager_synchronise_cluster_secrets_success(
     harness: Harness[MongoTestCharm], mocker
 ):

--- a/tests/unit/test_status_handler.py
+++ b/tests/unit/test_status_handler.py
@@ -4,7 +4,7 @@
 import pytest
 from data_platform_helpers.advanced_statuses.utils import as_status
 from ops import MaintenanceStatus
-from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
+from ops.model import ActiveStatus, BlockedStatus
 from ops.testing import Harness
 from pymongo.errors import AutoReconnect, ServerSelectionTimeoutError
 
@@ -26,14 +26,14 @@ from tests.charms.mongos_test_charm.src.charm import MongosTestCharm
 @pytest.mark.parametrize(
     ("replset_status", "expected_status"),
     (
-        ({}, WaitingStatus("Member being added...")),
+        ({}, MaintenanceStatus("Adding member...")),
         ({"10.0.0.10": "PRIMARY"}, ActiveStatus("Primary.")),
         ({"10.0.0.10": "SECONDARY"}, ActiveStatus("")),
-        ({"10.0.0.10": "STARTUP"}, WaitingStatus("Member is syncing...")),
-        ({"10.0.0.10": "STARTUP2"}, WaitingStatus("Member is syncing...")),
-        ({"10.0.0.10": "ROLLBACK"}, WaitingStatus("Member is syncing...")),
-        ({"10.0.0.10": "RECOVERING"}, WaitingStatus("Member is syncing...")),
-        ({"10.0.0.10": "REMOVED"}, WaitingStatus("Member is removing...")),
+        ({"10.0.0.10": "STARTUP"}, MaintenanceStatus("Syncing member...")),
+        ({"10.0.0.10": "STARTUP2"}, MaintenanceStatus("Syncing member...")),
+        ({"10.0.0.10": "ROLLBACK"}, MaintenanceStatus("Syncing member...")),
+        ({"10.0.0.10": "RECOVERING"}, MaintenanceStatus("Syncing member...")),
+        ({"10.0.0.10": "REMOVED"}, MaintenanceStatus("Removing member...")),
         ({"10.0.0.10": "ERROR"}, BlockedStatus("ERROR")),
     ),
 )
@@ -59,25 +59,28 @@ def test_mongo_get_status_no_error_lxd(
 @pytest.mark.parametrize(
     ("replset_status", "expected_status"),
     (
-        ({}, WaitingStatus("Member being added...")),
+        ({}, MaintenanceStatus("Adding member...")),
         ({"mongodb-k8s-0.mongodb-k8s-endpoints": "PRIMARY"}, ActiveStatus("Primary.")),
         ({"mongodb-k8s-0.mongodb-k8s-endpoints": "SECONDARY"}, ActiveStatus("")),
-        ({"mongodb-k8s-0.mongodb-k8s-endpoints": "STARTUP"}, WaitingStatus("Member is syncing...")),
+        (
+            {"mongodb-k8s-0.mongodb-k8s-endpoints": "STARTUP"},
+            MaintenanceStatus("Syncing member..."),
+        ),
         (
             {"mongodb-k8s-0.mongodb-k8s-endpoints": "STARTUP2"},
-            WaitingStatus("Member is syncing..."),
+            MaintenanceStatus("Syncing member..."),
         ),
         (
             {"mongodb-k8s-0.mongodb-k8s-endpoints": "ROLLBACK"},
-            WaitingStatus("Member is syncing..."),
+            MaintenanceStatus("Syncing member..."),
         ),
         (
             {"mongodb-k8s-0.mongodb-k8s-endpoints": "RECOVERING"},
-            WaitingStatus("Member is syncing..."),
+            MaintenanceStatus("Syncing member..."),
         ),
         (
             {"mongodb-k8s-0.mongodb-k8s-endpoints": "REMOVED"},
-            WaitingStatus("Member is removing..."),
+            MaintenanceStatus("Removing member..."),
         ),
         ({"mongodb-k8s-0.mongodb-k8s-endpoints": "ERROR"}, BlockedStatus("ERROR")),
     ),
@@ -107,7 +110,7 @@ def test_mongo_get_status_no_error_microk8s(
             ServerSelectionTimeoutError,
             MongodStatuses.WAITING_ELECTION.value,
         ),
-        (AutoReconnect, MongodStatuses.WAITING_RECONNECT.value),
+        (AutoReconnect, MongodStatuses.WAITING_RECONNECTION.value),
     ),
 )
 def test_mongo_get_status_with_error(
@@ -128,7 +131,29 @@ def test_mongo_get_status_with_error(
     assert status == expected_status
 
 
-def test_config_server_get_status_invalid_integration(
+@pytest.mark.parametrize(
+    "role",
+    [
+        MongoDBRoles.SHARD,
+        MongoDBRoles.REPLICATION,
+    ],
+)
+def test_sharding_components_get_status_invalid_cluster_relation(
+    harness: Harness[MongoTestCharm], mocker, mock_fs_interactions, role: MongoDBRoles
+):
+    harness.set_leader(True)
+    harness.charm.operator.state.db_initialised = True
+    harness.charm.operator.state.app_peer_data.role = role
+
+    harness.add_relation(RelationNames.CLUSTER.value, "mongos")
+
+    statuses = harness.charm.operator.get_statuses(scope=Scope.UNIT, recompute=True)
+    status = next(iter(statuses), None)
+
+    assert status == MongoDBStatuses.INVALID_MONGOS_REL.value
+
+
+def test_replica_set_get_status_invalid_config_server_relation(
     harness: Harness[MongoTestCharm], mocker, mock_fs_interactions
 ):
     harness.set_leader(True)
@@ -140,7 +165,7 @@ def test_config_server_get_status_invalid_integration(
     statuses = harness.charm.operator.get_statuses(scope=Scope.UNIT, recompute=True)
     status = next(iter(statuses), None)
 
-    assert status == MongoDBStatuses.SHARDING_ON_REPLICA.value
+    assert status == MongoDBStatuses.INVALID_SHARDING_REL.value
 
 
 def test_config_server_get_status_invalid_role(
@@ -189,7 +214,7 @@ def test_config_server_get_status_client_relation(
     statuses = harness.charm.operator.get_statuses(scope=Scope.UNIT, recompute=True)
     status = next(iter(statuses), None)
 
-    assert status == MongoDBStatuses.INVALID_DB_REL_ON_SHARD.value
+    assert status == MongoDBStatuses.INVALID_DB_REL.value
 
 
 def test_config_server_get_status_internal_mongos_not_running(
@@ -284,7 +309,7 @@ def test_config_server_get_status_shard_draining(
     )
     status = next(iter(statuses), None)
 
-    assert as_status(status) == MaintenanceStatus("Draining shard shard0")
+    assert as_status(status) == MaintenanceStatus("Draining shard shard0...")
 
 
 def test_config_server_get_status_unreachable_shards(
@@ -317,7 +342,7 @@ def test_config_server_get_status_unreachable_shards(
     )
     status = next(iter(statuses), None)
 
-    assert as_status(status) == BlockedStatus("Shards: shard0 are unreachable.")
+    assert as_status(status) == BlockedStatus("Shards: shard0 is unreachable.")
 
 
 def test_config_server_all_active(harness: Harness[MongoTestCharm], mocker, mock_fs_interactions):
@@ -378,7 +403,7 @@ def test_shard_get_status_db_not_initialised(
     assert status is None
 
 
-def test_shard_get_status_charm_is_replication(
+def test_replica_set_get_status_invalid_sharding_relation(
     harness: Harness[MongoTestCharm], mocker, mock_fs_interactions
 ):
     harness.set_leader(True)
@@ -390,7 +415,7 @@ def test_shard_get_status_charm_is_replication(
     statuses = harness.charm.operator.get_statuses(scope=Scope.UNIT, recompute=True)
     status = next(iter(statuses), None)
 
-    assert status == MongoDBStatuses.SHARDING_ON_REPLICA.value
+    assert status == MongoDBStatuses.INVALID_SHARDING_REL.value
 
 
 def test_shard_get_status_charm_client_relation(
@@ -405,7 +430,7 @@ def test_shard_get_status_charm_client_relation(
     statuses = harness.charm.operator.get_statuses(scope=Scope.UNIT, recompute=True)
     status = next(iter(statuses), None)
 
-    assert status == MongoDBStatuses.INVALID_DB_REL_ON_SHARD.value
+    assert status == MongoDBStatuses.INVALID_DB_REL.value
 
 
 def test_shard_get_status_charm_missing_relation_not_drained(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷 Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update
- [ ] Tooling and CI changes
- [ ] Dependencies upgrade or change

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and scope of this PR (what)
  - the impacted components (where, often match conventional commit scope)
  - explanation/algorithm if require (how)
-->


This PR ports the extension of statuses for MongoDB, MongoD and Config-server
1. d54a2601734d7ccc96b236b6fbe355ad118f7e32
2. 7de008590804a811a064370cc7ad62b7642f2994
3. a2925d00966fcb339e85204cae12911ec6478a73

- Make the short_message shorter than 40 characters.
- Add check and action when judged necessary
- Make the variable names, messages and vocabulary consistent


## 📑 Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Either the associated JIRA reference or a paragraph. -->

This PR improves the quality of the message displayed to the operator about the state of the charms

## 🧪 How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Existing integration tests 

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](../blob/6/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
