### PR TITLE
patch: uses system-users for password management in integration tests for mongo 8-transtion/edge

### DIFF
--- a/single_kernel_mongo/config/statuses.py
+++ b/single_kernel_mongo/config/statuses.py
@@ -507,5 +507,4 @@ class PasswordManagementStatuses(Enum):
         status="maintenance",
         message="Failed to update user passwords.",
         action="Check logs.",
-        running="blocking",
     )

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -805,26 +805,6 @@ class MongoDBOperator(OperatorProtocol, Object):
 
     # END: Handlers.
 
-    def assert_pass_password_checks(self) -> None:
-        """Sanity checks to run before password changes."""
-        if not self.model.unit.is_leader():
-            raise NonDeferrableFailedHookChecksError(
-                "Password rotation must be called on leader unit."
-            )
-        if self.state.upgrade_in_progress:
-            raise DeferrableFailedHookChecksError(
-                "Cannot set passwords while an upgrade is in progress"
-            )
-        if self.state.is_role(MongoDBRoles.SHARD):
-            raise NonDeferrableFailedHookChecksError(
-                "Cannot set password on shard, please set password on config-server."
-            )
-        pbm_status = self.backup_manager.backup_state()
-        if pbm_status in (BackupState.BACKUP_RUNNING, BackupState.RESTORE_RUNNING):
-            raise DeferrableFailedHookChecksError(
-                "Cannot change a password while a backup/restore is in progress."
-            )
-
     def perform_self_healing(self) -> None:
         """Reconfigures the replica set if necessary.
 

--- a/tests/integration/helpers/tls.py
+++ b/tests/integration/helpers/tls.py
@@ -73,8 +73,8 @@ async def mongo_tls_command(
             for unit in ops_test.model.applications[app_name].units
         ]
         replica_set_hosts = [f"{host}:{port}" for host in replica_set_hosts]
-        username = "operator"
-        password = await get_password(ops_test, OPERATOR_USERNAME, app_name=app_name)
+        username = OPERATOR_USERNAME
+        password = await get_password(ops_test, username, app_name=app_name)
         hosts = ",".join(replica_set_hosts)
         extra_args = f"?replicaSet={app_name}" if not mongos else ""
         uri = f"mongodb://{username}:{password}@{hosts}/admin{extra_args}"

--- a/tests/integration/helpers/upgrade.py
+++ b/tests/integration/helpers/upgrade.py
@@ -116,31 +116,14 @@ async def set_fcv(
     assert result.succeeded, f"Failed to set fcv to {fcv}."
 
 
-async def set_password_action(
-    ops_test: OpsTest,
-    unit_id: int,
-    username: str,
-    password: str,
-    app_name: str,
-) -> dict[str, any]:
-    """Use the charm action to retrieve the password from provided unit.
-
-    Returns:
-    String with the password stored on the peer relation databag.
-    """
-    action = await ops_test.model.units.get(f"{app_name}/{unit_id}").run_action(
-        "set-password", **{"username": username, "password": password}
-    )
-    action = await action.wait()
-    return action.results
-
-
 async def get_password_action(
     ops_test: OpsTest,
     username: str,
     app_name: str,
 ) -> str:
     """Use the charm action to retrieve the password from provided unit.
+
+    This action is only used for MongoDB 6.
 
     Returns:
         String with the password stored on the peer relation databag.

--- a/tests/integration/mongodb/test_major_upgrades.py
+++ b/tests/integration/mongodb/test_major_upgrades.py
@@ -19,14 +19,13 @@ from ..helpers.common import (
     deploy_application,
     deploy_charm,
     find_unit,
-    get_unit_id,
     relate_mongodb_and_application,
     set_password,
     start_continous_writes,
     stop_continous_writes,
 )
 from ..helpers.types import Substrate
-from ..helpers.upgrade import get_password_action, set_fcv, set_password_action
+from ..helpers.upgrade import get_password_action, set_fcv
 
 MONGODB_SIX = "mongodb-six"
 MONGODB_SEVEN = "mongodb-seven"
@@ -141,16 +140,11 @@ async def test_deploy_mongodb_7(
 
     for user in InternalUsers:
         password = await get_password_action(ops_test, username=user.username, app_name=MONGODB_SIX)
-        leader_unit = await find_unit(ops_test, leader=True, app_name=MONGODB_SEVEN)
-        await set_password_action(
-            ops_test,
-            unit_id=get_unit_id(leader_unit.name),
-            username=user.username,
-            password=password,
-            app_name=MONGODB_SEVEN,
+        await set_password(
+            ops_test, username=user.username, password=password, app_name=MONGODB_SEVEN
         )
 
-    await ops_test.model.wait_for_idle(apps=[MONGODB_SEVEN], timeout=TIMEOUT, status="active")
+        await ops_test.model.wait_for_idle(apps=[MONGODB_SEVEN], timeout=TIMEOUT, status="active")
 
 
 @pytest.mark.abort_on_fail
@@ -235,10 +229,7 @@ async def test_deploy_mongodb_8(
     for user in InternalUsers:
         password = await get_password_action(ops_test, username=user.username, app_name=MONGODB_SIX)
         await set_password(
-            ops_test,
-            username=user.username,
-            password=password,
-            app_name=MONGODB_EIGHT,
+            ops_test, username=user.username, password=password, app_name=MONGODB_EIGHT
         )
 
         await ops_test.model.wait_for_idle(apps=[MONGODB_EIGHT], timeout=TIMEOUT, status="active")

--- a/tests/integration/mongodb/test_sharding_major_upgrades.py
+++ b/tests/integration/mongodb/test_sharding_major_upgrades.py
@@ -14,7 +14,7 @@ from tests.integration.helpers.sharding import (
     deploy_cluster_components,
     integrate_sharding_components,
 )
-from tests.integration.helpers.upgrade import get_password_action, set_fcv, set_password_action
+from tests.integration.helpers.upgrade import get_password_action, set_fcv
 
 from ..helpers.backups import S3_APP_NAME, count_logical_backups
 from ..helpers.common import (
@@ -24,7 +24,6 @@ from ..helpers.common import (
     count_writes,
     deploy_application,
     find_unit,
-    get_unit_id,
     mongodb_uri,
     set_password,
     start_continous_writes,
@@ -202,16 +201,13 @@ async def test_deploy_mongodb_7(ops_test: OpsTest, substrate: Substrate, mongodb
         password = await get_password_action(
             ops_test, username=user.username, app_name=CONFIG_SERVER_SIX
         )
-        leader_unit = await find_unit(ops_test, leader=True, app_name=CONFIG_SERVER_SEVEN)
-        await set_password_action(
-            ops_test,
-            unit_id=get_unit_id(leader_unit.name),
-            username=user.username,
-            password=password,
-            app_name=CONFIG_SERVER_SEVEN,
+        await set_password(
+            ops_test, username=user.username, password=password, app_name=CONFIG_SERVER_SEVEN
         )
 
-    await ops_test.model.wait_for_idle(apps=[CONFIG_SERVER_SEVEN], timeout=TIMEOUT, status="active")
+        await ops_test.model.wait_for_idle(
+            apps=[CONFIG_SERVER_SEVEN], timeout=TIMEOUT, status="active"
+        )
 
 
 @pytest.mark.abort_on_fail


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷 Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update
- [ ] Tooling and CI changes
- [ ] Dependencies upgrade or change

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and scope of this PR (what)
  - the impacted components (where, often match conventional commit scope)
  - explanation/algorithm if require (how)
-->

`Mongo 8-transition` has been migrated to use config options to manage internal user passwords.

This PR updates the integration tests.
A little clean up is included as well.

## 📑 Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Either the associated JIRA reference or a paragraph. -->

Port internal user passwords managements to Mongo 8-transition, require update in the upgrade integration tests

## 🧪 How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Integration tests

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](../blob/6/edge/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
