### PR TITLE
patch(sharding): Sharding relation invalid

### DIFF
--- a/single_kernel_mongo/events/sharding.py
+++ b/single_kernel_mongo/events/sharding.py
@@ -19,6 +19,7 @@ from ops.framework import Object
 from pymongo.errors import OperationFailure, PyMongoError, ServerSelectionTimeoutError
 
 from single_kernel_mongo.config.literals import TrustStoreFiles
+from single_kernel_mongo.config.statuses import ShardStatuses
 from single_kernel_mongo.exceptions import (
     BalancerNotEnabledError,
     DeferrableFailedHookChecksError,
@@ -172,5 +173,8 @@ class ShardEventHandler(Object):
         except DeferrableFailedHookChecksError as e:
             defer_event_with_info_log(logger, event, str(type(event)), str(e))
         except NonDeferrableFailedHookChecksError as e:
+            self.manager.state.statuses.set(
+                ShardStatuses.MISSING_CONF_SERVER_REL, scope="unit", component=self.manager.name
+            )
             self.dependent.remove_ca_cert_from_trust_store(TrustStoreFiles.PBM)
             logger.info(f"Skipping {str(type(event))}: {str(e)}")

--- a/single_kernel_mongo/events/sharding.py
+++ b/single_kernel_mongo/events/sharding.py
@@ -174,7 +174,9 @@ class ShardEventHandler(Object):
             defer_event_with_info_log(logger, event, str(type(event)), str(e))
         except NonDeferrableFailedHookChecksError as e:
             self.manager.state.statuses.set(
-                ShardStatuses.MISSING_CONF_SERVER_REL, scope="unit", component=self.manager.name
+                ShardStatuses.MISSING_CONF_SERVER_REL.value,
+                scope="unit",
+                component=self.manager.name,
             )
             self.dependent.remove_ca_cert_from_trust_store(TrustStoreFiles.PBM)
             logger.info(f"Skipping {str(type(event))}: {str(e)}")

--- a/single_kernel_mongo/managers/sharding.py
+++ b/single_kernel_mongo/managers/sharding.py
@@ -695,9 +695,7 @@ class ShardManager(Object, ManagerStatusProtocol):
         """Waits for the shard to be fully drained from the cluster."""
         self.assert_pass_hook_checks(relation, is_leaving=True)
 
-        mongos_hosts = self.state.app_peer_data.mongos_hosts
-
-        if not mongos_hosts:
+        if not (mongos_hosts := self.state.app_peer_data.mongos_hosts):
             return
 
         self.wait_for_draining(mongos_hosts)

--- a/single_kernel_mongo/managers/sharding.py
+++ b/single_kernel_mongo/managers/sharding.py
@@ -536,11 +536,7 @@ class ShardManager(Object, ManagerStatusProtocol):
         if relation.app is None:
             raise NonDeferrableFailedHookChecksError("Missing app information in event, skipping.")
 
-        # We look in the relation databag because the shard state data
-        # interface returns nothing on relation broken event.
-        mongos_hosts = relation.data[relation.app].get(AppShardingComponentKeys.HOST.value)
-
-        if is_leaving and not mongos_hosts:
+        if is_leaving and not self.state.app_peer_data.mongos_hosts:
             raise NonDeferrableFailedHookChecksError(
                 "Config-server never set up, no need to process broken event."
             )
@@ -701,7 +697,12 @@ class ShardManager(Object, ManagerStatusProtocol):
 
         mongos_hosts = self.state.app_peer_data.mongos_hosts
 
+        if not mongos_hosts:
+            return
+
         self.wait_for_draining(mongos_hosts)
+
+        self.state.app_peer_data.mongos_hosts = []
 
         self.state.statuses.set(
             ShardStatuses.SHARD_DRAINED.value, scope="unit", component=self.name

--- a/tests/integration/mongodb/tls/test_sharding_tls_inconsistent_rels.py
+++ b/tests/integration/mongodb/tls/test_sharding_tls_inconsistent_rels.py
@@ -5,13 +5,19 @@
 import pytest
 from pytest_operator.plugin import OpsTest
 
-from ...helpers.common import DEPLOYMENT_TIMEOUT, TIMEOUT, wait_for_mongodb_units_blocked
+from ...helpers.common import (
+    DEPLOYMENT_TIMEOUT,
+    TIMEOUT,
+    deploy_charm,
+    wait_for_mongodb_units_blocked,
+)
 from ...helpers.sharding import (
     CLUSTER_COMPONENTS,
     CONFIG_SERVER_APP_NAME,
     CONFIG_SERVER_REL_NAME,
     SHARD_ONE_APP_NAME,
     SHARD_REL_NAME,
+    SHARD_THREE_APP_NAME,
     SHARD_TWO_APP_NAME,
     check_cluster_tls_enabled,
     deploy_cluster_components,
@@ -170,36 +176,47 @@ async def test_tls_inconsistent_rels(ops_test: OpsTest, substrate: Substrate) ->
         timeout=450,
     )
 
-    # CASE 4: Removal of integration while invalid TLS is safe
-    await ops_test.model.applications[SHARD_ONE_APP_NAME].remove_relation(
-        f"{SHARD_ONE_APP_NAME}:{TLS_RELATION_NAME}",
-        f"{TLS_CERTIFICATES_APP_NAME}:{TLS_RELATION_NAME}",
+
+async def test_invalid_relation_not_yet_established(
+    ops_test: OpsTest, substrate: Substrate, mongodb_charm: str, mongod_resource: dict
+):
+    await deploy_charm(
+        ops_test,
+        mongodb_charm,
+        substrate,
+        app_name=SHARD_THREE_APP_NAME,
+        mongod_resource=mongod_resource,
+        num_units=1,
+        config={"role": "shard"},
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[SHARD_THREE_APP_NAME],
+        idle_period=20,
+        timeout=DEPLOYMENT_TIMEOUT,
+    )
+
+    await ops_test.model.integrate(
+        f"{CONFIG_SERVER_APP_NAME}:{CONFIG_SERVER_REL_NAME}",
+        f"{SHARD_THREE_APP_NAME}:{SHARD_REL_NAME}",
     )
 
     await wait_for_mongodb_units_blocked(
         ops_test,
         substrate,
-        SHARD_ONE_APP_NAME,
-        status="Shard requires TLS to be enabled",
+        SHARD_THREE_APP_NAME,
+        status="Shard requires TLS to be enabled.",
         timeout=TIMEOUT,
     )
 
-    await ops_test.model.applications[SHARD_ONE_APP_NAME].remove_relation(
-        f"{SHARD_ONE_APP_NAME}:{SHARD_REL_NAME}",
+    await ops_test.model.applications[SHARD_THREE_APP_NAME].remove_relation(
+        f"{SHARD_THREE_APP_NAME}:{SHARD_REL_NAME}",
         f"{CONFIG_SERVER_APP_NAME}:{CONFIG_SERVER_REL_NAME}",
     )
 
     await wait_for_mongodb_units_blocked(
         ops_test,
         substrate,
-        SHARD_ONE_APP_NAME,
+        SHARD_THREE_APP_NAME,
         status="Missing relation to config-server.",
-        timeout=TIMEOUT,
-    )
-    await wait_for_mongodb_units_blocked(
-        ops_test,
-        substrate,
-        CONFIG_SERVER_APP_NAME,
-        status="Missing relation to shard(s).",
         timeout=TIMEOUT,
     )

--- a/tests/integration/mongodb/tls/test_sharding_tls_inconsistent_rels.py
+++ b/tests/integration/mongodb/tls/test_sharding_tls_inconsistent_rels.py
@@ -180,6 +180,12 @@ async def test_tls_inconsistent_rels(ops_test: OpsTest, substrate: Substrate) ->
 async def test_invalid_relation_not_yet_established(
     ops_test: OpsTest, substrate: Substrate, mongodb_charm: str, mongod_resource: dict
 ):
+    """Deploy a shard, integrate it but only the config server has TLS.
+
+    Then remove it and it should remove immediately and keep the relation to
+    config-server status.
+    """
+    # Deploy a new shard
     await deploy_charm(
         ops_test,
         mongodb_charm,
@@ -195,11 +201,13 @@ async def test_invalid_relation_not_yet_established(
         timeout=DEPLOYMENT_TIMEOUT,
     )
 
+    # Integrate the shard with the config-server
     await ops_test.model.integrate(
         f"{CONFIG_SERVER_APP_NAME}:{CONFIG_SERVER_REL_NAME}",
         f"{SHARD_THREE_APP_NAME}:{SHARD_REL_NAME}",
     )
 
+    # Shard has not TLS but config server has
     await wait_for_mongodb_units_blocked(
         ops_test,
         substrate,
@@ -208,11 +216,13 @@ async def test_invalid_relation_not_yet_established(
         timeout=TIMEOUT,
     )
 
+    # Remove the not yet added shard
     await ops_test.model.applications[SHARD_THREE_APP_NAME].remove_relation(
         f"{SHARD_THREE_APP_NAME}:{SHARD_REL_NAME}",
         f"{CONFIG_SERVER_APP_NAME}:{CONFIG_SERVER_REL_NAME}",
     )
 
+    # Wait to go back to normal status.
     await wait_for_mongodb_units_blocked(
         ops_test,
         substrate,

--- a/tests/integration/mongodb/tls/test_sharding_tls_inconsistent_rels.py
+++ b/tests/integration/mongodb/tls/test_sharding_tls_inconsistent_rels.py
@@ -9,7 +9,9 @@ from ...helpers.common import DEPLOYMENT_TIMEOUT, TIMEOUT, wait_for_mongodb_unit
 from ...helpers.sharding import (
     CLUSTER_COMPONENTS,
     CONFIG_SERVER_APP_NAME,
+    CONFIG_SERVER_REL_NAME,
     SHARD_ONE_APP_NAME,
+    SHARD_REL_NAME,
     SHARD_TWO_APP_NAME,
     check_cluster_tls_enabled,
     deploy_cluster_components,
@@ -166,4 +168,38 @@ async def test_tls_inconsistent_rels(ops_test: OpsTest, substrate: Substrate) ->
         SHARD_ONE_APP_NAME,
         status="Shard CA and Config-Server CA don't match.",
         timeout=450,
+    )
+
+    # CASE 4: Removal of integration while invalid TLS is safe
+    await ops_test.model.applications[SHARD_ONE_APP_NAME].remove_relation(
+        f"{SHARD_ONE_APP_NAME}:{TLS_RELATION_NAME}",
+        f"{TLS_CERTIFICATES_APP_NAME}:{TLS_RELATION_NAME}",
+    )
+
+    await wait_for_mongodb_units_blocked(
+        ops_test,
+        substrate,
+        SHARD_ONE_APP_NAME,
+        status="Shard requires TLS to be enabled",
+        timeout=TIMEOUT,
+    )
+
+    await ops_test.model.applications[SHARD_ONE_APP_NAME].remove_relation(
+        f"{SHARD_ONE_APP_NAME}:{SHARD_REL_NAME}",
+        f"{CONFIG_SERVER_APP_NAME}:{CONFIG_SERVER_REL_NAME}",
+    )
+
+    await wait_for_mongodb_units_blocked(
+        ops_test,
+        substrate,
+        SHARD_ONE_APP_NAME,
+        status="Missing relation to config-server.",
+        timeout=TIMEOUT,
+    )
+    await wait_for_mongodb_units_blocked(
+        ops_test,
+        substrate,
+        CONFIG_SERVER_APP_NAME,
+        status="Missing relation to shard(s).",
+        timeout=TIMEOUT,
     )

--- a/tests/unit/test_sharding.py
+++ b/tests/unit/test_sharding.py
@@ -542,3 +542,22 @@ def test_shard_manager_sync_cluster_passwords(
 
     assert manager.state.get_user_password(OperatorUser) == "test-operator"
     assert manager.state.get_user_password(BackupUser) == "test-backup"
+
+
+def test_shard_manager_remove_invalid_relation(
+    harness: Harness[MongoTestCharm], mocker, mongodb_hostname
+):
+    manager = harness.charm.operator.shard_manager
+
+    harness.set_leader()
+    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.SHARD
+    harness.charm.operator.state.db_initialised = True
+
+    rel_id = harness.add_relation(RelationNames.SHARDING.value, "config-server")
+
+    relation: Relation = harness.charm.model.get_relation(RelationNames.SHARDING.value, rel_id)  # type: ignore[assignment]
+
+    with pytest.raises(NonDeferrableFailedHookChecksError) as err:
+        manager.assert_pass_hook_checks(relation, is_leaving=True)
+
+    assert err.value == "Config-server never set up, no need to process broken event."

--- a/tests/unit/test_sharding.py
+++ b/tests/unit/test_sharding.py
@@ -560,4 +560,6 @@ def test_shard_manager_remove_invalid_relation(
     with pytest.raises(NonDeferrableFailedHookChecksError) as err:
         manager.assert_pass_hook_checks(relation, is_leaving=True)
 
-    assert err.value == "Config-server never set up, no need to process broken event."
+    assert err.value == NonDeferrableFailedHookChecksError(
+        "Config-server never set up, no need to process broken event."
+    )

--- a/tests/unit/test_sharding.py
+++ b/tests/unit/test_sharding.py
@@ -560,6 +560,4 @@ def test_shard_manager_remove_invalid_relation(
     with pytest.raises(NonDeferrableFailedHookChecksError) as err:
         manager.assert_pass_hook_checks(relation, is_leaving=True)
 
-    assert err.value == NonDeferrableFailedHookChecksError(
-        "Config-server never set up, no need to process broken event."
-    )
+    assert err.value.args[0] == "Config-server never set up, no need to process broken event."


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷 Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update
- [ ] Tooling and CI changes
- [ ] Dependencies upgrade or change

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and scope of this PR (what)
  - the impacted components (where, often match conventional commit scope)
  - explanation/algorithm if require (how)
-->
In case the relation was never fully established, it's useless to wait for draining, worse it will crash because it would access some non existing data (the mongos hosts).
Check by ensuring that `mongos_hosts ` has been stored or not in the hosts.

## 📑 Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Either the associated JIRA reference or a paragraph. -->
This is a bugfix discovered as part of a testing session for a demo.
It will ensure stability for the future.

## 🧪 How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added integration tests and unit tests for that bug.

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](../blob/6/edge/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
