### PR TITLE
patch: Outdated statuses and relation feasible

### DIFF
--- a/single_kernel_mongo/config/statuses.py
+++ b/single_kernel_mongo/config/statuses.py
@@ -249,6 +249,11 @@ class BackupStatuses(Enum):
     PBM_WAITING_TO_SYNC = StatusObject(
         status="waiting", message="Waiting to sync S3 configurations...", running="async"
     )
+    ACTION_RUNNING = StatusObject(
+        status="waiting",
+        message="Waiting for backup/restore to finish before removing the relation",
+        running="blocking",
+    )
 
     @staticmethod
     def backup_running(backup_id: str) -> StatusObject:

--- a/single_kernel_mongo/config/statuses.py
+++ b/single_kernel_mongo/config/statuses.py
@@ -38,6 +38,20 @@ class MongoDBStatuses(Enum):
         check="Relation validation.",
         action="Remove the relation on the shards interface (config-server or sharding relation) from this application.",
     )
+    INVALID_CFG_SRV_ON_SHARD_REL = StatusObject(
+        status="blocked",
+        message="The config-server interface cannot be used by shards.",
+        short_message="Invalid config-server relation.",
+        check="Relation validation.",
+        action="Remove the relation on the config-server interface from this application.",
+    )
+    INVALID_SHARD_ON_CFG_SRV_REL = StatusObject(
+        status="blocked",
+        message="The sharding interface cannot be used by a config-server.",
+        short_message="Invalid sharding relation.",
+        check="Relation validation.",
+        action="Remove the relation on the sharding interface from this application.",
+    )
     INVALID_MONGOS_REL = StatusObject(
         status="blocked",
         message="The cluster relation can only be used by config servers.",
@@ -90,6 +104,12 @@ class MongosStatuses(Enum):
         status="waiting",
         message="Waiting for mongos to start...",
         check="mongos process status check.",
+    )
+    INVALID_REL = StatusObject(
+        status="blocked",
+        message="The relation is invalid.",
+        check="Mongos charm relation check",
+        action="Remove the relation on mongos",
     )
     INVALID_EXPOSE_EXTERNAL = StatusObject(
         status="blocked",

--- a/single_kernel_mongo/core/operator.py
+++ b/single_kernel_mongo/core/operator.py
@@ -173,7 +173,7 @@ class OperatorProtocol(ABC, Object, ManagerStatusProtocol):
         ...
 
     @abstractmethod
-    def is_relation_feasible(self, name: str) -> bool:
+    def get_relation_feasible_status(self, name: str) -> StatusObject | None:
         """Checks if the relation is feasible in this context."""
         ...
 

--- a/single_kernel_mongo/events/backups.py
+++ b/single_kernel_mongo/events/backups.py
@@ -13,6 +13,7 @@ from botocore.exceptions import ConnectTimeoutError, SSLError
 from ops.charm import ActionEvent, RelationBrokenEvent, RelationJoinedEvent
 from ops.framework import Object
 
+from single_kernel_mongo.config.models import BackupState
 from single_kernel_mongo.config.relations import ExternalRequirerRelations
 from single_kernel_mongo.config.statuses import BackupStatuses, MongoDBStatuses
 from single_kernel_mongo.exceptions import (
@@ -122,6 +123,15 @@ class BackupEventsHandler(Object):
             )
             return
 
+        match self.manager.backup_state():
+            case BackupState.BACKUP_RUNNING | BackupState.RESTORE_RUNNING:
+                defer_event_with_info_log(
+                    logger, event, action, "Backup/Restore running, not changing credentials."
+                )
+                return
+            case _:
+                pass
+
         if not self.manager.validate_s3_config():
             logger.warning(
                 "Relation to S3 charm exists but not all necessary configurations have been set."
@@ -137,6 +147,12 @@ class BackupEventsHandler(Object):
         credentials = self.s3_client.get_s3_connection_info()
 
         try:
+            # We can clear all statuses as they will get rewritten right after if needed.
+            # The only ones we don't want to lose were checked earlier and returned early.
+            self.manager.state.statuses.clear(
+                scope="unit",
+                component=self.manager.name,
+            )
             # First create the bucket if it does not exist.
             self.manager.create_bucket(credentials=credentials)
             # Then set the config options on PBM.
@@ -207,6 +223,7 @@ class BackupEventsHandler(Object):
     def _on_s3_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Proceed on s3 relation broken."""
         self.manager.cleanup_certs_and_restart(event.relation)
+        self.manager.state.statuses.clear(scope="unit", component=self.manager.name)
 
     def _on_create_backup_action(self, event: ActionEvent) -> None:
         action = "backup"

--- a/single_kernel_mongo/events/backups.py
+++ b/single_kernel_mongo/events/backups.py
@@ -13,7 +13,6 @@ from botocore.exceptions import ConnectTimeoutError, SSLError
 from ops.charm import ActionEvent, RelationBrokenEvent, RelationJoinedEvent
 from ops.framework import Object
 
-from single_kernel_mongo.config.models import BackupState
 from single_kernel_mongo.config.relations import ExternalRequirerRelations
 from single_kernel_mongo.config.statuses import BackupStatuses, MongoDBStatuses
 from single_kernel_mongo.exceptions import (
@@ -122,15 +121,6 @@ class BackupEventsHandler(Object):
                 "Set PBM configurations, pbm-agent service not found.",
             )
             return
-
-        match self.manager.backup_state():
-            case BackupState.BACKUP_RUNNING | BackupState.RESTORE_RUNNING:
-                defer_event_with_info_log(
-                    logger, event, action, "Backup/Restore running, not changing credentials."
-                )
-                return
-            case _:
-                pass
 
         if not self.manager.validate_s3_config():
             logger.warning(

--- a/single_kernel_mongo/events/database.py
+++ b/single_kernel_mongo/events/database.py
@@ -122,9 +122,12 @@ class DatabaseEventsHandler(Object):
     def pass_hook_checks(self, event: RelationEvent) -> bool:
         """Runs the pre-hooks checks for MongoDBProvider, returns True if all pass."""
         # First, ensure that the relation is valid, useless to do anything else otherwise
-        if not self.dependent.state.is_role(
-            MongoDBRoles.MONGOS
-        ) and not self.dependent.is_relation_feasible(event.relation.name):
+        if (
+            not self.dependent.state.is_role(MongoDBRoles.MONGOS)
+            and (status := self.dependent.get_relation_feasible_status(self.relation_name))
+            is not None
+        ):
+            self.dependent.state.statuses.add(status, scope="unit", component=self.dependent.name)
             return False
 
         # We shouldn't try to create or update users if the database is not

--- a/single_kernel_mongo/events/database.py
+++ b/single_kernel_mongo/events/database.py
@@ -122,10 +122,8 @@ class DatabaseEventsHandler(Object):
     def pass_hook_checks(self, event: RelationEvent) -> bool:
         """Runs the pre-hooks checks for MongoDBProvider, returns True if all pass."""
         # First, ensure that the relation is valid, useless to do anything else otherwise
-        if (
-            not self.dependent.state.is_role(MongoDBRoles.MONGOS)
-            and (status := self.dependent.get_relation_feasible_status(self.relation_name))
-            is not None
+        if not self.dependent.state.is_role(MongoDBRoles.MONGOS) and (
+            status := self.dependent.get_relation_feasible_status(self.relation_name)
         ):
             self.dependent.state.statuses.add(status, scope="unit", component=self.dependent.name)
             return False

--- a/single_kernel_mongo/managers/backups.py
+++ b/single_kernel_mongo/managers/backups.py
@@ -258,6 +258,17 @@ class BackupManager(Object, BackupConfigManager, ManagerStatusProtocol):
             logger.info("Relation broken event occurring due to scale down.")
             return
 
+        # We have to wait until the backup / restore finishes if it is running.
+        while True:
+            match self.backup_state():
+                case BackupState.BACKUP_RUNNING | BackupState.RESTORE_RUNNING:
+                    self.dependent.charm.status_handler.set_running_status(
+                        scope="unit",
+                        component_name=self.name,
+                    )
+                case _:
+                    break
+
         # cleanup local certificate if it exists
         local_cert_file = TRUST_STORE_PATH / TrustStoreFiles.PBM.value
         if local_cert_file.exists() and local_cert_file.is_file():

--- a/single_kernel_mongo/managers/backups.py
+++ b/single_kernel_mongo/managers/backups.py
@@ -267,6 +267,8 @@ class BackupManager(Object, BackupConfigManager, ManagerStatusProtocol):
                         scope="unit",
                         component_name=self.name,
                     )
+                    # Wait for 10 seconds before retrying
+                    time.sleep(10)
                 case _:
                     break
 

--- a/single_kernel_mongo/managers/backups.py
+++ b/single_kernel_mongo/managers/backups.py
@@ -263,6 +263,7 @@ class BackupManager(Object, BackupConfigManager, ManagerStatusProtocol):
             match self.backup_state():
                 case BackupState.BACKUP_RUNNING | BackupState.RESTORE_RUNNING:
                     self.dependent.charm.status_handler.set_running_status(
+                        BackupStatuses.ACTION_RUNNING.value,
                         scope="unit",
                         component_name=self.name,
                     )

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -1038,7 +1038,7 @@ class MongoDBOperator(OperatorProtocol, Object):
         statuses = []
         if not self.backup_manager.is_valid_s3_integration():
             statuses.append(MongoDBStatuses.INVALID_S3_REL.value)
-        # Add valid statuses for all invalid relations integratedd
+        # Add valid statuses for all invalid integrated relations
         for relation_name in [
             RelationNames.DATABASE,
             RelationNames.SHARDING,

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -931,8 +931,14 @@ class MongoDBOperator(OperatorProtocol, Object):
         self.logrotate_config_manager.configure_and_restart()
 
     @override
-    def is_relation_feasible(self, rel_name: str) -> bool:
+    def get_relation_feasible_status(self, rel_name: str) -> StatusObject | None:
         """Checks if the relation is feasible in the current context.
+
+        Invalid relations are such:
+         * any sharding component on the database endpoint.
+         * shard on the config-server endpoints.
+         * config-server on the shard endpoint.
+         * database on sharding endpoints.
 
         TODO: in the future expand this to a handle other non-feasible
         relations (i.e. mongos-shard, shard-s3)
@@ -944,11 +950,7 @@ class MongoDBOperator(OperatorProtocol, Object):
                 self.state.app_peer_data.role,
                 rel_name,
             )
-
-            self.state.statuses.add(
-                MongoDBStatuses.INVALID_DB_REL.value, scope="unit", component=self.name
-            )
-            return False
+            return MongoDBStatuses.INVALID_DB_REL.value
         if not self.state.is_sharding_component and rel_name in {
             RelationNames.SHARDING,
             RelationNames.CONFIG_SERVER,
@@ -958,11 +960,17 @@ class MongoDBOperator(OperatorProtocol, Object):
                 self.state.app_peer_data.role,
                 rel_name,
             )
-            self.state.statuses.add(
-                MongoDBStatuses.INVALID_SHARDING_REL.value, scope="unit", component=self.name
-            )
-            return False
-        return True
+            return MongoDBStatuses.INVALID_SHARDING_REL.value
+        if self.state.is_role(MongoDBRoles.SHARD) and rel_name == RelationNames.CONFIG_SERVER:
+            logger.error("Charm is in sharding mode. Does not support %s interface.", rel_name)
+            return MongoDBStatuses.INVALID_CFG_SRV_ON_SHARD_REL.value
+        if self.state.is_role(MongoDBRoles.CONFIG_SERVER) and rel_name == RelationNames.SHARDING:
+            logger.error("Charm is in config-server mode. Does not support %s interface.", rel_name)
+            return MongoDBStatuses.INVALID_SHARD_ON_CFG_SRV_REL.value
+        if not self.state.is_role(MongoDBRoles.CONFIG_SERVER) and rel_name == RelationNames.CLUSTER:
+            logger.error("Charm is not a config-server, cannot integrate mongos")
+            return MongoDBStatuses.INVALID_MONGOS_REL.value
+        return None
 
     def _configure_workloads(self) -> None:
         """Handle filesystem interactions for charm configuration."""
@@ -1028,19 +1036,26 @@ class MongoDBOperator(OperatorProtocol, Object):
     def basic_statuses(self) -> list[StatusObject]:
         """Basic checks."""
         statuses = []
-        if not self.cluster_manager.is_valid_mongos_integration():
-            statuses.append(MongoDBStatuses.INVALID_MONGOS_REL.value)
-
         if not self.backup_manager.is_valid_s3_integration():
             statuses.append(MongoDBStatuses.INVALID_S3_REL.value)
-
-        if self.state.client_relations and self.state.is_sharding_component:
-            statuses.append(MongoDBStatuses.INVALID_DB_REL.value)
+        # Add valid statuses for all invalid relations integratedd
+        for relation_name in [
+            RelationNames.DATABASE,
+            RelationNames.SHARDING,
+            RelationNames.CONFIG_SERVER,
+            RelationNames.CLUSTER,
+        ]:
+            if (
+                self.model.relations[relation_name.value]
+                and (status := self.get_relation_feasible_status(relation_name)) is not None
+            ):
+                statuses.append(status)
 
         if not self.state.is_sharding_component and self.state.has_sharding_integration:
-            statuses.append(MongoDBStatuses.INVALID_SHARDING_REL.value)
-        elif rev_status := self.cluster_version_checker.get_cluster_mismatched_revision_status():
             # don't bother checking revision mismatch on sharding interface if replica
+            return statuses
+
+        if rev_status := self.cluster_version_checker.get_cluster_mismatched_revision_status():
             statuses.append(rev_status)
 
         return statuses

--- a/single_kernel_mongo/managers/mongos_operator.py
+++ b/single_kernel_mongo/managers/mongos_operator.py
@@ -342,7 +342,7 @@ class MongosOperator(OperatorProtocol, Object):
 
         In the mongos case, we only allow the mongos proxy client relation.
         """
-        if name != RelationNames.MONGOS_PROXY:
+        if name not in (RelationNames.MONGOS_PROXY, RelationNames.CLUSTER):
             return MongosStatuses.INVALID_REL.value
         return None
 

--- a/single_kernel_mongo/managers/mongos_operator.py
+++ b/single_kernel_mongo/managers/mongos_operator.py
@@ -337,12 +337,14 @@ class MongosOperator(OperatorProtocol, Object):
             raise
 
     @override
-    def is_relation_feasible(self, name: str) -> bool:
+    def get_relation_feasible_status(self, name: str) -> StatusObject | None:
         """Checks if the relation is feasible.
 
         In the mongos case, we only allow the mongos proxy client relation.
         """
-        return name == RelationNames.MONGOS_PROXY
+        if name != RelationNames.MONGOS_PROXY:
+            return MongosStatuses.INVALID_REL.value
+        return None
 
     def share_connection_info(self):
         """Shares the connection information of clients."""

--- a/single_kernel_mongo/managers/sharding.py
+++ b/single_kernel_mongo/managers/sharding.py
@@ -184,7 +184,7 @@ class ConfigServerManager(Object, ManagerStatusProtocol):
             raise NonDeferrableFailedHookChecksError("is only executed by config-server")
         if not self.state.db_initialised:
             raise DeferrableFailedHookChecksError("db is not initialised.")
-        if (status := self.dependent.get_relation_feasible_status(self.relation_name)) is not None:
+        if status := self.dependent.get_relation_feasible_status(self.relation_name):
             self.dependent.state.statuses.add(status, scope="unit", component=self.dependent.name)
             raise NonDeferrableFailedHookChecksError("relation is not feasible")
         if not self.charm.unit.is_leader():

--- a/single_kernel_mongo/managers/sharding.py
+++ b/single_kernel_mongo/managers/sharding.py
@@ -184,7 +184,8 @@ class ConfigServerManager(Object, ManagerStatusProtocol):
             raise NonDeferrableFailedHookChecksError("is only executed by config-server")
         if not self.state.db_initialised:
             raise DeferrableFailedHookChecksError("db is not initialised.")
-        if not self.dependent.is_relation_feasible(self.relation_name):
+        if (status := self.dependent.get_relation_feasible_status(self.relation_name)) is not None:
+            self.dependent.state.statuses.add(status, scope="unit", component=self.dependent.name)
             raise NonDeferrableFailedHookChecksError("relation is not feasible")
         if not self.charm.unit.is_leader():
             raise NonDeferrableFailedHookChecksError
@@ -508,7 +509,8 @@ class ShardManager(Object, ManagerStatusProtocol):
             raise NonDeferrableFailedHookChecksError("is only executed by shards")
         if not self.state.db_initialised:
             raise DeferrableFailedHookChecksError("db is not initialised.")
-        if not self.dependent.is_relation_feasible(self.relation_name):
+        if (status := self.dependent.get_relation_feasible_status(self.relation_name)) is not None:
+            self.dependent.state.statuses.add(status, scope="unit", component=self.dependent.name)
             raise NonDeferrableFailedHookChecksError("relation is not feasible")
         if self.state.upgrade_in_progress:
             logger.warning(

--- a/tests/unit/test_backup_manager.py
+++ b/tests/unit/test_backup_manager.py
@@ -116,6 +116,29 @@ def test_s3_credentials_no_db(harness: Harness[MongoTestCharm], mocker):
     defer.assert_called()
 
 
+def test_credentials_changed_backup_running(harness: Harness[MongoTestCharm], mocker):
+    harness.set_leader(True)
+    harness.charm.operator.state.db_initialised = True
+    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION
+    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True)
+    mocker.patch(
+        "single_kernel_mongo.events.backups.S3Requirer.get_s3_connection_info",
+        return_value={"access-key": "noneya", "secret-key": "business"},
+    )
+    defer = mocker.patch("ops.framework.EventBase.defer")
+    relation_id = harness.add_relation(
+        ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
+    )
+
+    harness.add_relation_unit(relation_id, "s3-integrator/0")
+    mocker.patch(
+        "single_kernel_mongo.managers.backups.BackupManager.backup_state",
+        return_value=BackupState.BACKUP_RUNNING,
+    )
+    harness.update_relation_data(relation_id, "s3-integrator/0", {"bucket": "hat"})
+    defer.assert_called()
+
+
 def test_environment_is_valid(harness: Harness[MongoTestCharm]):
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION

--- a/tests/unit/test_backup_manager.py
+++ b/tests/unit/test_backup_manager.py
@@ -116,29 +116,6 @@ def test_s3_credentials_no_db(harness: Harness[MongoTestCharm], mocker):
     defer.assert_called()
 
 
-def test_credentials_changed_backup_running(harness: Harness[MongoTestCharm], mocker):
-    harness.set_leader(True)
-    harness.charm.operator.state.db_initialised = True
-    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION
-    mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.active", return_value=True)
-    mocker.patch(
-        "single_kernel_mongo.events.backups.S3Requirer.get_s3_connection_info",
-        return_value={"access-key": "noneya", "secret-key": "business"},
-    )
-    defer = mocker.patch("ops.framework.EventBase.defer")
-    relation_id = harness.add_relation(
-        ExternalRequirerRelations.S3_CREDENTIALS.value, "s3-integrator"
-    )
-
-    harness.add_relation_unit(relation_id, "s3-integrator/0")
-    mocker.patch(
-        "single_kernel_mongo.managers.backups.BackupManager.backup_state",
-        return_value=BackupState.BACKUP_RUNNING,
-    )
-    harness.update_relation_data(relation_id, "s3-integrator/0", {"bucket": "hat"})
-    defer.assert_called()
-
-
 def test_environment_is_valid(harness: Harness[MongoTestCharm]):
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -4,12 +4,14 @@
 import json
 
 import pytest
+from data_platform_helpers.advanced_statuses.models import StatusObject
 from ops import BlockedStatus
 from ops.pebble import PathError, ProtocolError
 from ops.testing import ActionFailed, Harness
 from pymongo.errors import ConfigurationError, ConnectionFailure, OperationFailure
 
 from single_kernel_mongo.config.literals import Scope
+from single_kernel_mongo.config.relations import RelationNames
 from single_kernel_mongo.config.statuses import LdapStatuses, MongoDBStatuses, MongodStatuses
 from single_kernel_mongo.core.structured_config import MongoDBRoles
 from single_kernel_mongo.exceptions import (
@@ -1191,3 +1193,57 @@ def test_primary_other_unit(
     harness.update_relation_data(rel.id, f"{mongodb_name}/1", PEER_ADDR[substrate])
     output = harness.run_action("get-primary")
     assert output.results["replica-set-primary"] == f"{mongodb_name}/1"
+
+
+@pytest.mark.parametrize(
+    ("role", "rel_name", "status"),
+    (
+        (
+            MongoDBRoles.REPLICATION,
+            RelationNames.SHARDING,
+            MongoDBStatuses.INVALID_SHARDING_REL.value,
+        ),
+        (
+            MongoDBRoles.REPLICATION,
+            RelationNames.CONFIG_SERVER,
+            MongoDBStatuses.INVALID_SHARDING_REL.value,
+        ),
+        (MongoDBRoles.CONFIG_SERVER, RelationNames.DATABASE, MongoDBStatuses.INVALID_DB_REL.value),
+        (MongoDBRoles.SHARD, RelationNames.DATABASE, MongoDBStatuses.INVALID_DB_REL.value),
+        (
+            MongoDBRoles.SHARD,
+            RelationNames.CONFIG_SERVER,
+            MongoDBStatuses.INVALID_CFG_SRV_ON_SHARD_REL.value,
+        ),
+        (
+            MongoDBRoles.CONFIG_SERVER,
+            RelationNames.SHARDING,
+            MongoDBStatuses.INVALID_SHARD_ON_CFG_SRV_REL.value,
+        ),
+        (
+            MongoDBRoles.REPLICATION,
+            RelationNames.CLUSTER,
+            MongoDBStatuses.INVALID_MONGOS_REL.value,
+        ),
+        (
+            MongoDBRoles.SHARD,
+            RelationNames.CLUSTER,
+            MongoDBStatuses.INVALID_MONGOS_REL.value,
+        ),
+        (MongoDBRoles.REPLICATION, RelationNames.DATABASE, None),
+        (MongoDBRoles.CONFIG_SERVER, RelationNames.CONFIG_SERVER, None),
+        (MongoDBRoles.CONFIG_SERVER, RelationNames.CLUSTER, None),
+        (MongoDBRoles.SHARD, RelationNames.SHARDING, None),
+    ),
+)
+def test_get_relation_feasible_status(
+    harness: Harness[MongoTestCharm],
+    role: MongoDBRoles,
+    rel_name: RelationNames,
+    status: StatusObject | None,
+):
+    harness.set_leader(True)
+    harness.charm.operator.state.app_peer_data.role = role
+
+    computed_status = harness.charm.operator.get_relation_feasible_status(rel_name.value)
+    assert computed_status == status


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷 Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update
- [ ] Tooling and CI changes
- [ ] Dependencies upgrade or change

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and scope of this PR (what)
  - the impacted components (where, often match conventional commit scope)
  - explanation/algorithm if require (how)
-->
On backup manager, clear outdated statuses.
This also prevents the credentials from being updated while a backup is in progress, which was not given for granted before that.

On mongodb operator and mongos operator, improves drastically the `is_relation_feasible` method to check for way more cases, fixing #87 and other similar cases.
This PR also ensures that all those cases are reported in a similar fashion, with the same logic so that everything is always properly in sync.

Fixes: #87 

## 📑 Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Either the associated JIRA reference or a paragraph. -->
This is part of the preparations for new stable releases, and fulfilling an ongoing improvement of stability and edge cases handling.

## 🧪 How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I added unit testing of the methods modified.

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](../blob/6/edge/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
