### PR TITLE
patch(DPE-8421): Graceful validation of config options

### DIFF
--- a/single_kernel_mongo/abstract_charm.py
+++ b/single_kernel_mongo/abstract_charm.py
@@ -32,9 +32,9 @@ from data_platform_helpers.advanced_statuses.protocol import ManagerStatusProtoc
 from data_platform_helpers.advanced_statuses.types import Scope
 from ops.charm import CharmBase
 
-from single_kernel_mongo.config.literals import Substrates
+from single_kernel_mongo.config.literals import CharmKind, Substrates
 from single_kernel_mongo.config.relations import PeerRelationNames
-from single_kernel_mongo.config.statuses import CharmStatuses
+from single_kernel_mongo.config.statuses import CharmStatuses, MongoDBStatuses
 from single_kernel_mongo.core.operator import OperatorProtocol
 from single_kernel_mongo.core.structured_config import MongoConfigModel, MongoDBRoles
 from single_kernel_mongo.events.lifecycle import LifecycleEventsHandler
@@ -104,11 +104,19 @@ class AbstractMongoCharm(ManagerStatusProtocol, Generic[T, U], CharmBase):
             )
             self.workload.install()
 
-    def on_leader_elected(self, _):
+    def on_leader_elected(self, event):
         """First leader elected handler."""
         # Sets the role in the databag: when the charm is first created, its
         # role won't exist in the databag. We save it in the databag because we
         # don't allow role changing yet.
+        if (
+            self.operator.name == CharmKind.MONGOD
+            and self.parsed_config.role == MongoDBRoles.INVALID
+        ):
+            self.status_handler.set_running_status(MongoDBStatuses.INVALID_ROLE.value, scope="app")
+            event.defer()
+            return
+
         if self.operator.state.app_peer_data.role == MongoDBRoles.UNKNOWN:
             self.operator.state.app_peer_data.role = self.parsed_config.role
 

--- a/single_kernel_mongo/config/statuses.py
+++ b/single_kernel_mongo/config/statuses.py
@@ -64,6 +64,13 @@ class MongoDBStatuses(Enum):
     STARTING_MONGODB = StatusObject(
         status="maintenance", message="Starting MongoDB.", running="blocking"
     )
+    INVALID_ROLE = StatusObject(
+        status="blocked",
+        message="The role config option is invalid.",
+        check="Config validation failed.",
+        action="Set the role config to a valid value: `replication`, `shard` or `config-server`.",
+        running="blocking",
+    )
 
 
 class MongosStatuses(Enum):

--- a/single_kernel_mongo/core/structured_config.py
+++ b/single_kernel_mongo/core/structured_config.py
@@ -121,8 +121,8 @@ class MongoDBCharmConfig(MongoConfigModel):
 
     @field_validator("role", mode="before")
     @classmethod
-    def invalid_role_to_unknown(cls, v: str) -> MongoDBRoles:
-        """If the value is neither replication, config-server, or shard, returns unknown."""
+    def invalid_role_to_invalid(cls, v: str) -> MongoDBRoles:
+        """If the value is neither replication, config-server, or shard, returns invalid."""
         if v not in MongoDBRoles.valid_roles():
             return MongoDBRoles.INVALID
         return MongoDBRoles(v)

--- a/single_kernel_mongo/core/structured_config.py
+++ b/single_kernel_mongo/core/structured_config.py
@@ -44,6 +44,7 @@ class MongoDBRoles(str, Enum):
     """The different accepted roles for a charm."""
 
     UNKNOWN = ""
+    INVALID = "invalid"
     REPLICATION = "replication"
     CONFIG_SERVER = "config-server"
     SHARD = "shard"
@@ -123,7 +124,7 @@ class MongoDBCharmConfig(MongoConfigModel):
     def invalid_role_to_unknown(cls, v: str) -> MongoDBRoles:
         """If the value is neither replication, config-server, or shard, returns unknown."""
         if v not in MongoDBRoles.valid_roles():
-            return MongoDBRoles.UNKNOWN
+            return MongoDBRoles.INVALID
         return MongoDBRoles(v)
 
 

--- a/single_kernel_mongo/events/lifecycle.py
+++ b/single_kernel_mongo/events/lifecycle.py
@@ -51,6 +51,7 @@ from single_kernel_mongo.config.statuses import (
 from single_kernel_mongo.core.operator import OperatorProtocol
 from single_kernel_mongo.exceptions import (
     ContainerNotReadyError,
+    InvalidConfigRoleError,
     InvalidLdapQueryTemplateError,
     InvalidLdapUserToDnMappingError,
     UpgradeInProgressError,
@@ -121,6 +122,10 @@ class LifecycleEventsHandler(Object):
             logger.info("Not ready to start.")
             event.defer()
             return
+        except InvalidConfigRoleError:
+            logger.info("Missing a valid role.")
+            event.defer()
+            return
         except WorkloadNotReadyError:
             logger.info("Still starting service.")
             self.dependent.state.statuses.add(
@@ -163,6 +168,16 @@ class LifecycleEventsHandler(Object):
             self.dependent.update_config_and_restart()
         except (UpgradeInProgressError, WaitingForLeaderError):
             event.defer()
+        except InvalidConfigRoleError:
+            logger.info("Invalid config role.")
+            if self.charm.unit.is_leader():
+                self.dependent.state.statuses.add(
+                    MongoDBStatuses.INVALID_ROLE.value,
+                    scope="app",
+                    component=self.dependent.name,
+                )
+            event.defer()
+            return
         except InvalidLdapUserToDnMappingError:
             self.dependent.state.statuses.add(
                 LdapStatuses.INVALID_LDAP_USER_MAPPING.value,

--- a/single_kernel_mongo/exceptions.py
+++ b/single_kernel_mongo/exceptions.py
@@ -283,3 +283,7 @@ class MissingCredentialsError(Exception):
 
 class InvalidLdapHashError(DeferrableError):
     """Raised when the hash shared by config server is invalid."""
+
+
+class InvalidConfigRoleError(Exception):
+    """Raised when the role is invalid."""

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -320,7 +320,7 @@ class MongoDBOperator(OperatorProtocol, Object):
         """Handler on start."""
         # Ensure we're allowed to run.
         try:
-            self._prepare_checks()
+            self._run_startup_checks()
         except InvalidConfigRoleError:
             if self.charm.unit.is_leader():
                 self.state.statuses.add(
@@ -334,7 +334,7 @@ class MongoDBOperator(OperatorProtocol, Object):
             self.state.statuses.clear(scope="app", component=self.name)
 
         # Configure the workload. This requires a valid role!
-        # In the _prepare_checks, we ensure that we have a valid role before
+        # In the _run_startup_checks method, we ensure that we have a valid role before
         # allowing that event to run.
         self._configure_workloads()
 

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -1073,7 +1073,10 @@ class MongoDBOperator(OperatorProtocol, Object):
         if not self.mongodb_exporter_config_manager.workload.active():
             charm_statuses.append(MongoDBStatuses.WAITING_FOR_EXPORTER_START.value)
 
-        if not self.backup_manager.workload.active():
-            charm_statuses.append(BackupStatuses.WAITING_FOR_PBM_START.value)
+        # PBM does not start until the shard is integrated with a config-server
+        # So if we're everything BUT a shard or not added to cluster, let's check PBM as well
+        if not self.state.is_role(MongoDBRoles.SHARD) or self.state.is_shard_added_to_cluster():
+            if not self.backup_manager.workload.active():
+                charm_statuses.append(BackupStatuses.WAITING_FOR_PBM_START.value)
 
         return charm_statuses

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -299,7 +299,11 @@ class MongoDBOperator(OperatorProtocol, Object):
         # Truncate the file.
         self.workload.write(self.workload.paths.config_file, "")
 
-    def _prepare_checks(self):
+    def _run_startup_checks(self):
+        """Runs the startup checks.
+
+        None of those steps should fail otherwise the service is not yet allowed to start.
+        """
         if not self.workload.workload_present:
             logger.debug("mongod installation is not ready yet.")
             raise ContainerNotReadyError("Mongo DB installation not ready yet")
@@ -309,23 +313,25 @@ class MongoDBOperator(OperatorProtocol, Object):
             raise ContainerNotReadyError("Missing storage")
 
         if self.state.is_role(MongoDBRoles.UNKNOWN):
+            raise InvalidConfigRoleError()
+
+    @override
+    def prepare_for_startup(self) -> None:
+        """Handler on start."""
+        # Ensure we're allowed to run.
+        try:
+            self._prepare_checks()
+        except InvalidConfigRoleError:
             if self.charm.unit.is_leader():
                 self.state.statuses.add(
                     MongoDBStatuses.INVALID_ROLE.value,
                     scope="app",
                     component=self.name,
                 )
-
-            raise InvalidConfigRoleError()
+                raise
 
         if self.charm.unit.is_leader():
             self.state.statuses.clear(scope="app", component=self.name)
-
-    @override
-    def prepare_for_startup(self) -> None:
-        """Handler on start."""
-        # Ensure we're allowed to run.
-        self._prepare_checks()
 
         # Configure the workload. This requires a valid role!
         # In the _prepare_checks, we ensure that we have a valid role before

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -1050,7 +1050,7 @@ class MongoDBOperator(OperatorProtocol, Object):
             return [CharmStatuses.MONGODB_NOT_INSTALLED.value]
 
         if self.config.role == MongoDBRoles.INVALID:
-            charm_statuses = MongoDBStatuses.INVALID_ROLE.value
+            charm_statuses.append(MongoDBStatuses.INVALID_ROLE.value)
 
         if not is_valid_ldapusertodnmapping(self.config.ldap_user_to_dn_mapping):
             logger.error("Invalid LDAP Config - Please refer to the config option description.")

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -65,6 +65,7 @@ from single_kernel_mongo.exceptions import (
     ContainerNotReadyError,
     EarlyRemovalOfConfigServerError,
     FailedToElectNewPrimaryError,
+    InvalidConfigRoleError,
     InvalidLdapQueryTemplateError,
     InvalidLdapUserToDnMappingError,
     NonDeferrableFailedHookChecksError,
@@ -298,9 +299,7 @@ class MongoDBOperator(OperatorProtocol, Object):
         # Truncate the file.
         self.workload.write(self.workload.paths.config_file, "")
 
-    @override
-    def prepare_for_startup(self) -> None:
-        """Handler on start."""
+    def _prepare_checks(self):
         if not self.workload.workload_present:
             logger.debug("mongod installation is not ready yet.")
             raise ContainerNotReadyError("Mongo DB installation not ready yet")
@@ -309,6 +308,28 @@ class MongoDBOperator(OperatorProtocol, Object):
             logger.debug("Storages not attached yet.")
             raise ContainerNotReadyError("Missing storage")
 
+        if self.state.is_role(MongoDBRoles.UNKNOWN):
+            if self.charm.unit.is_leader():
+                self.state.statuses.add(
+                    MongoDBStatuses.INVALID_ROLE.value,
+                    scope="app",
+                    component=self.name,
+                )
+
+            raise InvalidConfigRoleError()
+
+        if self.charm.unit.is_leader():
+            self.state.statuses.clear(scope="app", component=self.name)
+
+    @override
+    def prepare_for_startup(self) -> None:
+        """Handler on start."""
+        # Ensure we're allowed to run.
+        self._prepare_checks()
+
+        # Configure the workload. This requires a valid role!
+        # In the _prepare_checks, we ensure that we have a valid role before
+        # allowing that event to run.
         self._configure_workloads()
 
         logger.info("Starting MongoDB.")
@@ -433,6 +454,12 @@ class MongoDBOperator(OperatorProtocol, Object):
                 "Changing config options is not permitted during an upgrade. The charm may be in a broken, unrecoverable state."
             )
             raise UpgradeInProgressError
+
+        if self.config.role == MongoDBRoles.INVALID:
+            logger.error(
+                f"Invalid role config - Please revert the config role to {self.state.app_peer_data.role}"
+            )
+            raise InvalidConfigRoleError("Invalid role")
 
         if not self.state.is_role(self.config.role):
             logger.error(
@@ -1019,22 +1046,26 @@ class MongoDBOperator(OperatorProtocol, Object):
         if not recompute:
             return self.state.statuses.get(scope=scope, component=self.name).root
 
-        if scope == "app":
-            return charm_statuses
+        if scope == "unit" and not self.workload.workload_present:
+            return [CharmStatuses.MONGODB_NOT_INSTALLED.value]
+
+        if self.config.role == MongoDBRoles.INVALID:
+            charm_statuses = MongoDBStatuses.INVALID_ROLE.value
 
         if not is_valid_ldapusertodnmapping(self.config.ldap_user_to_dn_mapping):
             logger.error("Invalid LDAP Config - Please refer to the config option description.")
             charm_statuses.append(LdapStatuses.INVALID_LDAP_USER_MAPPING.value)
+
         if not is_valid_ldap_options(
             self.config.ldap_user_to_dn_mapping, self.config.ldap_query_template
         ):
             logger.info("Invalid LDAP Config - Please refer to the config option description.")
             charm_statuses.append(LdapStatuses.INVALID_LDAP_QUERY_TEMPLATE.value)
 
-        if not self.workload.workload_present:
-            return [CharmStatuses.MONGODB_NOT_INSTALLED.value]
-
         charm_statuses += self.basic_statuses()
+
+        if scope == "app":
+            return charm_statuses
 
         if not self.state.db_initialised:
             charm_statuses.append(MongoDBStatuses.WAITING_FOR_MONGODB_START.value)
@@ -1042,6 +1073,7 @@ class MongoDBOperator(OperatorProtocol, Object):
         if not self.mongodb_exporter_config_manager.workload.active():
             charm_statuses.append(MongoDBStatuses.WAITING_FOR_EXPORTER_START.value)
 
-            return charm_statuses
+        if not self.backup_manager.workload.active():
+            charm_statuses.append(BackupStatuses.WAITING_FOR_PBM_START.value)
 
         return charm_statuses

--- a/single_kernel_mongo/state/app_peer_state.py
+++ b/single_kernel_mongo/state/app_peer_state.py
@@ -48,13 +48,11 @@ class AppPeerReplicaSet(AbstractRelationState[DataPeerData]):
         data_interface: DataPeerData,
         component: Application,
         substrate: Substrates,
-        role: MongoDBRoles,
         model: Model,
     ):
         super().__init__(relation, data_interface, component, substrate=substrate)
         self.data_interface = data_interface
         self._model = model
-        self._role = role
 
     @override
     def update(self, items: dict[str, str | None]) -> None:
@@ -76,7 +74,7 @@ class AppPeerReplicaSet(AbstractRelationState[DataPeerData]):
     def role(self) -> MongoDBRoles:
         """The role.
 
-        Either from the app databag or from the default from config.
+        Either from the app databag or unknown.
         """
         if (
             not (databag_role := self.relation_data.get(AppPeerDataKeys.ROLE.value))

--- a/single_kernel_mongo/state/app_peer_state.py
+++ b/single_kernel_mongo/state/app_peer_state.py
@@ -78,10 +78,11 @@ class AppPeerReplicaSet(AbstractRelationState[DataPeerData]):
 
         Either from the app databag or from the default from config.
         """
-        if not (databag_role := self.relation_data.get(AppPeerDataKeys.ROLE.value)):
+        if (
+            not (databag_role := self.relation_data.get(AppPeerDataKeys.ROLE.value))
+            or not self.relation
+        ):
             return MongoDBRoles.UNKNOWN
-        if not self.relation:
-            return self._role
         return MongoDBRoles(databag_role)
 
     @role.setter

--- a/single_kernel_mongo/state/charm_state.py
+++ b/single_kernel_mongo/state/charm_state.py
@@ -252,7 +252,6 @@ class CharmState(Object, StatusesStateProtocol):
             data_interface=self.peer_app_interface,
             component=self.model.app,
             substrate=self.substrate,
-            role=self.config.role,
             model=self.model,
         )
 

--- a/tests/integration/helpers/common.py
+++ b/tests/integration/helpers/common.py
@@ -854,6 +854,12 @@ async def check_status_detail(ops_test: OpsTest, app_name: str, status: str, mes
         assert unit_statuses[0]["Message"] == message
 
 
+async def check_app_status(ops_test: OpsTest, app_name: str, status: str, message: str) -> None:
+    app = ops_test.model.applications[app_name]
+    await ops_test.model.block_until(*[lambda: app.status == status], timeout=TIMEOUT)
+    assert app.status_message == message
+
+
 def is_relation_joined(ops_test: OpsTest, endpoint_one: str, endpoint_two: str) -> bool:
     """Check if a relation is joined.
 

--- a/tests/integration/helpers/common.py
+++ b/tests/integration/helpers/common.py
@@ -855,6 +855,7 @@ async def check_status_detail(ops_test: OpsTest, app_name: str, status: str, mes
 
 
 async def check_app_status(ops_test: OpsTest, app_name: str, status: str, message: str) -> None:
+    """Checks that the application has the correct status and message."""
     app = ops_test.model.applications[app_name]
     await ops_test.model.block_until(*[lambda: app.status == status], timeout=TIMEOUT)
     assert app.status_message == message

--- a/tests/integration/mongodb/test_charm_invalid_config.py
+++ b/tests/integration/mongodb/test_charm_invalid_config.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+import logging
+
+import pytest
+from pymongo import MongoClient
+from pytest_operator.plugin import OpsTest
+
+from ..helpers.common import (
+    DEPLOYMENT_TIMEOUT,
+    UNIT_IDS,
+    check_app_status,
+    deploy_charm,
+    find_unit,
+    get_address_of_unit,
+    get_app_name,
+    get_password,
+    unit_uri,
+)
+from ..helpers.types import Substrate
+
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(
+    ops_test: OpsTest, mongodb_charm: str, substrate: Substrate, mongod_resource, base_app_name
+):
+    await deploy_charm(
+        ops_test=ops_test,
+        charm=mongodb_charm,
+        substrate=substrate,
+        mongod_resource=mongod_resource,
+        app_name=base_app_name,
+        num_units=len(UNIT_IDS),
+        config={"role": "invalidrole"},
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[base_app_name], raise_on_blocked=False, timeout=DEPLOYMENT_TIMEOUT
+    )
+
+    # Check that status is blocked.
+    await check_app_status(ops_test, base_app_name, "blocked", "The role config option is invalid")
+
+    # Check that we can resolve it
+    await ops_test.model.applications[base_app_name].set_config({"role": "replication"})
+    await ops_test.model.wait_for_idle(
+        apps=[base_app_name], raise_on_blocked=False, status="active"
+    )
+    app_name = await get_app_name(ops_test)
+    leader_unit = await find_unit(ops_test, leader=True, app_name=app_name)
+    password = await get_password(ops_test, app_name=app_name)
+    ip_address = await get_address_of_unit(
+        ops_test, substrate, int(leader_unit.name.split("/")[1]), app_name
+    )
+
+    client = MongoClient(unit_uri(ip_address, password, app_name), directConnection=True)
+
+    # Good, we have a valid version, the server is running.
+    assert client.server_info()["version"].split("-")[0] is not None

--- a/tests/integration/mongodb/test_charm_invalid_config.py
+++ b/tests/integration/mongodb/test_charm_invalid_config.py
@@ -27,6 +27,11 @@ logger = logging.getLogger(__name__)
 async def test_build_and_deploy(
     ops_test: OpsTest, mongodb_charm: str, substrate: Substrate, mongod_resource, base_app_name
 ):
+    """Deploys the charm with an invalid config.
+
+    Then waits for the status to display, change it to a correct value and
+    checks that the service starts afterwards.
+    """
     await deploy_charm(
         ops_test=ops_test,
         charm=mongodb_charm,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -4,6 +4,7 @@
 import json
 
 import pytest
+from ops import BlockedStatus
 from ops.pebble import PathError, ProtocolError
 from ops.testing import ActionFailed, Harness
 from pymongo.errors import ConfigurationError, ConnectionFailure, OperationFailure
@@ -13,6 +14,7 @@ from single_kernel_mongo.config.statuses import LdapStatuses, MongoDBStatuses, M
 from single_kernel_mongo.core.structured_config import MongoDBRoles
 from single_kernel_mongo.exceptions import (
     ShardingMigrationError,
+    WaitingForLeaderError,
     WorkloadExecError,
     WorkloadNotReadyError,
     WorkloadServiceError,
@@ -489,6 +491,13 @@ def test_on_config_changed_invalid_role(harness):
         harness.update_config({"role": "shard"})
 
 
+def test_on_config_changed_no_role_yet(harness):
+    harness.set_leader(True)
+    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.UNKNOWN.value
+    with pytest.raises(WaitingForLeaderError):
+        harness.update_config({"role": "shard"})
+
+
 def test_on_config_changed_invalid_ldap_user_to_dn_mapping(harness):
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION.value
@@ -599,6 +608,23 @@ def test_on_leader_elected_dont_rotate_if_present(harness):
     operator_password = state.get_user_password(OperatorUser)
     harness.charm.on.leader_elected.emit()
     assert state.get_user_password(OperatorUser) == operator_password
+
+
+def test_leader_elected_invalid_role(harness: Harness[MongoTestCharm]):
+    state = harness.charm.operator.state
+    with harness.hooks_disabled():
+        harness.update_config({"role": "invalidrole"})
+
+    assert state.is_role(MongoDBRoles.UNKNOWN)
+
+    harness.set_leader(True)
+    assert harness.charm.app.status == BlockedStatus("The role config option is invalid.")
+    assert state.app_peer_data.role == MongoDBRoles.UNKNOWN
+
+    harness.update_config({"role": "replication"})
+    harness.set_leader(True)
+
+    assert state.app_peer_data.role == MongoDBRoles.REPLICATION
 
 
 def test_on_secret_changed(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -483,20 +483,27 @@ def test_start_fail_pbm_agent(harness, mocker, mock_fs_interactions):
     assert harness.charm.operator.state.db_initialised
 
 
-def test_on_config_changed_invalid_role(harness):
+def test_on_config_changed_inmpossible_to_change_role(harness):
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION.value
     with pytest.raises(ShardingMigrationError):
         harness.update_config({"role": "shard"})
 
 
-def test_on_config_changed_no_role_yet(harness: Harness[MongoTestCharm]):
+def test_on_config_changed_invalid_role(harness):
+    harness.set_leader(True)
+    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION.value
+    harness.update_config({"role": "invalidrole"})
+    harness.evaluate_status()
+    assert harness.charm.app.status == BlockedStatus("The role config option is invalid.")
+
+
+def test_on_config_changed_no_role_yet(harness: Harness[MongoTestCharm], mocker):
+    mocked_defer = mocker.patch("ops.framework.EventBase.defer")
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.UNKNOWN.value
     harness.update_config({"role": "shard"})
-    harness.evaluate_status()
-
-    assert harness.charm.app.status == BlockedStatus("The role config option is invalid.")
+    mocked_defer.assert_called()
 
 
 def test_on_config_changed_invalid_ldap_user_to_dn_mapping(harness):

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -14,7 +14,6 @@ from single_kernel_mongo.config.statuses import LdapStatuses, MongoDBStatuses, M
 from single_kernel_mongo.core.structured_config import MongoDBRoles
 from single_kernel_mongo.exceptions import (
     ShardingMigrationError,
-    WaitingForLeaderError,
     WorkloadExecError,
     WorkloadNotReadyError,
     WorkloadServiceError,
@@ -491,11 +490,13 @@ def test_on_config_changed_invalid_role(harness):
         harness.update_config({"role": "shard"})
 
 
-def test_on_config_changed_no_role_yet(harness):
+def test_on_config_changed_no_role_yet(harness: Harness[MongoTestCharm]):
     harness.set_leader(True)
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.UNKNOWN.value
-    with pytest.raises(WaitingForLeaderError):
-        harness.update_config({"role": "shard"})
+    harness.update_config({"role": "shard"})
+    harness.evaluate_status()
+
+    assert harness.charm.app.status == BlockedStatus("The role config option is invalid.")
 
 
 def test_on_config_changed_invalid_ldap_user_to_dn_mapping(harness):

--- a/tests/unit/test_structured_config.py
+++ b/tests/unit/test_structured_config.py
@@ -8,7 +8,7 @@ from single_kernel_mongo.core.structured_config import (
 
 def test_invalid_mongodb_config():
     model = MongoDBCharmConfig.model_validate({"role": "wrong", "auto_delete": True})  # type: ignore
-    assert model.role == MongoDBRoles.UNKNOWN
+    assert model.role == MongoDBRoles.INVALID
 
 
 def test_invalid_mongos_config():


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷 Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update
- [ ] Tooling and CI changes
- [ ] Dependencies upgrade or change

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and scope of this PR (what)
  - the impacted components (where, often match conventional commit scope)
  - explanation/algorithm if require (how)
-->
Proper validation of the role config option: it can be updated before the start event, but not after.
The start event will not run until the role config option is valid.
Adds unit test + integration test for that feature.
Also fixes some missing statuses regarding PBM: in case PBM should be running and is not, report it in the status.

Finally, the get_statuses function is reworked for the MongoDBOperator, so that app statuses are reported both for the app and the units, while the unit statuses will only be reported for the unit.
This allows for a better app report of statuses in the main operator.


## 📑 Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Either the associated JIRA reference or a paragraph. -->
We discovered recently that the role config option was never properly validated in some cases allowing weird deployments.

Closes #66 

## 🧪 How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
This is a bug fix, part of DPE-8421.

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](../blob/6/edge/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
