### PR TITLE
patch: extend statuses messages for mongos, charm, tls, upgrade and backup components

### DIFF
--- a/single_kernel_mongo/config/statuses.py
+++ b/single_kernel_mongo/config/statuses.py
@@ -69,27 +69,58 @@ class MongoDBStatuses(Enum):
 class MongosStatuses(Enum):
     """Mongos related statuses."""
 
-    INVALID_EXPOSE_EXTERNAL = StatusObject(
-        status="blocked", message="Config option for expose-external not valid."
-    )
     CONNECTING_TO_CONFIG_SERVER = StatusObject(
-        status="waiting", message="Connecting to config-server..."
+        status="waiting",
+        message="Connecting to config-server...",
+        check="mongos process status check.",
     )
     WAITING_FOR_SECRETS = StatusObject(
-        status="waiting", message="Waiting for secrets from config-server"
+        status="waiting",
+        message="Waiting for config-server secrets...",
+        check="Cluster relation validation.",
     )
-    REQUIRES_TLS = StatusObject(status="blocked", message="mongos requires TLS to be enabled.")
-    REQUIRES_NO_TLS = StatusObject(
-        status="blocked", message="mongos has TLS enabled, but config-server does not."
+    WAITING_FOR_MONGOS_START = StatusObject(
+        status="waiting",
+        message="Waiting for mongos to start...",
+        check="mongos process status check.",
+    )
+    INVALID_EXPOSE_EXTERNAL = StatusObject(
+        status="blocked",
+        message="The expose-external config option is invalid. Valid options are `nodeport` and `none`.",
+        short_message="Invalid expose-external config.",
+        check="Config validation failed.",
+        action="Set the expose-external config to a valid value: `nodeport` or `none`.",
+    )
+    MISSING_TLS_REL = StatusObject(
+        status="blocked",
+        message="TLS must be enabled in mongos, since it is enabled on the config-server in the cluster relation.",
+        short_message="Missing certificates relation.",
+        check="Relation validation failed.",
+        action="Add the certificates relation (tls-certificates interface) to mongos.",
+    )
+    INVALID_TLS_REL = StatusObject(
+        status="blocked",
+        message="TLS must be disabled in mongos, since it is disabled on the config-server in the cluster relation.",
+        short_message="Invalid certificates relation.",
+        check="Relation validation failed.",
+        action="Remove the certificates relation (tls-certificates interface) from this application.",
     )
     CA_MISMATCH = StatusObject(
-        status="blocked", message="mongos CA and Config-Server CA don't match."
+        status="blocked",
+        message="The mongos CA and Config-Server CA don't match.",
+        short_message="CA mismatch.",
+        check="Relation validation failed.",
+        action="Verify the certificates relations. Use the same CA for all cluster components.",
     )
-    MONGOS_NOT_STARTED = StatusObject(status="waiting", message="Waiting to start mongos...")
 
     # Running statuses:
     MISSING_CONF_SERVER_REL = StatusObject(
-        status="blocked", message="Missing relation to config-server.", running="async"
+        status="blocked",
+        message="The cluster relation with the config-server is missing.",
+        short_message="Missing cluster relation.",
+        check="Relation validation failed.",
+        action="Add the cluster relation (config-server interface) to mongos.",
+        running="async",
     )
     STARTING_MONGOS = StatusObject(
         status="maintenance", message="Starting mongos.", running="blocking"
@@ -100,68 +131,96 @@ class CharmStatuses(Enum):
     """Charm Statuses."""
 
     ACTIVE_IDLE = StatusObject(status="active", message="")
-    FAILED_SERVICES_START = StatusObject(status="blocked", message="Failed to start services.")
-    WAITING_TO_START = StatusObject(status="waiting", message="Starting services.")
-    MONGODB_NOT_INSTALLED = StatusObject(status="blocked", message="MongoDB not installed.")
-    MONGOS_NOT_STARTED = StatusObject(status="waiting", message="Waiting to start mongos...")
+    FAILED_SERVICES_START = StatusObject(
+        status="blocked",
+        message="Failed to start services. Retrying...",
+        action="Check logs for more information.",
+    )
+    MONGODB_NOT_INSTALLED = StatusObject(
+        status="waiting", message="Waiting for MongoDB to be installed..."
+    )
 
     # RUNNING Statuses
     INSTALLING_MONGODB = StatusObject(
-        status="maintenance", message="installing MongoDB", running="blocking"
+        status="maintenance", message="Installing MongoDB...", running="blocking"
     )
     DEPLOYED_WITHOUT_TRUST = StatusObject(
-        status="blocked", message="Charm deployed without `trust`", running="async"
+        status="blocked",
+        message="Charm deployed without `trust` option.",
+        action="Run `juju trust --scope=cluster <application-name>`.",
+        running="async",
     )
 
 
 class TLSStatuses(Enum):
     """TLS statuses."""
 
-    ACTIVE_IDLE = StatusObject(status="active", message="")
-
     # RUNNING statuses:
     DISABLING_TLS = StatusObject(
-        status="maintenance", message="Disabling TLS...", running="blocking"
+        status="maintenance",
+        message="Disabling TLS...",
+        check="Certificates relation (tls-certificates interface) removed.",
+        running="blocking",
     )
     # Enabling TLS takes a while because we wait for multiple certs so it's
     # async to span over multiple events.
-    ENABLING_TLS = StatusObject(status="maintenance", message="Enabling TLS...", running="blocking")
+    ENABLING_TLS = StatusObject(
+        status="maintenance",
+        message="Enabling TLS...",
+        check="Certificates relation (tls-certificates interface) added.",
+        running="async",
+    )
 
 
 class BackupStatuses(Enum):
     """Backup manager related statuses."""
 
+    ACTIVE_IDLE = StatusObject(status="active", message="")
     # note unlike other daemons (exporter and mongod) this status belongs to the backup manager
     # since certain configurations are required for pbm to be active and running.
-    WAITING_FOR_PBM_START = StatusObject(status="waiting", message="Waiting for pbm to start...")
-    PBM_MISSING_CONFIGS = StatusObject(status="blocked", message="s3 configurations missing.")
-    PBM_INCORRECT_CREDS = StatusObject(
+    WAITING_FOR_PBM_START = StatusObject(status="waiting", message="Waiting for PBM to start...")
+    PBM_MISSING_CONF = StatusObject(
         status="blocked",
-        message="s3 credentials are incorrect.",
-        action="Check S3 credentials on s3-integrator",
+        message="Missing configurations in the s3-credentials relation.",
+        short_message="Missing S3 configurations.",
+        action="Check the logs and verify the configuration in the s3-credentials relation (s3 interface).",
+        check="S3 configuration validation failed.",
     )
     PBM_INCOMPATIBLE_CONF = StatusObject(
         status="blocked",
-        message="s3 config options are incompatible.",
-        action="Check S3 configuration on s3-integrator",
+        message="Incompatible S3 config options.",
+        action="Check the logs and verify the configuration in the s3-credentials relation (s3 interface).",
+        check="S3 configuration validation failed.",
     )
-    UNKNOWN_PBM_ERROR = StatusObject(
+    PBM_INCORRECT_CREDS = StatusObject(
+        status="blocked",
+        message="Incorrect S3 credentials.",
+        action="Check the configuration in the s3-credentials relation (s3 interface).",
+        check="S3 configuration validation failed.",
+    )
+    PBM_UNKNOWN_ERROR = StatusObject(
         status="blocked",
         message="Unknown PBM error, check logs.",
-        action="Check logs for more information",
+        action="Check the logs and verify the configuration in the s3-credentials relation (s3 interface).",
+        check="PBM error found.",
     )
-    CANT_CONFIGURE = StatusObject(status="blocked", message="Couldn't configure s3 backup options.")
-    ACTIVE_IDLE = StatusObject(status="active", message="")
+    CANT_CONFIGURE = StatusObject(
+        status="blocked",
+        message="Failed to configure S3 backup options.",
+        short_message="Invalid S3 configuration.",
+        action="Check the logs and verify the configuration in the s3-credentials relation (s3 interface).",
+        check="S3 configuration validation failed.",
+    )
     FAILED_TO_CREATE_BUCKET = StatusObject(
         status="blocked",
-        message="Failed to create S3 bucket, check logs.",
-        action="Check S3 configuration on s3-integrator.",
-        check="Failed to create S3 bucket",
+        message="Failed to create S3 bucket.",
+        action="Check the logs and verify the configuration in the s3-credentials relation (s3 interface).",
+        check="S3 bucket creation failed.",
     )
 
     # Running status
     PBM_WAITING_TO_SYNC = StatusObject(
-        status="waiting", message="Waiting to sync s3 configurations...", running="async"
+        status="waiting", message="Waiting to sync S3 configurations...", running="async"
     )
 
     @staticmethod
@@ -170,6 +229,7 @@ class BackupStatuses(Enum):
         return StatusObject(
             status="maintenance",
             message=f"Backup started/running, backup id: '{backup_id}'",
+            short_message="Backing up...",
             running="async",
         )
 
@@ -179,6 +239,7 @@ class BackupStatuses(Enum):
         return StatusObject(
             status="maintenance",
             message=f"Restore started/running, backup id: '{backup_id}'",
+            short_message="Restoring...",
             running="async",
         )
 

--- a/single_kernel_mongo/config/statuses.py
+++ b/single_kernel_mongo/config/statuses.py
@@ -404,21 +404,24 @@ class MongodStatuses(Enum):
 class UpgradeStatuses(Enum):
     """Upgrade statuses."""
 
-    UNHEALTHY_UPGRADE = StatusObject(
-        status="blocked", message="Unhealthy after refresh.", approved_critical_component=True
-    )
-    INCOMPATIBLE_UPGRADE = StatusObject(
-        status="blocked",
-        message="Refresh incompatible. Rollback to previous revision with `juju refresh`",
-        approved_critical_component=True,
-    )
     ACTIVE_IDLE = StatusObject(status="active", message="")
     WAITING_POST_UPGRADE_STATUS = StatusObject(
         status="waiting", message="Waiting for post upgrade checks..."
     )
+    UNHEALTHY_UPGRADE = StatusObject(
+        status="blocked",
+        message="Unhealthy after refresh. Rollback to previous revision with `juju refresh`.",
+        approved_critical_component=True,
+    )
+    INCOMPATIBLE_UPGRADE = StatusObject(
+        status="blocked",
+        message="Refresh incompatible. Rollback to previous revision with `juju refresh`.",
+        approved_critical_component=True,
+    )
     REFRESH_IN_PROGRESS = StatusObject(
         status="maintenance",
-        message="Refreshing. To rollback, `juju refresh` to the previous revision",
+        message="Refreshing...",
+        action="To rollback, run `juju refresh` to the previous revision.",
         approved_critical_component=True,
     )
 
@@ -435,7 +438,7 @@ class UpgradeStatuses(Enum):
             status="active",
             message=f"MongoDB {unit_workload_version} running; "
             f"Snap revision {unit_workload_container_version}{outdated_str}; "
-            f"Charm revision {current_versions}",
+            f"Charm revision {current_versions}.",
             approved_critical_component=True,
         )
 
@@ -447,7 +450,7 @@ class UpgradeStatuses(Enum):
         outdated_str = " (restart pending)" if outdated else ""
         return StatusObject(
             status="active",
-            message=f"MongoDB {workload_version} running{outdated_str};  Charm revision {charm_version}",
+            message=f"MongoDB {workload_version} running{outdated_str};  Charm revision {charm_version}.",
             approved_critical_component=True,
         )
 
@@ -458,7 +461,7 @@ class UpgradeStatuses(Enum):
         """Returns refreshing status."""
         return StatusObject(
             status="blocked",
-            message=f"Refreshing. {resume_string}To rollback, `juju refresh` to last revision",
+            message=f"Refreshing. {resume_string}To rollback, `juju refresh` to last revision.",
             approved_critical_component=True,
         )
 

--- a/single_kernel_mongo/events/backups.py
+++ b/single_kernel_mongo/events/backups.py
@@ -127,7 +127,7 @@ class BackupEventsHandler(Object):
                 "Relation to S3 charm exists but not all necessary configurations have been set."
             )
             self.manager.state.statuses.set(
-                BackupStatuses.PBM_MISSING_CONFIGS.value,
+                BackupStatuses.PBM_MISSING_CONF.value,
                 scope="unit",
                 component=self.manager.name,
             )

--- a/single_kernel_mongo/events/tls.py
+++ b/single_kernel_mongo/events/tls.py
@@ -116,7 +116,7 @@ class TLSEventsHandler(Object):
         # When we can integrate, clean the mongos requires tls status.
         if self.manager.state.is_role(MongoDBRoles.MONGOS):
             self.manager.state.statuses.delete(
-                MongosStatuses.REQUIRES_TLS.value, scope="unit", component=self.dependent.name
+                MongosStatuses.MISSING_TLS_REL.value, scope="unit", component=self.dependent.name
             )
 
         for internal in (True, False):

--- a/single_kernel_mongo/managers/backups.py
+++ b/single_kernel_mongo/managers/backups.py
@@ -436,7 +436,7 @@ class BackupManager(Object, BackupConfigManager, ManagerStatusProtocol):
             case BackupState.EMPTY:
                 return []
             case BackupState.MISSING_CONFIG:
-                return [BackupStatuses.PBM_MISSING_CONFIGS.value]
+                return [BackupStatuses.PBM_MISSING_CONF.value]
             case BackupState.WAITING_PBM_START:
                 return [BackupStatuses.WAITING_FOR_PBM_START.value]
             case BackupState.INCORRECT_CREDS:
@@ -444,7 +444,7 @@ class BackupManager(Object, BackupConfigManager, ManagerStatusProtocol):
             case BackupState.INCOMPATIBLE_CONF:
                 return [BackupStatuses.PBM_INCOMPATIBLE_CONF.value]
             case BackupState.UNKNOWN_ERROR:
-                return [BackupStatuses.UNKNOWN_PBM_ERROR.value]
+                return [BackupStatuses.PBM_UNKNOWN_ERROR.value]
             case BackupState.WAITING_TO_SYNC:
                 return [BackupStatuses.PBM_WAITING_TO_SYNC.value]
             case BackupState.FAILED_TO_CREATE_BUCKET:

--- a/single_kernel_mongo/managers/cluster.py
+++ b/single_kernel_mongo/managers/cluster.py
@@ -333,7 +333,7 @@ class ClusterRequirer(Object):
             if not self.dependent.is_mongos_running():
                 logger.info("Mongos has not started yet, deferring")
                 self.state.statuses.set(
-                    MongosStatuses.MONGOS_NOT_STARTED.value,
+                    MongosStatuses.WAITING_FOR_MONGOS_START.value,
                     scope="unit",
                     component=self.dependent.name,
                 )
@@ -469,9 +469,9 @@ class ClusterRequirer(Object):
         mongos_has_tls, config_server_has_tls = self.tls_status()
         match (mongos_has_tls, config_server_has_tls):
             case False, True:
-                return MongosStatuses.REQUIRES_TLS.value
+                return MongosStatuses.MISSING_TLS_REL.value
             case True, False:
-                return MongosStatuses.REQUIRES_NO_TLS.value
+                return MongosStatuses.INVALID_TLS_REL.value
             case _:
                 pass
         if not self.is_ca_compatible():

--- a/single_kernel_mongo/managers/mongos_operator.py
+++ b/single_kernel_mongo/managers/mongos_operator.py
@@ -329,7 +329,7 @@ class MongosOperator(OperatorProtocol, Object):
         except WorkloadServiceError as e:
             logger.error("An exception occurred when starting mongos agent, error: %s.", str(e))
             self.charm.status_handler.set_running_status(
-                MongosStatuses.MONGOS_NOT_STARTED.value,
+                MongosStatuses.WAITING_FOR_MONGOS_START.value,
                 scope="unit",
                 statuses_state=self.state.statuses,
                 component_name=self.name,
@@ -565,7 +565,7 @@ class MongosOperator(OperatorProtocol, Object):
 
         if not self.is_mongos_running():
             logger.info("mongos has not started yet")
-            charm_statuses.append(CharmStatuses.MONGOS_NOT_STARTED.value)
+            charm_statuses.append(MongosStatuses.WAITING_FOR_MONGOS_START.value)
             return charm_statuses
 
         username = self.state.secrets.get_for_key(Scope.APP, key=AppPeerDataKeys.USERNAME.value)

--- a/single_kernel_mongo/managers/tls.py
+++ b/single_kernel_mongo/managers/tls.py
@@ -221,6 +221,8 @@ class TLSManager:
         self.charm.status_handler.set_running_status(
             TLSStatuses.ENABLING_TLS.value,
             scope="unit",
+            statuses_state=self.state.statuses,
+            component_name=self.charm.name,
         )
         try:
             self.dependent.restart_charm_services(force=True)

--- a/single_kernel_mongo/state/cluster_state.py
+++ b/single_kernel_mongo/state/cluster_state.py
@@ -38,7 +38,7 @@ class ClusterState(AbstractRelationState[Data]):
 
     @property
     def config_server_uri(self) -> str:
-        """Is TLS enabled."""
+        """Return config-server URI in the databag."""
         return self.relation_data.get(ClusterStateKeys.CONFIG_SERVER_DB.value, "")
 
     @property

--- a/tests/integration/mongodb/backups/test_backups.py
+++ b/tests/integration/mongodb/backups/test_backups.py
@@ -25,6 +25,7 @@ from ...helpers.common import (
     TIMEOUT,
     UNIT_IDS,
     check_or_scale_app,
+    check_status_detail,
     count_writes,
     deploy_charm,
     destroy_cluster,
@@ -78,7 +79,18 @@ async def test_blocked_missing_config(ops_test: OpsTest, substrate: Substrate) -
     )
 
     await wait_for_mongodb_units_blocked(
-        ops_test, substrate, db_app_name, status="s3 configurations missing.", timeout=300
+        ops_test,
+        substrate,
+        db_app_name,
+        status="Missing configurations in the s3-credentials relation.",
+        timeout=300,
+    )
+
+    await check_status_detail(
+        ops_test,
+        db_app_name,
+        status="blocked",
+        message="Missing configurations in the s3-credentials relation.",
     )
 
 
@@ -105,7 +117,13 @@ async def test_blocked_incorrect_creds(
     await ops_test.model.wait_for_idle(apps=[S3_APP_NAME], status="active")
 
     await wait_for_mongodb_units_blocked(
-        ops_test, substrate, db_app_name, status="s3 credentials are incorrect.", timeout=300
+        ops_test, substrate, db_app_name, status="Incorrect S3 credentials.", timeout=300
+    )
+    await check_status_detail(
+        ops_test,
+        db_app_name,
+        status="blocked",
+        message="Incorrect S3 credentials.",
     )
 
 

--- a/tests/integration/mongos/ldap/test_ldap.py
+++ b/tests/integration/mongos/ldap/test_ldap.py
@@ -130,7 +130,7 @@ async def test_build_and_deploy_mongos(
         ops_test,
         substrate,
         app_name,
-        status="Missing relation to config-server.",
+        status="The cluster relation with the config-server is missing",
         timeout=300,
         subordinate=(substrate == "lxd"),
     )

--- a/tests/integration/mongos/test_charm.py
+++ b/tests/integration/mongos/test_charm.py
@@ -65,7 +65,7 @@ async def test_waits_for_config_server(ops_test: OpsTest, substrate: Substrate) 
         ops_test,
         substrate,
         MONGOS_APP_NAME,
-        status="Missing relation to config-server.",
+        status="The cluster relation with the config-server is missing.",
         timeout=300,
         subordinate=(substrate == "lxd"),
     )

--- a/tests/integration/mongos/test_external_relation_kubernetes.py
+++ b/tests/integration/mongos/test_external_relation_kubernetes.py
@@ -8,6 +8,7 @@ from pytest_operator.plugin import OpsTest
 from ..helpers.common import (
     DATA_INTEGRATOR_APP_NAME,
     MONGOS_APP_NAME,
+    check_status_detail,
     deploy_charm,
     wait_for_mongodb_units_blocked,
 )
@@ -150,8 +151,14 @@ async def test_mongos_bad_configuration(ops_test: OpsTest, substrate: Substrate)
         ops_test,
         substrate,
         MONGOS_APP_NAME,
-        status="Config option for expose-external not valid.",
+        status="The expose-external config option is invalid. Valid options are `nodeport` and `none`.",
         timeout=300,
+    )
+    await check_status_detail(
+        ops_test,
+        MONGOS_APP_NAME,
+        status="blocked",
+        message="The expose-external config option is invalid. Valid options are `nodeport` and `none`.",
     )
 
     # verify new-configuration didn't break old configuration

--- a/tests/integration/mongos/test_tls.py
+++ b/tests/integration/mongos/test_tls.py
@@ -8,6 +8,7 @@ from pytest_operator.plugin import OpsTest
 from ..helpers.common import (
     MONGOS_APP_NAME,
     TIMEOUT,
+    check_status_detail,
     wait_for_mongodb_units_blocked,
 )
 from ..helpers.mongos import (
@@ -76,9 +77,16 @@ async def test_mongos_tls_enabled(ops_test: OpsTest, substrate: Substrate) -> No
         ops_test,
         substrate,
         MONGOS_APP_NAME,
-        status="mongos has TLS enabled, but config-server does not.",
+        status="TLS must be disabled in mongos, since it is disabled on the config-server in the cluster relation.",
         timeout=TIMEOUT,
         subordinate=(substrate == "lxd"),
+    )
+
+    await check_status_detail(
+        ops_test,
+        MONGOS_APP_NAME,
+        status="blocked",
+        message="TLS must be disabled in mongos, since it is disabled on the config-server in the cluster relation.",
     )
 
     await integrate_cluster_with_tls(ops_test)
@@ -146,9 +154,15 @@ async def test_mongos_tls_disabled(ops_test: OpsTest, substrate: Substrate) -> N
         ops_test,
         substrate,
         MONGOS_APP_NAME,
-        status="mongos requires TLS to be enabled.",
+        status="TLS must be enabled in mongos, since it is enabled on the config-server in the cluster relation.",
         timeout=TIMEOUT,
         subordinate=(substrate == "lxd"),
+    )
+    await check_status_detail(
+        ops_test,
+        MONGOS_APP_NAME,
+        status="blocked",
+        message="TLS must be enabled in mongos, since it is enabled on the config-server in the cluster relation.",
     )
 
 
@@ -199,7 +213,14 @@ async def test_mongos_tls_ca_mismatch(ops_test: OpsTest, substrate: Substrate) -
         ops_test,
         substrate,
         MONGOS_APP_NAME,
-        status="mongos CA and Config-Server CA don't match.",
+        status="The mongos CA and Config-Server CA don't match.",
         timeout=TIMEOUT,
         subordinate=(substrate == "lxd"),
+    )
+
+    await check_status_detail(
+        ops_test,
+        MONGOS_APP_NAME,
+        status="blocked",
+        message="The mongos CA and Config-Server CA don't match.",
     )

--- a/tests/unit/test_backup_manager.py
+++ b/tests/unit/test_backup_manager.py
@@ -150,13 +150,13 @@ def test_get_status_fail(harness: Harness[MongoTestCharm], backup_manager: Backu
 @pytest.mark.parametrize(
     ("pbm_status", "expected"),
     (
-        ("status code: 403", "s3 credentials are incorrect."),
-        ("status code: 404", "s3 config options are incompatible."),
-        ("status code: 301", "s3 config options are incompatible."),
+        ("status code: 403", "Incorrect S3 credentials."),
+        ("status code: 404", "Incompatible S3 config options."),
+        ("status code: 301", "Incompatible S3 config options."),
         ("Unknown message", "Unknown PBM error, check logs."),
         (
             '{"cluster": [{"nodes":[{"host": "%s/%s:27017", "errors": "status code: 403"}], "rs": "%s"}]}',
-            "s3 credentials are incorrect.",
+            "Incorrect S3 credentials.",
         ),
     ),
 )

--- a/tests/unit/test_cluster_manager.py
+++ b/tests/unit/test_cluster_manager.py
@@ -451,7 +451,7 @@ def test_cluster_requirer_update_mongos_and_restart_mongos_not_running(
     statuses = mongos_harness.charm.operator.state.statuses.get(
         scope=Scope.UNIT, component=mongos_harness.charm.operator.name
     )
-    assert as_status(statuses[0]) == WaitingStatus("Waiting to start mongos...")
+    assert as_status(statuses[0]) == WaitingStatus("Waiting for mongos to start...")
 
 
 def test_cluster_requirer_remove_users_and_cleanup_mongo(
@@ -637,11 +637,11 @@ def test_cluster_requirer_tls_status(
 @pytest.mark.parametrize(
     ("mongos_ca_secret", "cluster_ca_secret", "expected_status"),
     (
-        (None, "deadbeef", MongosStatuses.REQUIRES_TLS.value),
+        (None, "deadbeef", MongosStatuses.MISSING_TLS_REL.value),
         (
             "deadbeef",
             None,
-            MongosStatuses.REQUIRES_NO_TLS.value,
+            MongosStatuses.INVALID_TLS_REL.value,
         ),
         (None, None, None),
         ("deadbeef", "deadbeef", None),

--- a/tests/unit/test_status_handler.py
+++ b/tests/unit/test_status_handler.py
@@ -716,7 +716,7 @@ def test_mongos_get_status_tls_status(
         new_callable=mocker.PropertyMock,
         return_value=True,
     )
-    expected_status = MongosStatuses.REQUIRES_TLS.value
+    expected_status = MongosStatuses.MISSING_TLS_REL.value
     mocker.patch(
         "single_kernel_mongo.managers.cluster.ClusterRequirer.get_tls_statuses",
         return_value=expected_status,


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷 Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update
- [ ] Tooling and CI changes
- [ ] Dependencies upgrade or change

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and scope of this PR (what)
  - the impacted components (where, often match conventional commit scope)
  - explanation/algorithm if require (how)
-->

This PR ports:
- 3d7e4ee7a5e1be288c4341941c28b617d8fcd48d
- 65ae544b9c050624990885669c2b3b470959bc85

- Extend the status in `MongosStatuses`, `CharmStatuses`, `TLSStatuses`, `UpgradeStatuses` and `BackupStatuses` classes
  - Make the short_message shorter than 40 characters.
  - Add check and action when judged necessary
  - Make the variable names, messages and vocabulary consistent

Functional changes:
- The `TLSStatuses.ENABLING_TLS` becomes `async` as indicated in the existing comment above its declaration. 
- Improve the assert message in the blocked status message check for units

## 📑 Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- Either the associated JIRA reference or a paragraph. -->

This PR improves the quality of the message displayed to the operator about the state of the charms

## 🧪 How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Existing tests

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](../blob/6/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
