### PR TITLE
patch(DPE-8837): Migrate to self-hosted runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,9 @@
 name: Run integration tests
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 on:
   pull_request:
     paths-ignore:

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -92,20 +92,9 @@ jobs:
     runs-on: ${{ matrix.job.runner }}
     timeout-minutes: 226  # Sum of steps `timeout-minutes` + 5
     steps:
-      - name: Free up disk space
-        timeout-minutes: 15
-        run: |
-          printf '\nDisk usage before cleanup\n'
-          df --human-readable
-          # Based on https://github.com/actions/runner-images/issues/2840#issuecomment-790492173
-          rm -r /opt/hostedtoolcache/
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/share/swift
-          sudo rm -rf /usr/local/julia*
-          sudo apt purge -y firefox google-chrome-stable microsoft-edge-stable
-          printf '\nDisk usage after cleanup\n'
-          df --human-readable
+      - name: Disk usage
+        timeout-minutes: 1
+        run: df --human-readable
       - name: Checkout
         timeout-minutes: 3
         uses: actions/checkout@v4
@@ -130,7 +119,8 @@ jobs:
           sudo lxc image copy ubuntu:568f69ff1166 local:
           sudo lxc image alias create "juju/ubuntu@22.04/amd64" 568f69ff1166
       - name: Run spread job
-        timeout-minutes: 180
+        # FIXME: Change back to 180
+        timeout-minutes: 45
         id: spread
         # TODO: replace with `charmcraft test` when
         # https://github.com/canonical/charmcraft/issues/2105 and
@@ -141,19 +131,12 @@ jobs:
           AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_KEY }}
           GCP_ACCESS_KEY: ${{ secrets.GCP_ACCESS_KEY }}
           GCP_SECRET_KEY: ${{ secrets.GCP_SECRET_KEY }}
-
-      #- name: Setup tmate session
-      #  uses: mxschmitt/action-tmate@v3
-      #  if: ${{ failure() }}
-      #  with:
-      #    limit-access-to-actor: true
-
       - name: Upload Allure results
         timeout-minutes: 3
         # Only upload results from one spread system & one spread variant
         # Allure can only process one result per pytest test ID. If parameterization is done via
         # spread instead of pytest, there will be overlapping pytest test IDs.
-        if: ${{ (success() || (failure() && steps.spread.outcome == 'failure')) && startsWith(matrix.job.spread_job, 'github-ci:ubuntu-22.04:') && github.event_name == 'schedule' && github.run_attempt == '1' }}
+        if: ${{ (success() || (failure() && steps.spread.outcome == 'failure')) && startsWith(matrix.job.spread_job, 'github-ci:') && github.event_name == 'schedule' && github.run_attempt == '1' }}
         uses: actions/upload-artifact@v4
         with:
           name: allure-results-integration-test-${{ matrix.job.name_in_artifact }}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -119,8 +119,7 @@ jobs:
           sudo lxc image copy ubuntu:568f69ff1166 local:
           sudo lxc image alias create "juju/ubuntu@22.04/amd64" 568f69ff1166
       - name: Run spread job
-        # FIXME: Change back to 180
-        timeout-minutes: 45
+        timeout-minutes: 180
         id: spread
         # TODO: replace with `charmcraft test` when
         # https://github.com/canonical/charmcraft/issues/2105 and

--- a/spread.yaml
+++ b/spread.yaml
@@ -87,7 +87,10 @@ backends:
       PermitEmptyPasswords yes
       EOF
 
-      sudo passwd -d runner
+      sudo systemctl daemon-reload
+      sudo systemctl start ssh
+
+      sudo passwd -d ubuntu
 
       ADDRESS localhost
     # HACK: spread does not pass environment variables set on runner
@@ -99,10 +102,14 @@ backends:
       AWS_SECRET_KEY: '$(HOST: echo $AWS_SECRET_KEY)'
       GCP_ACCESS_KEY: '$(HOST: echo $GCP_ACCESS_KEY)'
       GCP_SECRET_KEY: '$(HOST: echo $GCP_SECRET_KEY)'
-      CONCIERGE_EXTRA_DEBS: build-essential,python3-dev,libldap-dev,libsasl2-dev
+      DOCKERHUB_MIRROR: '$(HOST: echo $DOCKERHUB_MIRROR)'
+      CONCIERGE_EXTRA_DEBS: pipx,build-essential,python3-dev,libldap-dev,libsasl2-dev
+      CONCIERGE_MICROK8S_CHANNEL: 1.34-strict/stable
     systems:
-      - ubuntu-24.04:
-          username: runner
+      - self-hosted-linux-amd64-noble-medium:
+          username: ubuntu
+      - self-hosted-linux-amd64-noble-large:
+          username: ubuntu
 
 suites:
   tests/spread/mongodb/lxd/:
@@ -120,25 +127,51 @@ kill-timeout: 3h
 environment:
   PATH: $PATH:$(pipx environment --value PIPX_BIN_DIR)
   CONCIERGE_JUJU_CHANNEL: 3.6/stable
-  CHARM_UBUNTU_BASE: 22.04
+  CHARM_UBUNTU_BASE: 24.04
 prepare: |
   snap refresh --hold
   chown -R root:root "$SPREAD_PATH"
   cd "$SPREAD_PATH"
   snap install --classic concierge
 
-  # Install charmcraft & pipx (on lxd-vm backend)
+  if [[ -n "$DOCKERHUB_MIRROR" ]] && ([[ $SPREAD_SUITE == *"microk8s"* ]] || [[ $SPREAD_TASK == *"ldap"* ]])
+  then
+    # Running on IS-hosted runner; configure microk8s to use Docker Hub mirror
+    # Run before concierge prepare because of https://github.com/canonical/concierge/issues/75
+
+    snap install microk8s --channel "$CONCIERGE_MICROK8S_CHANNEL" --classic
+
+    # Wait for microk8s to populate iptables
+    # https://chat.canonical.com/canonical/pl/jo5cg6wqjjrudqd5ybj6hhttee
+    until [[ -n $(iptables --list | grep -i "microk8s") ]]
+    do
+      echo "MicroK8s has not yet configured iptables."
+      sleep 10
+    done
+
+    tee /var/snap/microk8s/current/args/certs.d/docker.io/hosts.toml << EOF
+    server = "$DOCKERHUB_MIRROR"
+    [host."${DOCKERHUB_MIRROR#'https://'}"]
+    capabilities = ["pull", "resolve"]
+  EOF
+    microk8s stop
+    microk8s start
+  fi
+
   if [[ $SPREAD_SUITE == *"lxd"* ]]
   then
     concierge prepare --trace -c concierge-lxd.yaml
-    if [[ $SPREAD_TASK == *"ldap"* ]]
-    then
-      concierge prepare --trace -c concierge-microk8s.yaml
-    fi
-  else
-    concierge prepare --trace -c concierge-microk8s.yaml
   fi
 
+  if [[ $SPREAD_SUITE == *"microk8s"* ]] || [[ $SPREAD_TASK == *"ldap"* ]]
+  then
+    concierge prepare --trace -c concierge-microk8s.yaml
+    # microk8s config | juju add-k8s my-k8s --client
+    # juju bootstrap my-k8s concierge-microk8s
+    # juju add-model --controller concierge-microk8s testing
+  fi
+
+  # Install charmcraft & pipx (on lxd-vm backend)
   pipx install tox poetry
 prepare-each: |
   cd "$SPREAD_PATH"

--- a/tests/spread/mongodb/lxd/test_backups.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_backups.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/backups/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/lxd/test_backups_tls.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_backups_tls.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/backups/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/lxd/test_charm.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_charm.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/lxd/test_ha.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_ha.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/ha/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/lxd/test_ldap.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_ldap.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/ldap/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/lxd/test_major_upgrades.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_major_upgrades.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/lxd/test_metrics.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_metrics.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/lxd/test_mongos.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_mongos.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/relations/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/lxd/test_network_cut.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_network_cut.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/ha/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/lxd/test_relations.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_relations.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/relations/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/lxd/test_revision_checker.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_revision_checker.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/upgrades/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/lxd/test_rollback.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_rollback.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/upgrades/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/lxd/test_scale_up_down.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_scale_up_down.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/ha/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/lxd/test_sharded_backups_tls.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_sharded_backups_tls.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/backups/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/lxd/test_sharding.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_sharding.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/lxd/test_sharding_backups.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_sharding_backups.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/backups/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/lxd/test_sharding_ldap.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_sharding_ldap.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/ldap/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/lxd/test_sharding_major_upgrades.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_sharding_major_upgrades.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/lxd/test_sharding_race_condition.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_sharding_race_condition.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/ha/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/lxd/test_sharding_relations.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_sharding_relations.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/relations/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/lxd/test_sharding_rollback.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_sharding_rollback.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/upgrades/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/lxd/test_sharding_rollback_cluster_components.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_sharding_rollback_cluster_components.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/upgrades/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/lxd/test_sharding_tls_correct_relations.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_sharding_tls_correct_relations.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/tls/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/lxd/test_sharding_tls_inconsistent_rels.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_sharding_tls_inconsistent_rels.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/tls/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/lxd/test_sharding_upgrades.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_sharding_upgrades.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/upgrades/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/lxd/test_single_tls.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_single_tls.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/tls/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/lxd/test_single_tls_sharding.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_single_tls_sharding.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/tls/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/lxd/test_tls.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_tls.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/tls/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/lxd/test_upgrade.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_upgrade.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/upgrades/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/microk8s/test_backups.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_backups.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/backups/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/microk8s/test_backups_tls.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_backups_tls.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/backups/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/microk8s/test_charm.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_charm.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/microk8s/test_ha.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_ha.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/ha/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/microk8s/test_ldap.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_ldap.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/ldap/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/microk8s/test_major_upgrades.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_major_upgrades.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/microk8s/test_metrics.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_metrics.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/microk8s/test_mongos.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_mongos.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/relations/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/microk8s/test_network_cut.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_network_cut.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/ha/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/microk8s/test_relations.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_relations.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/relations/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/microk8s/test_revision_checker.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_revision_checker.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/upgrades/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/microk8s/test_rollback.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_rollback.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/upgrades/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/microk8s/test_scale_up_down.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_scale_up_down.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/ha/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/microk8s/test_sharded_backups_tls.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_sharded_backups_tls.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/backups/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/microk8s/test_sharding.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_sharding.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/microk8s/test_sharding_backups.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_sharding_backups.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/backups/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/microk8s/test_sharding_ldap.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_sharding_ldap.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/ldap/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/microk8s/test_sharding_major_upgrades.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_sharding_major_upgrades.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/microk8s/test_sharding_race_condition.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_sharding_race_condition.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/ha/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/microk8s/test_sharding_relations.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_sharding_relations.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/relations/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/microk8s/test_sharding_rollback.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_sharding_rollback.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/upgrades/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/microk8s/test_sharding_rollback_cluster_components.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_sharding_rollback_cluster_components.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/upgrades/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/microk8s/test_sharding_tls_correct_relations.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_sharding_tls_correct_relations.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/tls/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/microk8s/test_sharding_tls_inconsistent_rels.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_sharding_tls_inconsistent_rels.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/tls/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/microk8s/test_sharding_upgrades.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_sharding_upgrades.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/upgrades/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/microk8s/test_single_tls.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_single_tls.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/tls/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/microk8s/test_single_tls_sharding.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_single_tls_sharding.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/tls/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/microk8s/test_tls.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_tls.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/tls/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongodb/microk8s/test_upgrade.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_upgrade.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongodb/upgrades/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongos/lxd/test_charm.py/task.yaml
+++ b/tests/spread/mongos/lxd/test_charm.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongos/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongos/lxd/test_external_relation.py/task.yaml
+++ b/tests/spread/mongos/lxd/test_external_relation.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongos/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongos/lxd/test_ldap.py/task.yaml
+++ b/tests/spread/mongos/lxd/test_ldap.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongos/ldap/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongos/lxd/test_rollback.py/task.yaml
+++ b/tests/spread/mongos/lxd/test_rollback.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongos/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongos/lxd/test_tls.py/task.yaml
+++ b/tests/spread/mongos/lxd/test_tls.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongos/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongos/lxd/test_tls_race_condition.py/task.yaml
+++ b/tests/spread/mongos/lxd/test_tls_race_condition.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongos/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongos/lxd/test_upgrade.py/task.yaml
+++ b/tests/spread/mongos/lxd/test_upgrade.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongos/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongos/microk8s/test_charm.py/task.yaml
+++ b/tests/spread/mongos/microk8s/test_charm.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongos/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongos/microk8s/test_external_relation.py/task.yaml
+++ b/tests/spread/mongos/microk8s/test_external_relation.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongos/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongos/microk8s/test_external_relation_kubernetes.py/task.yaml
+++ b/tests/spread/mongos/microk8s/test_external_relation_kubernetes.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongos/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongos/microk8s/test_internal_relation_kubernetes.py/task.yaml
+++ b/tests/spread/mongos/microk8s/test_internal_relation_kubernetes.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongos/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongos/microk8s/test_ldap.py/task.yaml
+++ b/tests/spread/mongos/microk8s/test_ldap.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongos/ldap/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongos/microk8s/test_rollback.py/task.yaml
+++ b/tests/spread/mongos/microk8s/test_rollback.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongos/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongos/microk8s/test_tls.py/task.yaml
+++ b/tests/spread/mongos/microk8s/test_tls.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongos/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongos/microk8s/test_tls_race_condition.py/task.yaml
+++ b/tests/spread/mongos/microk8s/test_tls_race_condition.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongos/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium

--- a/tests/spread/mongos/microk8s/test_upgrade.py/task.yaml
+++ b/tests/spread/mongos/microk8s/test_upgrade.py/task.yaml
@@ -5,3 +5,5 @@ execute: |
   tox run -e integration -- "tests/integration/mongos/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
 artifacts:
   - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷️ Type of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tooling and CI
- [ ] Dependencies upgrade or change
- [ ] Chores / refactoring

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and feature scope of this PR (what)
  - the motivation behind this change (why)
  - the impacted components (often matches conventional commit scope)
  - explanation/algorithm if required (how)
-->
This PR moves from Github runners to self hosted runners for the integration tests.
The expectation is to have more stable tests, and being able to have bigger runners for specific tests.

Some additional changes that were brought:
 * Use a concurrency-group on the integration tests to allow for faster job cancellation
 * Tweaks on the spread config for microk8s to be avoid rate limiting
 * Support for both medium and large runners even if only medium runners are used for now (seems enough).

## 🧪 Manual testing steps
<!--- Give a list of instructions to manually test your change. -->
<!--- These instructions are meant for reviewers to test the PR -->
<!--- on their development environment. -->

N/A

## 🔬 Automated testing steps
<!--- Describe the unit and integration tests that you added -->
<!--- to ensure that this feature works as expected. Include details -->
<!--- on the positive and negative test cases, as well as any changes -->
<!--- made to the existing tests to ensure they are still relevant. -->
N/A

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have added or updated any relevant documentation.
- [x] I have read the [**CONTRIBUTING**](../blob/8/edge/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
