### PR TITLE
patch: fix removal of TLS relation from shard error display 

### DIFF
--- a/single_kernel_mongo/config/statuses.py
+++ b/single_kernel_mongo/config/statuses.py
@@ -356,36 +356,57 @@ class ConfigServerStatuses(Enum):
 class ShardStatuses(Enum):
     """Shard statuses."""
 
-    REQUIRES_TLS = StatusObject(status="blocked", message="Shard requires TLS to be enabled.")
-    REQUIRES_NO_TLS = StatusObject(
-        status="blocked", message="Shard has TLS enabled, but config-server does not."
-    )
-    CA_MISMATCH = StatusObject(
-        status="blocked", message="Shard CA and Config-Server CA don't match."
-    )
+    ACTIVE_IDLE = StatusObject(status="active", message="")
 
-    MISSING_CONF_SERVER_REL = StatusObject(
-        status="blocked", message="Missing relation to config-server."
-    )
     SHARD_DRAINED = StatusObject(
         status="active", message="Shard drained from cluster, ready for removal."
     )
-    WAITING_TO_REMOVE = StatusObject(
-        status="waiting", message="Waiting for config-server to remove shard", running="blocking"
-    )
-    SYNCING_PASSWORDS = StatusObject(
-        status="waiting", message="Waiting to sync passwords across the cluster..."
-    )
+
     ADDING_TO_CLUSTER = StatusObject(status="maintenance", message="Adding shard to config-server")
-    SHARD_NOT_AWARE = StatusObject(status="blocked", message="Shard is not yet shard aware.")
-    ACTIVE_IDLE = StatusObject(status="active", message="")
+    SYNCING_PASSWORDS = StatusObject(
+        status="waiting", message="Waiting for passwords to be synced across the cluster..."
+    )
+    SHARD_NOT_AWARE = StatusObject(status="waiting", message="Shard is not yet shard aware.")
+
+    REQUIRES_TLS = StatusObject(
+        status="blocked",
+        message="TLS must be enabled in shard, since it is enabled on the config-server in the cluster relation.",
+        short_message="Shard requires TLS to be enabled.",
+        check="Relation validation failed.",
+        action="Align the TLS configuration in all the cluster components: add the certificates relation to the shard.",
+    )
+    REQUIRES_NO_TLS = StatusObject(
+        status="blocked",
+        message="TLS must be disabled in shard, since it is disabled on the config-server in the cluster relation.",
+        short_message="Shard requires TLS to be disabled.",
+        check="Relation validation failed.",
+        action="Align the TLS configuration in all the cluster components: remove the certificates relation from the shard.",
+    )
+    CA_MISMATCH = StatusObject(
+        status="blocked",
+        message="Shard CA and config-server CA don't match.",
+        short_message="CA mismatch.",
+        check="TLS configuration validation failed.",
+        action="Verify the certificates relations. Use the same CA for all the cluster components.",
+    )
+    MISSING_CONF_SERVER_REL = StatusObject(
+        status="blocked",
+        message="Missing relation to config-server.",
+        check="Relation validation failed.",
+        action="Add the sharding relation (shards interface) to the shard.",
+    )
 
     # RUNNING status:
     DRAINING_SHARD = StatusObject(
         status="maintenance", message="Draining shard from cluster...", running="blocking"
     )
     FAILED_TO_DRAIN = StatusObject(
-        status="blocked", message="Failed to drain shard from cluster", running="blocking"
+        status="blocked", message="Failed to drain shard from cluster.", running="blocking"
+    )
+    WAITING_TO_REMOVE = StatusObject(
+        status="waiting",
+        message="Waiting for config-server to remove shard...",
+        running="blocking",
     )
 
     @staticmethod
@@ -398,6 +419,7 @@ class ShardStatuses(Enum):
         """Returns needs shard upgrade status."""
         return StatusObject(
             status="blocked",
+            short_message="Charm revision mismatch.",
             message=f"Charm revision ({current_charms_version}{local_identifier}) is not up-to date with config-server ({config_server_revision}{remote_local_identifier}).",
         )
 
@@ -409,6 +431,7 @@ class ShardStatuses(Enum):
         """Returns needs shard upgrade status."""
         return StatusObject(
             status="blocked",
+            short_message="Charm revision mismatch.",
             message=f"Charm revision ({current_charms_version}{local_identifier}) is not up-to date with config-server.",
         )
 
@@ -423,6 +446,7 @@ class MongodStatuses(Enum):
     ADDING_MEMBER = StatusObject(status="maintenance", message="Adding member...")
     REMOVING_MEMBER = StatusObject(status="maintenance", message="Removing member...")
     SYNCING_MEMBER = StatusObject(status="maintenance", message="Syncing member...")
+    NOT_READY = StatusObject(status="waiting", message="Mongod is not ready.")
     WAITING_REPL_SET_INIT = StatusObject(
         status="waiting", message="Waiting for replica set initialisation..."
     )

--- a/single_kernel_mongo/managers/mongo.py
+++ b/single_kernel_mongo/managers/mongo.py
@@ -498,6 +498,9 @@ class MongoManager(Object, ManagerStatusProtocol):
         if scope == "app":
             return []
 
+        if not self.mongod_ready():
+            return [MongodStatuses.NOT_READY.value]
+
         try:
             with MongoConnection(self.state.mongo_config) as mongo:
                 replset_status = mongo.get_replset_status()

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -181,7 +181,6 @@ class MongoDBOperator(OperatorProtocol, Object):
             self,
             self.workload,
             self.state,
-            self.substrate,
         )
         self.mongo_manager = MongoManager(
             self,

--- a/single_kernel_mongo/managers/mongos_operator.py
+++ b/single_kernel_mongo/managers/mongos_operator.py
@@ -107,7 +107,6 @@ class MongosOperator(OperatorProtocol, Object):
             self,
             self.workload,
             self.state,
-            self.substrate,
         )
         self.cluster_manager = ClusterRequirer(
             self, self.workload, self.state, self.substrate, RelationNames.CLUSTER

--- a/single_kernel_mongo/managers/sharding.py
+++ b/single_kernel_mongo/managers/sharding.py
@@ -17,7 +17,6 @@ from typing import TYPE_CHECKING
 from data_platform_helpers.advanced_statuses.models import StatusObject
 from data_platform_helpers.advanced_statuses.protocol import ManagerStatusProtocol
 from data_platform_helpers.advanced_statuses.types import Scope
-from ops import StatusBase
 from ops.framework import Object
 from ops.model import (
     Relation,
@@ -545,29 +544,10 @@ class ShardManager(Object, ManagerStatusProtocol):
                 "Config-server never set up, no need to process broken event."
             )
 
-        shard_has_tls, config_server_has_tls = self.tls_status()
-        match (shard_has_tls, config_server_has_tls):
-            case False, True:
-                self.state.statuses.add(
-                    ShardStatuses.REQUIRES_TLS.value, scope="unit", component=self.name
-                )
-                raise DeferrableFailedHookChecksError(
-                    "Config-Server uses TLS but shard does not. Please synchronise encryption method."
-                )
-            case True, False:
-                self.state.statuses.add(
-                    ShardStatuses.REQUIRES_NO_TLS.value, scope="unit", component=self.name
-                )
-                raise DeferrableFailedHookChecksError(
-                    "Shard uses TLS but config-server does not. Please synchronise encryption method."
-                )
-            case _:
-                pass
-
-        if not self.is_ca_compatible():
-            raise DeferrableFailedHookChecksError(
-                "Shard is integrated to a different CA than the config server. Please use the same CA for all cluster components.",
-            )
+        if tls_status := self.get_tls_status():
+            self.state.statuses.add(tls_status, scope="unit", component=self.name)
+            exception_msg = f"{tls_status.message} {tls_status.action}"
+            raise DeferrableFailedHookChecksError(exception_msg)
 
         if is_leaving:
             self.dependent.assert_proceed_on_broken_event(relation)
@@ -950,7 +930,7 @@ class ShardManager(Object, ManagerStatusProtocol):
 
         return False
 
-    def get_tls_status(self) -> StatusBase | None:
+    def get_tls_status(self) -> StatusObject | None:
         """Returns the TLS status of the sharded deployment."""
         shard_has_tls, config_server_has_tls = self.tls_status()
         match (shard_has_tls, config_server_has_tls):

--- a/single_kernel_mongo/managers/tls.py
+++ b/single_kernel_mongo/managers/tls.py
@@ -22,7 +22,6 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
 from ops.model import ModelError, SecretNotFoundError
 
-from single_kernel_mongo.config.literals import Substrates
 from single_kernel_mongo.config.statuses import TLSStatuses
 from single_kernel_mongo.core.operator import OperatorProtocol
 from single_kernel_mongo.core.structured_config import MongoDBRoles
@@ -92,13 +91,12 @@ class TLSManager:
         dependent: OperatorProtocol,
         workload: MongoDBWorkload | MongosWorkload,
         state: CharmState,
-        substrate: Substrates,
     ) -> None:
         self.dependent = dependent
         self.charm = dependent.charm
         self.workload = workload
         self.state = state
-        self.substrate = substrate
+        self.substrate = self.dependent.substrate
 
     def generate_certificate_request(self, key: bytes, internal: bool) -> bytes:
         """Generate a TLS Certificate request."""

--- a/tests/integration/mongodb/tls/test_sharding_tls_inconsistent_rels.py
+++ b/tests/integration/mongodb/tls/test_sharding_tls_inconsistent_rels.py
@@ -149,7 +149,7 @@ async def test_tls_inconsistent_rels(ops_test: OpsTest, substrate: Substrate) ->
         ops_test,
         substrate,
         SHARD_ONE_APP_NAME,
-        status="Shard has TLS enabled, but config-server does not.",
+        status="TLS must be disabled in shard, since it is disabled on the config-server in the cluster relation.",
         timeout=450,
     )
 
@@ -172,7 +172,7 @@ async def test_tls_inconsistent_rels(ops_test: OpsTest, substrate: Substrate) ->
         ops_test,
         substrate,
         SHARD_ONE_APP_NAME,
-        status="Shard CA and Config-Server CA don't match.",
+        status="Shard CA and config-server CA don't match.",
         timeout=450,
     )
 

--- a/tests/unit/test_status_handler.py
+++ b/tests/unit/test_status_handler.py
@@ -104,6 +104,22 @@ def test_mongo_get_status_no_error_microk8s(
     assert as_status(status) == expected_status
 
 
+def test_mongo_get_status_not_ready(harness: Harness[MongoTestCharm], mocker):
+    harness.set_leader(True)
+    harness.charm.operator.state.db_initialised = True
+    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION
+
+    mocker.patch(
+        "single_kernel_mongo.managers.mongo.MongoManager.mongod_ready",
+        return_value=False,
+    )
+
+    statuses = harness.charm.operator.mongo_manager.get_statuses(scope=Scope.UNIT, recompute=True)
+    status = next(iter(statuses), None)
+
+    assert status == MongodStatuses.NOT_READY.value
+
+
 @pytest.mark.parametrize(
     ("error", "expected_status"),
     (


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷️ Type of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling and CI
- [ ] Dependencies upgrade or change
- [ ] Chores / refactoring

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and feature scope of this PR (what)
  - the motivation behind this change (why)
  - the impacted components (often matches conventional commit scope)
  - explanation/algorithm if required (how)
-->

This PR includes a bug fix and a some refactoring to clean up the TLS -related statuses

### Issue:

In a sharded cluster with TLS enabled. If we remove the certificates relation from a shard, we'll see the following message:

<img width="580" height="52" alt="image" src="https://github.com/user-attachments/assets/ff07e830-843c-474f-bd9b-81859814f4a5" />

This is not a meaningful message.

### Context

If TLS is enabled in the config server but it's disabled in a shard, the shard is not reachable (ping mongod fails)

### Solution

Add a "Not ready" waiting status for mongo manager. 

TLS missing message (blocked status) is prioritory so it will be shown first. 


## 🧪 Manual testing steps
<!--- Give a list of instructions to manually test your change. -->
<!--- These instructions are meant for reviewers to test the PR -->
<!--- on their development environment. -->

```
juju deploy mongodb-k8s config-server --config role=config-server
juju deploy  mongodb-k8s shard0 --config role=shard
juju deploy self-signed-certificates

juju integrate shard0:sharding config-server
juju integrate config-server:certificates self-signed-certificates
juju integrate shard0:certificates self-signed-certificates
```
Remove TLS from shard

```
juju remove-relation shard:certificates self-signed-certificates
```
--> 
<img width="724" height="286" alt="image" src="https://github.com/user-attachments/assets/25a53965-b6da-4589-a2d7-2b2daaa8a8ad" />


## 🔬 Automated testing steps
<!--- Describe the unit and integration tests that you added -->
<!--- to ensure that this feature works as expected. Include details -->
<!--- on the positive and negative test cases, as well as any changes -->
<!--- made to the existing tests to ensure they are still relevant. -->

There is an existing integration test for inconsitent TLS relations

Added a UT for "mongod not ready message"

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have added or updated any relevant documentation.
- [x] I have read the [**CONTRIBUTING**](../blob/6/edge/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
