### PR TITLE
patch: add redirects for charmhub URLs

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -21,6 +21,7 @@ GLAuth
 GPG
 gyre
 homebrewed
+hostname
 hostnames
 html
 https
@@ -64,9 +65,9 @@ sitemapindex
 Sphinx
 Spread
 spread_test_example
+storedKey
 subproject
 subprojects
-storedKey
 SVG
 tex
 texlive
@@ -74,8 +75,8 @@ TOC
 toctree
 txt
 uncommenting
-userId
 URL
+userId
 utils
 VMs
 WCAG

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -223,6 +223,7 @@ sitemap_excludes = [
 # NOTE: If undefined, set to None, or empty,
 #       the sphinx_reredirects extension will be disabled.
 
+rediraffe_redirects = "redirects.txt"
 
 ###########################
 # Link checker exceptions #
@@ -286,6 +287,7 @@ extensions = [
     "sphinx_last_updated_by_git",
     "sphinx.ext.intersphinx",
     "sphinx_sitemap",
+    "sphinxext.rediraffe"
 ]
 
 # Excludes files or directories from processing

--- a/docs/explanation/users.md
+++ b/docs/explanation/users.md
@@ -3,16 +3,18 @@
 
 Charmed MongoDB has the following internal users:
 
+```text
 | user        | function                                              |
 |-------------|-------------------------------------------------------|
 | `operator`  | Admin user that manages database/cluster (i.e. admin) |
 | `monitor`   | Manages COS integration                               |
 | `backup`    | Manages all backup operations                         |
 | `logrotate` | Manages log rotation                                  |
+```
 
 Sample full dump of internal users on a newly installed Charmed MongoDB replica set:
 
-\`\`\`
+```text
 [
   {
     _id: 'admin.operator',
@@ -89,7 +91,7 @@ Sample full dump of internal users on a newly installed Charmed MongoDB replica 
     roles: [ { role: 'logRotate', db: 'admin' } ]
   }
 ]
-\`\`\`
+```
 
 ```{caution}
 These users are dedicated to the operator's logic, and **using them incorrectly could damage your deployment.**

--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -1,0 +1,74 @@
+# The redirects.txt file stores all the redirects for the published docs
+# If you change a filename, move or delete a file, you need a redirect here.
+# - Comment lines start with a hash (#) and are ignored
+# - Each redirect should appear on its own line
+
+# We are using the dirhtml builder, so files are treated as directories:
+# - A file is built like `filename/index.html`, not `filename.html`
+# - *Do* include a trailing slash at the end of the path
+# - *Do not* include a file extension or you'll get errors
+# - Paths don't need a slash in front of them
+
+# Example:
+# redirect/from/file/ redirect/to/file/
+
+# Tutorial
+t-replica-set tutorial/ 
+t-set-up tutorial/ 
+t-deploy tutorial/ 
+t-access tutorial/ 
+t-scale-replicas tutorial/ 
+t-passwords tutorial/ 
+t-integrate tutorial/ 
+t-enable-tls tutorial/
+t-clean-up tutorial/ 
+t-sharded-cluster tutorial/ 
+t-set-up-sharding tutorial/ 
+t-deploy-sharding tutorial/ 
+t-access-sharding tutorial/ 
+t-scale-sharding tutorial/ 
+t-passwords-sharding tutorial/ 
+t-integrate-sharding tutorial/ 
+t-enable-tls-sharding tutorial/ 
+
+# How-to guides
+h-deploy/ how-to/deploy/
+h-scale how-to/scale-replicas-and-shards
+h-enable-tls how-to/enable-tls
+h-manage-client-connections how-to/manage-client-connections
+h-enable-ldap how-to/enable-ldap
+
+h-backup how-to/back-up-and-restore/
+h-configure-s3 how-to/back-up-and-restore/configure-s3-aws
+h-create-backup how-to/back-up-and-restore/create-a-backup
+h-restore-backup how-to/back-up-and-restore/restore-a-backup
+h-migrate-cluster how-to/back-up-and-restore/migrate-a-cluster
+
+h-upgrade how-to/upgrade/
+h-upgrade-replica-set how-to/upgrade/minor-version-upgrade/upgrade-replica-set
+h-upgrade-sharding how-to/upgrade/minor-version-upgrade/upgrade-sharded-cluster
+h-major-upgrade how-to/upgrade/major-version-upgrade
+
+h-view-metrics how-to/monitoring/view-metrics
+h-audit-logging how-to/monitoring/view-audit-logs
+
+# Reference
+r-system-requirements reference/system-requirements
+
+r-revision-164 reference/release-notes/vm/revision-164
+r-revision-199 reference/release-notes/vm/revision-199
+r-revision-229 reference/release-notes/vm/revision-229
+r-revision-61 reference/release-notes/k8s/revision-61
+r-revision-81 reference/release-notes/k8s/revision-81
+
+r-testing reference/charm-testing
+
+# Explanation
+e-users explanation/users
+e-sharding explanation/sharding
+
+e-security explanation/security/
+e-cryptography explanation/security/cryptography
+e-hardening explanation/security/hardening-guide
+
+e-advanced-statuses explanation/advanced-statuses

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,3 +3,4 @@ packaging
 sphinxcontrib-svg2pdfconverter[CairoSVG]
 sphinx-last-updated-by-git
 sphinx-sitemap
+sphinxext-rediraffe

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -437,7 +437,7 @@ Now view and save the output of the URI:
 echo $URI
 ```
 
-Like earlier, we access `mongo` by `ssh`ing into one of the Charmed MongoDB hosts:
+Like earlier, we access `mongo` by `ssh`-ing into one of the Charmed MongoDB hosts:
 
 ```shell
 juju ssh mongodb/0


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷️ Type of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Tooling and CI
- [ ] Dependencies upgrade or change
- [ ] Chores / refactoring

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and feature scope of this PR (what)
  - the motivation behind this change (why)
  - the impacted components (often matches conventional commit scope)
  - explanation/algorithm if required (how)
-->
This PR adds the Sphinx extension `rediraffe` to our dependencies, and introduces a file with the URL mapping between old `charmhub.io paths` and the new `canonical-charmed-mongodb.readthedocs-hosted.com` paths.

This is done so that old Charmhub URLs automatically redirect to the new RTD site (e.g. bookmarks, links in other documentation and blog posts...)

## 🧪 Manual testing steps

```shell
cd docs
make clean
make run
```

The build will automatically test all the redirects and output something like

```shell
Writing redirects...
(good) t-replica-set/index.html --> tutorial/index.html
(good) t-set-up/index.html --> tutorial/index.html
(good) t-deploy/index.html --> tutorial/index.html
...
```
 

## 🔬 Automated testing steps
<!--- Describe the unit and integration tests that you added -->
<!--- to ensure that this feature works as expected. Include details -->
<!--- on the positive and negative test cases, as well as any changes -->
<!--- made to the existing tests to ensure they are still relevant. -->

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [x] I have added or updated any relevant documentation.
- [x] I have read the [**CONTRIBUTING**](../blob/6/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
