### PR TITLE
patch: fix MongoDB exporter invalid URI

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -9,7 +9,6 @@ on:
         required: true
         type: string
 
-
 jobs:
   collect-integration-tests:
     name: Collect integration test spread jobs
@@ -80,7 +79,6 @@ jobs:
     outputs:
       jobs: ${{ steps.collect-jobs.outputs.jobs }}
 
-
   integration-test:
     strategy:
       fail-fast: false
@@ -90,7 +88,7 @@ jobs:
     needs:
       - collect-integration-tests
     runs-on: ${{ matrix.job.runner }}
-    timeout-minutes: 226  # Sum of steps `timeout-minutes` + 5
+    timeout-minutes: 227 # Sum of steps `timeout-minutes` + 5
     steps:
       - name: Disk usage
         timeout-minutes: 1
@@ -113,7 +111,7 @@ jobs:
           pattern: ${{ inputs.artifact-prefix }}-*
           merge-multiple: true
       - name: Override lxd image
-        timeout-minutes: 1
+        timeout-minutes: 2
         id: override-lxd
         run: |
           sudo lxc image copy ubuntu:568f69ff1166 local:

--- a/single_kernel_mongo/state/charm_state.py
+++ b/single_kernel_mongo/state/charm_state.py
@@ -731,7 +731,7 @@ class CharmState(Object, StatusesStateProtocol):
     @property
     def stats_config(self) -> MongoConfiguration:
         """Mongo Configuration for the charmed-stats user."""
-        return self.mongodb_config_for_user(CharmedStatsUser, hosts=self.internal_hosts)
+        return self.mongodb_config_for_user(CharmedStatsUser)
 
     @property
     def logrotate_config(self) -> MongoConfiguration:

--- a/tests/integration/mongodb/test_metrics.py
+++ b/tests/integration/mongodb/test_metrics.py
@@ -119,3 +119,4 @@ async def verify_endpoints(ops_test: OpsTest, substrate: Substrate, unit: JujuUn
     # if configured correctly there should be more than one mongodb metric present
     mongodb_metrics = mongo_resp.text
     assert mongodb_metrics.count("mongo") > 1
+    assert mongodb_metrics.count(f'rs_nm="{app_name}"') > 1

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1088,7 +1088,6 @@ def test_on_secret_changed_unknown(harness: Harness[MongoTestCharm], mocker):
 def test_connect_mongodb_exporter_success(
     harness: Harness[MongoTestCharm],
     mocker,
-    mongodb_hostname: str,
     mongodb_name,
 ):
     """Tests the correct config is done."""
@@ -1102,6 +1101,8 @@ def test_connect_mongodb_exporter_success(
     mocker.patch(
         "single_kernel_mongo.managers.mongo.MongoManager.set_feature_compatibility_version"
     )
+
+    mongodb_hostname = "127.0.0.1"
 
     harness.set_leader(True)
     harness.charm.operator.state.db_initialised = True

--- a/tests/unit/test_charm_state.py
+++ b/tests/unit/test_charm_state.py
@@ -106,3 +106,12 @@ def test_unit_peer_data(
     state = harness.charm.operator.state
 
     assert state.unit_peer_data.internal_address == mongodb_hostname
+
+
+def test_mongodb_status_user(harness: Harness[MongoTestCharm]):
+    harness.set_leader(True)
+    state = harness.charm.operator.state
+    password = state.get_user_password(user=CharmedStatsUser)
+    assert state.stats_config.uri.startswith(
+        f"mongodb://charmed-stats:{password}@127.0.0.1:27017/admin?"
+    )


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷️ Type of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling and CI
- [ ] Dependencies upgrade or change
- [ ] Chores / refactoring

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and feature scope of this PR (what)
  - the motivation behind this change (why)
  - the impacted components (often matches conventional commit scope)
  - explanation/algorithm if required (how)
-->
An issue was reported on MongoDB Operator repo (https://github.com/canonical/mongodb-operator/issues/595).
We realised that the list of hosts on mongodb exporter was wrong.

## 🧪 Manual testing steps
<!--- Give a list of instructions to manually test your change. -->
<!--- These instructions are meant for reviewers to test the PR -->
<!--- on their development environment. -->

```text
1. juju deploy mongodb -n 3
2. juju ssh mongodb/0
3. sudo journalctl --no-pager -u snap.charmed-mongodb.mongodb-exporter | grep invalid
```
This should not return any line containing `Cannot connect to MongoDB: invalid MongoDB options: a direct connection cannot be made if multiple hosts are specified`

## 🔬 Automated testing steps
<!--- Describe the unit and integration tests that you added -->
<!--- to ensure that this feature works as expected. Include details -->
<!--- on the positive and negative test cases, as well as any changes -->
<!--- made to the existing tests to ensure they are still relevant. -->
Added a test to ensure we don't rollback that change in the future and that we only have one host.

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have added or updated any relevant documentation.
- [x] I have read the [**CONTRIBUTING**](../blob/6/edge/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
