### PR TITLE
patch: Mitigate CVE-2025-14847

### DIFF
--- a/single_kernel_mongo/managers/config.py
+++ b/single_kernel_mongo/managers/config.py
@@ -274,8 +274,14 @@ class MongoConfigManager(FileBasedConfigManager, ABC):
                 self.log_options,
                 self.audit_options,
                 self.ldap_parameters,
+                self.patch_parameters,
             ],
         )
+
+    @property
+    def patch_parameters(self) -> dict[str, Any]:
+        """The additional patch parameters added to the conf."""
+        return {"net": {"compression": {"compressors": "snappy,zstd"}}}
 
     @property
     @abstractmethod

--- a/single_kernel_mongo/managers/config.py
+++ b/single_kernel_mongo/managers/config.py
@@ -281,6 +281,7 @@ class MongoConfigManager(FileBasedConfigManager, ABC):
     @property
     def patch_parameters(self) -> dict[str, Any]:
         """The additional patch parameters added to the conf."""
+        # This patches CVE-2025-14847.
         return {"net": {"compression": {"compressors": "snappy,zstd"}}}
 
     @property

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -106,7 +106,11 @@ def test_mongodb_config_manager(mocker, role: MongoDBRoles, expected_parameter: 
     assert (
         all_params
         == {
-            "net": {"bindIpAll": True, "port": 27017},
+            "net": {
+                "bindIpAll": True,
+                "port": 27017,
+                "compression": {"compressors": "snappy,zstd"},
+            },
             "security": {
                 "authorization": "enabled",
                 "clusterAuthMode": "keyFile",
@@ -254,6 +258,7 @@ def test_mongos_config_manager(mocker):
                 "filePermissions": "0766",
             },
             "port": 27018,
+            "compression": {"compressors": "snappy,zstd"},
         },
         "security": {
             "clusterAuthMode": "keyFile",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷️ Type of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling and CI
- [ ] Dependencies upgrade or change
- [ ] Chores / refactoring

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and feature scope of this PR (what)
  - the motivation behind this change (why)
  - the impacted components (often matches conventional commit scope)
  - explanation/algorithm if required (how)
-->
This is a mitigation for [mongobleed](https://nvd.nist.gov/vuln/detail/CVE-2025-14847) that disables the zlib compression. This effectively prevents Mongobleed from being exectued.

## 🧪 Manual testing steps
<!--- Give a list of instructions to manually test your change. -->
<!--- These instructions are meant for reviewers to test the PR -->
<!--- on their development environment. -->


```text
1. juju deploy <my-app>
2. Wait for charm to be stable
3. Connect as charm-operator
4. Run `db.adminCommand({ getCmdLineOpts: 1 }).parsed.net.compression` and check that only snappy and zstd are enabled.
```

## 🔬 Automated testing steps
<!--- Describe the unit and integration tests that you added -->
<!--- to ensure that this feature works as expected. Include details -->
<!--- on the positive and negative test cases, as well as any changes -->
<!--- made to the existing tests to ensure they are still relevant. -->
Patched unit tests to take that into account.

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have added or updated any relevant documentation.
- [x] I have read the [**CONTRIBUTING**](../blob/8/edge/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
