### PR TITLE
patch: add workflow dispatch for bump library in charm repos workflow

### DIFF
--- a/.github/workflows/bump_dependent_charms.yaml
+++ b/.github/workflows/bump_dependent_charms.yaml
@@ -6,7 +6,7 @@ on:
       version:
         required: true
         type: string
-      branch_name:
+      base_branch:
         required: true
         type: string
 
@@ -29,7 +29,7 @@ jobs:
 
     env:
       VERSION: ${{ inputs.version }}
-      BASE_BRANCH: ${{ inputs.branch_name }}
+      BASE_BRANCH: ${{ inputs.base_branch }}
       DEP_NAME: mongo-charms-single-kernel
 
     steps:
@@ -42,8 +42,12 @@ jobs:
           token: ${{ secrets.PAT }}
           ref: ${{ env.BASE_BRANCH }}
 
-      - name: Install poetry
-        run: pipx install poetry
+      - name: Install tox & poetry
+        run: |
+          pipx ensurepath
+          echo "${HOME}/.local/bin" >> "${GITHUB_PATH}"
+          pipx install tox poetry
+
       - name: Setup python
         uses: actions/setup-python@v5
         with:
@@ -53,12 +57,13 @@ jobs:
       - name: Install deps
         run: |
           sudo apt update
-          sudo apt install -y  build-essential python3-dev libldap-dev libsasl2-dev
+          sudo apt install -y build-essential python3-dev libldap-dev libsasl2-dev
 
       - name: Create update branch
         run: |
-          BRANCH="bump-${DEP_NAME}-${VERSION}"
-          git checkout -b "$BRANCH"
+          PR_BRANCH="bump-${DEP_NAME}-${VERSION}"
+          git checkout -b "$PR_BRANCH"
+          echo "PR_BRANCH=$PR_BRANCH" >> $GITHUB_ENV
 
       - name: Update dependency version in pyproject.toml
         run: |
@@ -78,14 +83,14 @@ jobs:
 
       - name: Push branch
         run: |
-          git push origin "$BRANCH" -f
+          git push origin "${PR_BRANCH}" -f
 
       - name: Open Pull Request
         env:
           GITHUB_TOKEN: ${{ secrets.PAT }}
         run: |
           gh pr create \
-            --title "Bump ${DEP_NAME} to ${VERSION}" \
+            --title "patch: Bump ${DEP_NAME} to ${VERSION}" \
             --body "Automated bump of \`${DEP_NAME}\` to version \`${VERSION}\` after PyPI release." \
             --base ${{ env.BASE_BRANCH }}  \
-            --head "$BRANCH"
+            --head "${PR_BRANCH}"

--- a/.github/workflows/bump_dependent_charms.yaml
+++ b/.github/workflows/bump_dependent_charms.yaml
@@ -9,6 +9,14 @@ on:
       base_branch:
         required: true
         type: string
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        type: string
+      base_branch:
+        required: true
+        type: string
 
 jobs:
   update-dependent-charms:

--- a/.github/workflows/bump_dependent_charms.yaml
+++ b/.github/workflows/bump_dependent_charms.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Install CLI
         run: pipx install git+https://github.com/canonical/data-platform-workflows@v31.1.1#subdirectory=python/cli
       - name: Checkout target repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ matrix.repo }}
           ref: ${{ env.BASE_BRANCH }}

--- a/.github/workflows/bump_dependent_charms.yaml
+++ b/.github/workflows/bump_dependent_charms.yaml
@@ -39,7 +39,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: ${{ matrix.repo }}
-          token: ${{ secrets.PAT }}
           ref: ${{ env.BASE_BRANCH }}
 
       - name: Install tox & poetry

--- a/.github/workflows/bump_dependent_charms.yaml
+++ b/.github/workflows/bump_dependent_charms.yaml
@@ -62,7 +62,7 @@ jobs:
         run: |
           PR_BRANCH="bump-${DEP_NAME}-${VERSION}"
           git checkout -b "$PR_BRANCH"
-          echo "PR_BRANCH=$PR_BRANCH" >> $GITHUB_ENV
+          echo "PR_BRANCH=$PR_BRANCH" >> "$GITHUB_ENV"
 
       - name: Update dependency version in pyproject.toml
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,5 +70,5 @@ jobs:
     uses: ./.github/workflows/bump_dependent_charms.yaml
     with:
       version: ${{ needs.release-part1.outputs.git-tag }}
-      branch_name: ${{ github.ref_name }}
+      base_branch: ${{ github.ref_name }}
     secrets: inherit


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷️ Type of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tooling and CI
- [ ] Dependencies upgrade or change
- [ ] Chores / refactoring

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and feature scope of this PR (what)
  - the motivation behind this change (why)
  - the impacted components (often matches conventional commit scope)
  - explanation/algorithm if required (how)
-->

This PR adds workflow_dispatch to the Bump dependent charm versions job. 

The job is currently failing: https://github.com/canonical/mongo-single-kernel-library/actions/runs/20824797578/job/59892440874

Improvements:
- Replace `branch_name` with `base_branch`
- We do not need the PAT to checkout to public repositories
- Improve poetry installation
- Export the `PR_BRANCH` to the env so that it can be used in a later step


## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have added or updated any relevant documentation.
- [x] I have read the [**CONTRIBUTING**](../blob/8/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
