### PR TITLE
patch: bump rust toolchain

### DIFF
--- a/tests/charms/mongodb_k8s_test_charm/charmcraft.yaml
+++ b/tests/charms/mongodb_k8s_test_charm/charmcraft.yaml
@@ -77,7 +77,7 @@ parts:
       # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
       # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
-      rustup default 1.83.0  # renovate: charmcraft-rust-latest
+      rustup default 1.92.0  # renovate: charmcraft-rust-latest
 
       # Relock for single-kernel-library if it's not a local build
       if [ ! -d single_kernel_mongo ]

--- a/tests/charms/mongodb_test_charm/charmcraft.yaml
+++ b/tests/charms/mongodb_test_charm/charmcraft.yaml
@@ -78,7 +78,7 @@ parts:
       # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
       # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
-      rustup default 1.83.0  # renovate: charmcraft-rust-latest
+      rustup default 1.92.0  # renovate: charmcraft-rust-latest
 
       # Relock for single-kernel-library if it's not a local build
       if [ ! -d single_kernel_mongo ]

--- a/tests/charms/mongos_k8s_test_charm/charmcraft.yaml
+++ b/tests/charms/mongos_k8s_test_charm/charmcraft.yaml
@@ -77,7 +77,7 @@ parts:
       # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
       # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
-      rustup default 1.83.0  # renovate: charmcraft-rust-latest
+      rustup default 1.92.0  # renovate: charmcraft-rust-latest
 
       # Relock for single-kernel-library if it's not a local build
       if [ ! -d single_kernel_mongo ]

--- a/tests/charms/mongos_test_charm/charmcraft.yaml
+++ b/tests/charms/mongos_test_charm/charmcraft.yaml
@@ -77,7 +77,7 @@ parts:
       # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
       # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
-      rustup default 1.83.0  # renovate: charmcraft-rust-latest
+      rustup default 1.92.0  # renovate: charmcraft-rust-latest
 
       # Relock for single-kernel-library if it's not a local build
       if [ ! -d single_kernel_mongo ]

--- a/tests/integration/applications/client_relations_charm/charmcraft.yaml
+++ b/tests/integration/applications/client_relations_charm/charmcraft.yaml
@@ -72,7 +72,7 @@ parts:
       # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
       # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
-      rustup default 1.83.0  # renovate: charmcraft-rust-latest
+      rustup default 1.92.0  # renovate: charmcraft-rust-latest
 
 
       craftctl default

--- a/tests/integration/applications/continuous_write_charm/charmcraft.yaml
+++ b/tests/integration/applications/continuous_write_charm/charmcraft.yaml
@@ -72,7 +72,7 @@ parts:
       # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
       # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
-      rustup default 1.83.0  # renovate: charmcraft-rust-latest
+      rustup default 1.92.0  # renovate: charmcraft-rust-latest
 
 
       craftctl default

--- a/tests/integration/applications/mongos_client_charm/charmcraft.yaml
+++ b/tests/integration/applications/mongos_client_charm/charmcraft.yaml
@@ -72,7 +72,7 @@ parts:
       # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
       # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
       rustup set profile minimal
-      rustup default 1.83.0  # renovate: charmcraft-rust-latest
+      rustup default 1.92.0  # renovate: charmcraft-rust-latest
 
 
       craftctl default


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷️ Type of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling and CI
- [x] Dependencies upgrade or change
- [ ] Chores / refactoring

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and feature scope of this PR (what)
  - the motivation behind this change (why)
  - the impacted components (often matches conventional commit scope)
  - explanation/algorithm if required (how)
-->

charm builds are [failing](https://github.com/canonical/charmcraftcache-hub/actions/runs/20730309844) because of an outdated rust toolchain after the recent release of maturin

This PR sets the rust toolchain to 1.92.0

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have added or updated any relevant documentation.
- [x] I have read the [**CONTRIBUTING**](../blob/8/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
