### PR TITLE
patch: validate private key matches certificate and config

### DIFF
--- a/single_kernel_mongo/events/tls.py
+++ b/single_kernel_mongo/events/tls.py
@@ -182,14 +182,18 @@ class TLSEventsHandler(Object):
         )
         peer_certificates, peer_private_key = self.peer_certificate.get_assigned_certificates()
 
-        if client_certificates and client_certificates[0].certificate == cert:
+        if (
+            client_certificates
+            and client_private_key
+            and client_certificates[0].certificate == cert
+        ):
             internal = False
             provider_cert = client_certificates[0]
-            private_key = client_private_key if client_private_key else None
-        elif peer_certificates and peer_certificates[0].certificate == cert:
+            private_key = client_private_key
+        elif peer_certificates and peer_private_key and peer_certificates[0].certificate == cert:
             internal = True
             provider_cert = peer_certificates[0]
-            private_key = peer_private_key if peer_private_key else None
+            private_key = peer_private_key
         else:
             logger.error("Received certificate does not match any assigned certificates.")
             return
@@ -198,10 +202,10 @@ class TLSEventsHandler(Object):
             f"Received {TLSType.PEER.value if internal else TLSType.CLIENT.value} certificate."
         )
 
-        logger.info(f"private key is None = {private_key is None}")
-
-        if not self.manager.is_certificate_match(provider_cert.certificate, private_key, internal):
-            logger.error("Received certificate does not match private key.")
+        if not self.manager.certificate_and_private_key_match(
+            provider_cert.certificate, private_key, internal
+        ):
+            logger.error("Received certificate and private key do not match.")
             return
 
         self.manager.set_certificates(
@@ -209,7 +213,7 @@ class TLSEventsHandler(Object):
             certificate=provider_cert.certificate.raw,
             csr=provider_cert.certificate_signing_request.raw,
             ca=provider_cert.ca.raw,
-            private_key=private_key,
+            private_key=private_key.raw,
             internal=internal,
         )
         if internal:

--- a/single_kernel_mongo/events/tls.py
+++ b/single_kernel_mongo/events/tls.py
@@ -185,11 +185,11 @@ class TLSEventsHandler(Object):
         if client_certificates and client_certificates[0].certificate == cert:
             internal = False
             provider_cert = client_certificates[0]
-            private_key = client_private_key.raw if client_private_key else None
+            private_key = client_private_key if client_private_key else None
         elif peer_certificates and peer_certificates[0].certificate == cert:
             internal = True
             provider_cert = peer_certificates[0]
-            private_key = peer_private_key.raw if peer_private_key else None
+            private_key = peer_private_key if peer_private_key else None
         else:
             logger.error("Received certificate does not match any assigned certificates.")
             return
@@ -197,6 +197,12 @@ class TLSEventsHandler(Object):
         logger.debug(
             f"Received {TLSType.PEER.value if internal else TLSType.CLIENT.value} certificate."
         )
+
+        logger.info(f"private key is None = {private_key is None}")
+
+        if not self.manager.is_certificate_match(provider_cert.certificate, private_key, internal):
+            logger.error("Received certificate does not match private key.")
+            return
 
         self.manager.set_certificates(
             secret_chain=[c.raw for c in provider_cert.chain],

--- a/single_kernel_mongo/managers/tls.py
+++ b/single_kernel_mongo/managers/tls.py
@@ -243,7 +243,7 @@ class TLSManager(ManagerStatusProtocol):
         certificate: str | None,
         csr: str | None,
         ca: str | None,
-        private_key: PrivateKey | None,
+        private_key: str | None,
         internal: bool,
     ):
         """Sets the certificates."""
@@ -252,8 +252,7 @@ class TLSManager(ManagerStatusProtocol):
             SECRET_CHAIN_LABEL,
             "\n".join(secret_chain) if secret_chain else None,
         )
-        if private_key:
-            self.state.tls.set_secret(internal, SECRET_KEY_LABEL, private_key.raw)
+        self.state.tls.set_secret(internal, SECRET_KEY_LABEL, private_key)
         self.state.tls.set_secret(internal, SECRET_CSR_LABEL, csr)
         self.state.tls.set_secret(internal, SECRET_CERT_LABEL, certificate)
         self.state.tls.set_secret(internal, SECRET_CA_LABEL, ca)
@@ -414,28 +413,24 @@ class TLSManager(ManagerStatusProtocol):
             return True
         return False
 
-    def is_certificate_match(
-        self, certificate: Certificate, private_key: PrivateKey | None, internal: bool
+    def certificate_and_private_key_match(
+        self, certificate: Certificate, private_key: PrivateKey, internal: bool
     ) -> bool:
-        """Checks a given certificates matches the private key."""
+        """Returns true if the certificate and the private key match.
+
+        Private key must also match the config private key if it exists.
+        """
         private_key_id = (
             self.dependent.config.tls_peer_private_key_id
             if internal
             else self.dependent.config.tls_client_private_key_id
         )
 
-        logger.info(f"is_certificate_match {private_key_id}")
-
         if private_key_id:
             config_private_key = self.read_and_validate_private_key(private_key_id)
-
             if config_private_key is not None:
                 if private_key != config_private_key:
-                    logger.info("key in config and received private key do not match")
+                    logger.debug("Certificate private key do not match the config private key.")
                     return False
 
-        if private_key:
-            logger.info("cert and received private key do not match")
-            return certificate.matches_private_key(private_key)
-        logger.info("received private key is none")
-        return False
+        return certificate.matches_private_key(private_key)

--- a/single_kernel_mongo/managers/tls.py
+++ b/single_kernel_mongo/managers/tls.py
@@ -428,9 +428,8 @@ class TLSManager(ManagerStatusProtocol):
 
         if private_key_id:
             config_private_key = self.read_and_validate_private_key(private_key_id)
-            if config_private_key is not None:
-                if private_key != config_private_key:
-                    logger.debug("Certificate private key do not match the config private key.")
-                    return False
+            if config_private_key is not None and private_key != config_private_key:
+                logger.debug("Certificate private key does not match the config private key.")
+                return False
 
         return certificate.matches_private_key(private_key)

--- a/single_kernel_mongo/managers/tls.py
+++ b/single_kernel_mongo/managers/tls.py
@@ -28,6 +28,7 @@ from single_kernel_mongo.core.operator import OperatorProtocol
 from single_kernel_mongo.core.structured_config import MongoDBRoles
 from single_kernel_mongo.exceptions import WorkloadServiceError
 from single_kernel_mongo.lib.charms.tls_certificates_interface.v4.tls_certificates import (
+    Certificate,
     CertificateRequestAttributes,
     PrivateKey,
 )
@@ -242,7 +243,7 @@ class TLSManager(ManagerStatusProtocol):
         certificate: str | None,
         csr: str | None,
         ca: str | None,
-        private_key: str | None,
+        private_key: PrivateKey | None,
         internal: bool,
     ):
         """Sets the certificates."""
@@ -251,7 +252,8 @@ class TLSManager(ManagerStatusProtocol):
             SECRET_CHAIN_LABEL,
             "\n".join(secret_chain) if secret_chain else None,
         )
-        self.state.tls.set_secret(internal, SECRET_KEY_LABEL, private_key)
+        if private_key:
+            self.state.tls.set_secret(internal, SECRET_KEY_LABEL, private_key.raw)
         self.state.tls.set_secret(internal, SECRET_CSR_LABEL, csr)
         self.state.tls.set_secret(internal, SECRET_CERT_LABEL, certificate)
         self.state.tls.set_secret(internal, SECRET_CA_LABEL, ca)
@@ -410,4 +412,30 @@ class TLSManager(ManagerStatusProtocol):
             return True
         if not self.workload.exists(self.workload.paths.int_pem_file):
             return True
+        return False
+
+    def is_certificate_match(
+        self, certificate: Certificate, private_key: PrivateKey | None, internal: bool
+    ) -> bool:
+        """Checks a given certificates matches the private key."""
+        private_key_id = (
+            self.dependent.config.tls_peer_private_key_id
+            if internal
+            else self.dependent.config.tls_client_private_key_id
+        )
+
+        logger.info(f"is_certificate_match {private_key_id}")
+
+        if private_key_id:
+            config_private_key = self.read_and_validate_private_key(private_key_id)
+
+            if config_private_key is not None:
+                if private_key != config_private_key:
+                    logger.info("key in config and received private key do not match")
+                    return False
+
+        if private_key:
+            logger.info("cert and received private key do not match")
+            return certificate.matches_private_key(private_key)
+        logger.info("received private key is none")
         return False

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -287,41 +287,22 @@ def test_private_key_is_none_certificate_available(harness: Harness[MongoTestCha
     )
     harness.add_relation_unit(peer_rel_id, "self-signed-certificates/0")
 
-    manager.state.secrets.set("ext-chain-secret", "app-chain-old-1", Scope.UNIT)
-    manager.state.secrets.set("ext-cert-secret", "app-cert-old-1", Scope.UNIT)
-    manager.state.secrets.set("ext-ca-secret", "app-ca-old-1", Scope.UNIT)
-    manager.state.secrets.set("ext-key-secret", "unit-key-1", Scope.UNIT)
-    manager.state.secrets.set("int-chain-secret", "app-chain-old-2", Scope.UNIT)
-    manager.state.secrets.set("int-cert-secret", "app-cert-old-2", Scope.UNIT)
-    manager.state.secrets.set("int-ca-secret", "app-ca-old-2", Scope.UNIT)
-    manager.state.secrets.set("int-key-secret", "unit-key-2", Scope.UNIT)
-
     event = MagicMock(spec=CertificateAvailableEvent)
     event.certificate = new_cert.certificate
 
     harness.charm.operator.tls_events._on_certificate_available(event)
 
-    ext_chain_secret = manager.state.secrets.get_for_key(Scope.UNIT, "ext-chain-secret")
-    ext_unit_secret = manager.state.secrets.get_for_key(Scope.UNIT, "ext-cert-secret")
-    ext_ca_secret = manager.state.secrets.get_for_key(Scope.UNIT, "ext-ca-secret")
-    ext_key_secret = manager.state.secrets.get_for_key(Scope.UNIT, "ext-key-secret")
-    int_chain_secret = manager.state.secrets.get_for_key(Scope.UNIT, "int-chain-secret")
-    int_unit_secret = manager.state.secrets.get_for_key(Scope.UNIT, "int-cert-secret")
-    int_ca_secret = manager.state.secrets.get_for_key(Scope.UNIT, "int-ca-secret")
-    int_key_secret = manager.state.secrets.get_for_key(Scope.UNIT, "int-key-secret")
+    assert manager.state.secrets.get_for_key(Scope.UNIT, "ext-chain-secret") is None
+    assert manager.state.secrets.get_for_key(Scope.UNIT, "ext-cert-secret") is None
+    assert manager.state.secrets.get_for_key(Scope.UNIT, "ext-ca-secret") is None
+    assert manager.state.secrets.get_for_key(Scope.UNIT, "ext-key-secret") is None
+    assert manager.state.secrets.get_for_key(Scope.UNIT, "int-chain-secret") is None
+    assert manager.state.secrets.get_for_key(Scope.UNIT, "int-cert-secret") is None
+    assert manager.state.secrets.get_for_key(Scope.UNIT, "int-ca-secret") is None
+    assert manager.state.secrets.get_for_key(Scope.UNIT, "int-key-secret") is None
 
-    assert ext_chain_secret == "app-chain-old-1"
-    assert ext_unit_secret == "app-cert-old-1"
-    assert ext_ca_secret == "app-ca-old-1"
-    assert ext_key_secret == "unit-key-1"
-
-    assert int_chain_secret == "app-chain-old-2"
-    assert int_unit_secret == "app-cert-old-2"
-    assert int_ca_secret == "app-ca-old-2"
-    assert int_key_secret == "unit-key-2"
-
-    assert harness.charm.operator.state.tls.client_enabled
-    assert harness.charm.operator.state.tls.peer_enabled
+    assert not harness.charm.operator.state.tls.client_enabled
+    assert not harness.charm.operator.state.tls.peer_enabled
 
     mock_restart.assert_not_called()
 

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -176,9 +176,7 @@ def test_internal_certificate_available(
         MongoDBRoles.CONFIG_SERVER,
     ],
 )
-def test_unknown_certificate_available(
-    harness: Harness[MongoTestCharm], mocker, mock_fs_interactions, role
-):
+def test_unknown_certificate_available(harness: Harness[MongoTestCharm], mocker, role):
     manager = harness.charm.operator.tls_manager
     mock_restart = mocker.patch(
         "single_kernel_mongo.managers.mongodb_operator.MongoDBOperator.restart_charm_services",

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -176,7 +176,9 @@ def test_internal_certificate_available(
         MongoDBRoles.CONFIG_SERVER,
     ],
 )
-def test_unknown_certificate_available(harness: Harness[MongoTestCharm], mocker, role):
+def test_unknown_certificate_available(
+    harness: Harness[MongoTestCharm], mocker, mock_fs_interactions, role
+):
     manager = harness.charm.operator.tls_manager
     mock_restart = mocker.patch(
         "single_kernel_mongo.managers.mongodb_operator.MongoDBOperator.restart_charm_services",
@@ -196,6 +198,7 @@ def test_unknown_certificate_available(harness: Harness[MongoTestCharm], mocker,
     )
 
     harness.set_leader(True)
+    harness.charm.operator.state.db_initialised = True
     harness.charm.operator.state.app_peer_data.role = role
     client_rel_id = harness.add_relation(
         ExternalRequirerRelations.CLIENT_TLS.value, "self-signed-certificates"
@@ -217,7 +220,7 @@ def test_unknown_certificate_available(harness: Harness[MongoTestCharm], mocker,
 
     # Mock an unknown certificate
     event = MagicMock(spec=CertificateAvailableEvent)
-    event.certificate = new_cert.certificate
+    event.certificate = MagicMock()
     event.certificate.raw = "1234"
 
     harness.charm.operator.tls_events._on_certificate_available(event)
@@ -244,6 +247,214 @@ def test_unknown_certificate_available(harness: Harness[MongoTestCharm], mocker,
     assert harness.charm.operator.state.tls.client_enabled
     assert harness.charm.operator.state.tls.peer_enabled
 
+    mock_restart.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "role",
+    [
+        MongoDBRoles.REPLICATION,
+        MongoDBRoles.SHARD,
+        MongoDBRoles.CONFIG_SERVER,
+    ],
+)
+def test_private_key_is_none_certificate_available(harness: Harness[MongoTestCharm], mocker, role):
+    manager = harness.charm.operator.tls_manager
+    mock_restart = mocker.patch(
+        "single_kernel_mongo.managers.mongodb_operator.MongoDBOperator.restart_charm_services",
+        return_value=None,
+    )
+    new_private_key = MagicMock()
+    new_private_key.raw = "my_new_private_key"
+    new_cert = get_certificate_mock(
+        cert="new_certificate_external_value",
+        chain="new_chain",
+        ca="new_test_ca_server",
+        csr="new_csr",
+    )
+    mocker.patch(
+        "single_kernel_mongo.lib.charms.tls_certificates_interface.v4.tls_certificates.TLSCertificatesRequiresV4.get_assigned_certificates",
+        side_effect=[([new_cert], None), ([new_cert], None)],
+    )
+
+    harness.set_leader(True)
+    harness.charm.operator.state.db_initialised = True
+    harness.charm.operator.state.app_peer_data.role = role
+    client_rel_id = harness.add_relation(
+        ExternalRequirerRelations.CLIENT_TLS.value, "self-signed-certificates"
+    )
+    harness.add_relation_unit(client_rel_id, "self-signed-certificates/0")
+    peer_rel_id = harness.add_relation(
+        ExternalRequirerRelations.PEER_TLS.value, "self-signed-certificates"
+    )
+    harness.add_relation_unit(peer_rel_id, "self-signed-certificates/0")
+
+    manager.state.secrets.set("ext-chain-secret", "app-chain-old-1", Scope.UNIT)
+    manager.state.secrets.set("ext-cert-secret", "app-cert-old-1", Scope.UNIT)
+    manager.state.secrets.set("ext-ca-secret", "app-ca-old-1", Scope.UNIT)
+    manager.state.secrets.set("ext-key-secret", "unit-key-1", Scope.UNIT)
+    manager.state.secrets.set("int-chain-secret", "app-chain-old-2", Scope.UNIT)
+    manager.state.secrets.set("int-cert-secret", "app-cert-old-2", Scope.UNIT)
+    manager.state.secrets.set("int-ca-secret", "app-ca-old-2", Scope.UNIT)
+    manager.state.secrets.set("int-key-secret", "unit-key-2", Scope.UNIT)
+
+    event = MagicMock(spec=CertificateAvailableEvent)
+    event.certificate = new_cert.certificate
+
+    harness.charm.operator.tls_events._on_certificate_available(event)
+
+    ext_chain_secret = manager.state.secrets.get_for_key(Scope.UNIT, "ext-chain-secret")
+    ext_unit_secret = manager.state.secrets.get_for_key(Scope.UNIT, "ext-cert-secret")
+    ext_ca_secret = manager.state.secrets.get_for_key(Scope.UNIT, "ext-ca-secret")
+    ext_key_secret = manager.state.secrets.get_for_key(Scope.UNIT, "ext-key-secret")
+    int_chain_secret = manager.state.secrets.get_for_key(Scope.UNIT, "int-chain-secret")
+    int_unit_secret = manager.state.secrets.get_for_key(Scope.UNIT, "int-cert-secret")
+    int_ca_secret = manager.state.secrets.get_for_key(Scope.UNIT, "int-ca-secret")
+    int_key_secret = manager.state.secrets.get_for_key(Scope.UNIT, "int-key-secret")
+
+    assert ext_chain_secret == "app-chain-old-1"
+    assert ext_unit_secret == "app-cert-old-1"
+    assert ext_ca_secret == "app-ca-old-1"
+    assert ext_key_secret == "unit-key-1"
+
+    assert int_chain_secret == "app-chain-old-2"
+    assert int_unit_secret == "app-cert-old-2"
+    assert int_ca_secret == "app-ca-old-2"
+    assert int_key_secret == "unit-key-2"
+
+    assert harness.charm.operator.state.tls.client_enabled
+    assert harness.charm.operator.state.tls.peer_enabled
+
+    mock_restart.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "role",
+    [
+        MongoDBRoles.REPLICATION,
+        MongoDBRoles.SHARD,
+        MongoDBRoles.CONFIG_SERVER,
+    ],
+)
+def test_private_key_does_not_match_config_client_certificate_available(
+    harness: Harness[MongoTestCharm], mocker, mock_fs_interactions, mongodb_name, role
+):
+    manager = harness.charm.operator.tls_manager
+    mock_restart = mocker.patch(
+        "single_kernel_mongo.managers.mongodb_operator.MongoDBOperator.restart_charm_services",
+        return_value=None,
+    )
+    mocker.patch(
+        "single_kernel_mongo.managers.mongo.MongoManager.mongod_ready",
+        return_value=None,
+    )
+
+    new_private_key = MagicMock()
+    new_private_key.raw = "my_new_private_key"
+    new_cert = get_certificate_mock(
+        cert="new_certificate_external_value",
+        chain="new_chain",
+        ca="new_test_ca_server",
+        csr="new_csr",
+    )
+    mocker.patch(
+        "single_kernel_mongo.lib.charms.tls_certificates_interface.v4.tls_certificates.TLSCertificatesRequiresV4.get_assigned_certificates",
+        return_value=([new_cert], new_private_key),
+    )
+    mocker.patch(
+        "single_kernel_mongo.lib.charms.tls_certificates_interface.v4.tls_certificates.TLSCertificatesRequiresV4.get_assigned_certificate",
+        return_value=(new_cert, new_private_key),
+    )
+
+    private_key_content = Path("tests/unit/data/key.pem").read_text()
+    secret_id = harness.add_model_secret(mongodb_name, {"private-key": private_key_content})
+    harness.update_config({"tls-client-private-key": secret_id})
+
+    harness.set_leader(True)
+    harness.charm.operator.state.db_initialised = True
+    harness.charm.operator.state.app_peer_data.role = role
+    rel_id = harness.add_relation(
+        ExternalRequirerRelations.CLIENT_TLS.value, "self-signed-certificates"
+    )
+    harness.add_relation_unit(rel_id, "self-signed-certificates/0")
+
+    event = MagicMock(spec=CertificateAvailableEvent)
+    event.certificate = new_cert.certificate
+
+    harness.charm.operator.tls_events._on_certificate_available(event)
+
+    assert manager.state.secrets.get_for_key(Scope.UNIT, "ext-chain-secret") is None
+    assert manager.state.secrets.get_for_key(Scope.UNIT, "ext-cert-secret") is None
+    assert manager.state.secrets.get_for_key(Scope.UNIT, "ext-ca-secret") is None
+    assert manager.state.secrets.get_for_key(Scope.UNIT, "ext-key-secret") is not None
+
+    assert not harness.charm.operator.state.tls.client_enabled
+    mock_restart.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "role",
+    [
+        MongoDBRoles.REPLICATION,
+        MongoDBRoles.SHARD,
+        MongoDBRoles.CONFIG_SERVER,
+    ],
+)
+def test_private_key_does_not_match_config_peer_certificate_available(
+    harness: Harness[MongoTestCharm], mocker, mock_fs_interactions, mongodb_name, role
+):
+    manager = harness.charm.operator.tls_manager
+    mock_restart = mocker.patch(
+        "single_kernel_mongo.managers.mongodb_operator.MongoDBOperator.restart_charm_services",
+        return_value=None,
+    )
+    mocker.patch(
+        "single_kernel_mongo.managers.mongo.MongoManager.mongod_ready",
+        return_value=None,
+    )
+    new_private_key = MagicMock()
+    new_private_key.raw = "my_new_private_key"
+    new_cert = get_certificate_mock(
+        cert="new_certificate_external_value",
+        chain="new_chain",
+        ca="new_test_ca_server",
+        csr="new_csr",
+    )
+    mocker.patch(
+        "single_kernel_mongo.lib.charms.tls_certificates_interface.v4.tls_certificates.TLSCertificatesRequiresV4.get_assigned_certificates",
+        side_effect=[([], None), ([new_cert], new_private_key)],
+    )
+    mocker.patch(
+        "single_kernel_mongo.lib.charms.tls_certificates_interface.v4.tls_certificates.TLSCertificatesRequiresV4.get_assigned_certificate",
+        side_effect=[
+            (new_cert, new_private_key),
+            (None, None),
+        ],
+    )
+
+    private_key_content = Path("tests/unit/data/key.pem").read_text()
+    secret_id = harness.add_model_secret(mongodb_name, {"private-key": private_key_content})
+    harness.update_config({"tls-peer-private-key": secret_id})
+
+    harness.set_leader(True)
+    harness.charm.operator.state.db_initialised = True
+    harness.charm.operator.state.app_peer_data.role = role
+    rel_id = harness.add_relation(
+        ExternalRequirerRelations.PEER_TLS.value, "self-signed-certificates"
+    )
+    harness.add_relation_unit(rel_id, "self-signed-certificates/0")
+
+    event = MagicMock(spec=CertificateAvailableEvent)
+    event.certificate = new_cert.certificate
+
+    harness.charm.operator.tls_events._on_certificate_available(event)
+
+    assert manager.state.secrets.get_for_key(Scope.UNIT, "int-chain-secret") is None
+    assert manager.state.secrets.get_for_key(Scope.UNIT, "int-cert-secret") is None
+    assert manager.state.secrets.get_for_key(Scope.UNIT, "int-ca-secret") is None
+    assert manager.state.secrets.get_for_key(Scope.UNIT, "int-key-secret") is not None
+
+    assert not harness.charm.operator.state.tls.peer_enabled
     mock_restart.assert_not_called()
 
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷️ Type of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling and CI
- [ ] Dependencies upgrade or change
- [ ] Chores / refactoring

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and feature scope of this PR (what)
  - the motivation behind this change (why)
  - the impacted components (often matches conventional commit scope)
  - explanation/algorithm if required (how)
-->

In the context of the SSDLC the following control has been marked as `planned` since last cycle but not implemented:
```
16 - Ensure provided certificates match private key
```

This control is a mitigation to the following threat: 
```
The TLS provider service is tampered to produce corrupted certificates (TLS integrity)
```

This PR implements the control. We now verify that the private key and the certificate received from the TLS provider match. We also check that the received private key matches the one in the configuration, if it exists.

## 🧪 Manual testing steps
<!--- Give a list of instructions to manually test your change. -->
<!--- These instructions are meant for reviewers to test the PR -->
<!--- on their development environment. -->

Build and deploy charm:
```text
bash scripts/build_lib_for_integration.sh tests/charms/mongodb_test_charm/
juju deploy ./tests/charms/mongodb_test_charm/mongodb_ubuntu@24.04-amd64.charm mongo0
juju deploy self-signed-certificates
```
Peer private key config:
```text
   19  juju integrate self-signed-certificates:certificates mongo0:peer-certificates
   21  openssl genrsa -out peer-pk.pem 3072
   22  juju add-secret peer-pk private-key=$(base64 -w0 peer-pk.pem)
   24  juju grant-secret peer-pk mongo0
   25  juju config mongo0 tls-peer-private-key=secret:d5gdnpbtct6ts4vjfnbg
   26  cat peer-pk.pem

   juju secrets
   juju show-secret --reveal d5gdml3tct6ts4vjfnb0
```

client private key config
```
   27  openssl genrsa -out client-pk.pem 3072
   28  juju add-secret client-pk private-key=$(base64 -w0 client-pk.pem)
   29  juju config mongo0 tls-client-private-key=secret:d5gdrmjtct6ts4vjfnc0
   30  juju grant-secret client-pk mongo0
   31  juju config mongo0 tls-client-private-key=secret:d5gdrmjtct6ts4vjfnc0
   34  cat client-pk.pem

   juju secrets
   juju show-secret --reveal d5gdml3tct6ts4vjfnb0
```

On certificate available events, none of the following logs is present:
```
logger.error("Received certificate does not match any assigned certificates.")
logger.error("Received certificate and private key do not match.")
```
Neither before or after setting the keys as config values. 

## 🔬 Automated testing steps
<!--- Describe the unit and integration tests that you added -->
<!--- to ensure that this feature works as expected. Include details -->
<!--- on the positive and negative test cases, as well as any changes -->
<!--- made to the existing tests to ensure they are still relevant. -->

Added UTs. 
All integration tests passed.

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have added or updated any relevant documentation.
- [x] I have read the [**CONTRIBUTING**](../blob/8/edge/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
