### PR TITLE
patch: Systemd Parameter for unlimited tasks

### DIFF
--- a/docs/reference/system-requirements.md
+++ b/docs/reference/system-requirements.md
@@ -49,3 +49,8 @@ lxc config set <instance_name> limits.hugepages.<hugepage-size>=<number of hugep
 ```
 
 Charmed MongoDB on Kubernetes does not support yet setting the Transparent Hugepages.
+
+## Systemd Parameters
+
+On VM, this charm sets the `TasksMax` parameter of the Mongod and Mongos services it starts to `infinity`.
+This ensures that MongoDB will not drop connections when it is under high load.

--- a/single_kernel_mongo/config/literals.py
+++ b/single_kernel_mongo/config/literals.py
@@ -90,6 +90,8 @@ class VmUser(WorkloadUser[int]):
 
 CRON_FILE = Path("/etc/cron.d/mongodb")
 
+SYSTEMD_MONGODB_OVERRIDE = Path("/etc/systemd/system/snap.charmed-mongodb.mongod.service.d")
+SYSTEMD_MONGOS_OVERRIDE = Path("/etc/systemd/system/snap.charmed-mongodb.mongos.service.d")
 
 SECRETS_UNIT: list[str] = []
 

--- a/single_kernel_mongo/config/models.py
+++ b/single_kernel_mongo/config/models.py
@@ -68,10 +68,21 @@ class THPConfig:
 
     service_template: Traversable = TEMPLATE_DIRECTORY / "enable-transparent-huge-pages.service.j2"
     service_file_path: Path = Path("/etc/systemd/system/enable-transparent-huge-pages.service")
-    service_name = "enable-transparent-huge-pages"
+    service_name: str = "enable-transparent-huge-pages"
 
 
 THP_CONFIG = THPConfig()
+
+
+@dataclass(frozen=True)
+class OverrideFile:
+    """Dataclass for the systemd override."""
+
+    override_template: Path = Path(f"{TEMPLATE_DIRECTORY}") / "override.conf"
+    override_path: Path = Path("override.conf")
+
+
+OVERRIDE_FILES = OverrideFile()
 
 
 @dataclass(frozen=True)

--- a/single_kernel_mongo/core/operator.py
+++ b/single_kernel_mongo/core/operator.py
@@ -15,6 +15,7 @@ this operator like backups or cluster event handlers, etc.
 
 from __future__ import annotations
 
+import shutil
 from abc import ABC, abstractmethod
 from collections.abc import Sequence
 from logging import getLogger
@@ -31,12 +32,20 @@ from ops.model import Relation, Unit
 
 from single_kernel_mongo.config.literals import (
     OS_REQUIREMENTS,
+    SYSTEMD_MONGODB_OVERRIDE,
+    SYSTEMD_MONGOS_OVERRIDE,
     TRUST_STORE_PATH,
     Scope,
     Substrates,
     TrustStoreFiles,
 )
-from single_kernel_mongo.config.models import SNAP_NAME, THP_CONFIG, CharmSpec, LogRotateConfig
+from single_kernel_mongo.config.models import (
+    OVERRIDE_FILES,
+    SNAP_NAME,
+    THP_CONFIG,
+    CharmSpec,
+    LogRotateConfig,
+)
 from single_kernel_mongo.core.structured_config import MongoConfigModel
 from single_kernel_mongo.events.ldap import LDAPEventHandler
 from single_kernel_mongo.exceptions import (
@@ -405,3 +414,31 @@ class OperatorProtocol(ABC, Object, ManagerStatusProtocol):
             raise Exception("Waiting for leader unit to generate keyfile contents")
 
         self.workload.write(self.workload.paths.keyfile, keyfile)
+
+    def setup_systemd_overrides(self) -> None:
+        """Sets up some overrides to allow the service to run smoothly."""
+        if self.substrate == Substrates.K8S:
+            return
+
+        for path in (SYSTEMD_MONGODB_OVERRIDE, SYSTEMD_MONGOS_OVERRIDE):
+            full_path = path / OVERRIDE_FILES.override_path
+            # Create the directory if it does not exist.
+            path.mkdir(exist_ok=True)
+            # Copy the file to the new directory"
+            _ = shutil.copy(Path(OVERRIDE_FILES.override_template), full_path)
+            # Give it the right permissions
+            _ = self.workload.exec(["chown", "-R", "root:root", f"{full_path}"])
+            # Reload the daemon to take the override into account.
+            _ = self.workload.exec(["systemctl", "daemon-reload"])
+
+    def remove_systemd_overrides(self) -> None:
+        """Sets up some overrides to allow the service to run smoothly."""
+        if self.substrate == Substrates.K8S:
+            return
+
+        for path in (SYSTEMD_MONGODB_OVERRIDE, SYSTEMD_MONGOS_OVERRIDE):
+            full_path = path / OVERRIDE_FILES.override_path
+            if path.exists():
+                full_path.unlink()
+                path.rmdir
+            _ = self.workload.exec(["systemctl", "daemon-reload"])

--- a/single_kernel_mongo/core/operator.py
+++ b/single_kernel_mongo/core/operator.py
@@ -424,12 +424,12 @@ class OperatorProtocol(ABC, Object, ManagerStatusProtocol):
             full_path = path / OVERRIDE_FILES.override_path
             # Create the directory if it does not exist.
             path.mkdir(exist_ok=True)
-            # Copy the file to the new directory"
-            _ = shutil.copy(Path(OVERRIDE_FILES.override_template), full_path)
-            # Give it the right permissions
-            _ = self.workload.exec(["chown", "-R", "root:root", f"{full_path}"])
+            # Copy the file to the new directory.
+            shutil.copy(Path(OVERRIDE_FILES.override_template), full_path)
+            # Give it the right permissions.
+            self.workload.exec(["chown", "-R", "root:root", f"{full_path}"])
             # Reload the daemon to take the override into account.
-            _ = self.workload.exec(["systemctl", "daemon-reload"])
+            self.workload.exec(["systemctl", "daemon-reload"])
 
     def remove_systemd_overrides(self) -> None:
         """Sets up some overrides to allow the service to run smoothly."""
@@ -440,5 +440,5 @@ class OperatorProtocol(ABC, Object, ManagerStatusProtocol):
             full_path = path / OVERRIDE_FILES.override_path
             if path.exists():
                 full_path.unlink()
-                path.rmdir
-            _ = self.workload.exec(["systemctl", "daemon-reload"])
+                path.rmdir()
+            self.workload.exec(["systemctl", "daemon-reload"])

--- a/single_kernel_mongo/core/operator.py
+++ b/single_kernel_mongo/core/operator.py
@@ -428,6 +428,7 @@ class OperatorProtocol(ABC, Object, ManagerStatusProtocol):
             shutil.copy(Path(OVERRIDE_FILES.override_template), full_path)
             # Give it the right permissions.
             self.workload.exec(["chown", "-R", "root:root", f"{full_path}"])
+            self.workload.exec(["chmod", "644", f"{full_path}"])
             # Reload the daemon to take the override into account.
             self.workload.exec(["systemctl", "daemon-reload"])
 

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -525,6 +525,7 @@ class MongoDBOperator(OperatorProtocol, Object):
         """
         if self.substrate == Substrates.VM:
             self.remove_systemd_overrides()
+            return
 
         # According to the MongoDB documentation, before upgrading the primary, we must ensure a
         # safe primary re-election.

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -511,7 +511,8 @@ class MongoDBOperator(OperatorProtocol, Object):
     def prepare_for_shutdown(self) -> None:  # pragma: nocover
         """Handler for the stop event.
 
-        K8S Only, VM has nothing to do on this step.
+        On VM:
+         * Remove the overrides files.
         On K8S:
          * First: Raise partition to prevent other units from restarting if an
          upgrade is in progress. If an upgrade is not in progress, the leader
@@ -523,7 +524,7 @@ class MongoDBOperator(OperatorProtocol, Object):
         stepped down before the pod is removed.
         """
         if self.substrate == Substrates.VM:
-            return
+            self.remove_systemd_overrides()
 
         # According to the MongoDB documentation, before upgrading the primary, we must ensure a
         # safe primary re-election.
@@ -1154,6 +1155,9 @@ class MongoDBOperator(OperatorProtocol, Object):
             self.tls_manager.push_tls_files_to_workload(internal)
 
         self.ldap_manager.save_certificates(self.state.ldap.chain)
+
+        # Setup systemd overrides to prevent mongos/mongodb from cutting connections
+        self.setup_systemd_overrides()
 
         # Update licenses
         self.handle_licenses()

--- a/single_kernel_mongo/managers/mongos_operator.py
+++ b/single_kernel_mongo/managers/mongos_operator.py
@@ -220,6 +220,9 @@ class MongosOperator(OperatorProtocol, Object):
         # Save LDAP certificates
         self.ldap_manager.save_certificates(self.state.ldap.chain)
 
+        # Setup systemd overrides to prevent mongos/mongodb from cutting connections
+        self.setup_systemd_overrides()
+
         # Update licenses
         self.handle_licenses()
 
@@ -370,7 +373,13 @@ class MongosOperator(OperatorProtocol, Object):
 
     @override
     def prepare_for_shutdown(self) -> None:
-        return
+        """Handler for the stop event.
+
+        On VM:
+         * Remove the overrides files.
+        """
+        if self.substrate == Substrates.VM:
+            self.remove_systemd_overrides()
 
     @override
     def start_charm_services(self) -> None:

--- a/single_kernel_mongo/templates/override.conf
+++ b/single_kernel_mongo/templates/override.conf
@@ -1,0 +1,2 @@
+[Service]
+TasksMax=infinity

--- a/tests/integration/helpers/common.py
+++ b/tests/integration/helpers/common.py
@@ -1280,7 +1280,7 @@ async def execute_on_server(
     command: str,
     container: str = "mongod",
 ) -> str:
-    """Checks if the file exists or not."""
+    """Executes a command on the server."""
     app_name = get_app_name_from_unit(unit.name)
     match substrate:
         case "lxd":

--- a/tests/integration/helpers/common.py
+++ b/tests/integration/helpers/common.py
@@ -228,10 +228,7 @@ async def generate_mongodb_client(
         complement = f"replicaSet={app_name}"
 
     return (
-        f"mongodb://{username}:"
-        f"{quote_plus(password)}@"
-        f"{hosts}/{quote_plus(database)}?"
-        f"{complement}"
+        f"mongodb://{username}:{quote_plus(password)}@{hosts}/{quote_plus(database)}?{complement}"
     )
 
 
@@ -1274,3 +1271,28 @@ async def has_file(
         universal_newlines=True,
     )
     return filename in files
+
+
+async def execute_on_server(
+    ops_test: OpsTest,
+    substrate: Substrate,
+    unit: JujuUnit,
+    command: str,
+    container: str = "mongod",
+) -> str:
+    """Checks if the file exists or not."""
+    app_name = get_app_name_from_unit(unit.name)
+    match substrate:
+        case "lxd":
+            base_command = f"JUJU_MODEL={ops_test.model_full_name} juju ssh {app_name}/leader sudo"
+        case "microk8s":
+            base_command = f"JUJU_MODEL={ops_test.model_full_name} juju ssh --container {container} {app_name}/leader"
+        case _:
+            raise Exception(f"Invalid substrate {substrate}")
+
+    return subprocess.check_output(
+        f"{base_command} {command}",
+        stderr=subprocess.PIPE,
+        shell=True,
+        universal_newlines=True,
+    )

--- a/tests/integration/mongodb/test_charm.py
+++ b/tests/integration/mongodb/test_charm.py
@@ -35,6 +35,7 @@ from tests.integration.helpers.common import (
     deploy_application,
     deploy_charm,
     execute_on_mongod,
+    execute_on_server,
     find_unit,
     generate_collection_id,
     generate_mongodb_client,
@@ -129,6 +130,20 @@ async def test_unit_is_running_as_replica_set(
 
     # close connection
     client.close()
+
+
+@pytest.mark.abort_on_fail
+@pytest.mark.skip_if_substrate("microk8s")
+async def test_check_max_tasks(ops_test: OpsTest, substrate: Substrate):
+    app_name = await get_app_name(ops_test)
+    for unit in ops_test.model.applications[app_name].units:
+        output = await execute_on_server(
+            ops_test,
+            substrate,
+            unit,
+            "systemctl show --property TasksMax snap.charmed-mongodb.mongod",
+        )
+        assert output == "infinity", f"Unit {unit.name} has an invalid TasksMax value"
 
 
 @pytest.mark.abort_on_fail

--- a/tests/integration/mongodb/test_charm.py
+++ b/tests/integration/mongodb/test_charm.py
@@ -143,7 +143,7 @@ async def test_check_max_tasks(ops_test: OpsTest, substrate: Substrate):
             unit,
             "systemctl show --property TasksMax snap.charmed-mongodb.mongod",
         )
-        assert output == "infinity", f"Unit {unit.name} has an invalid TasksMax value"
+        assert "infinity" in output, f"Unit {unit.name} has an invalid TasksMax value"
 
 
 @pytest.mark.abort_on_fail

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -234,6 +234,7 @@ def test_start_not_ready(harness, mocker, mock_fs_interactions):
     patched_mongo_initialise = mocker.patch(
         "single_kernel_mongo.managers.mongo.MongoManager.initialise_replica_set"
     )
+    mocker.patch("single_kernel_mongo.core.operator.OperatorProtocol.setup_systemd_overrides")
 
     harness.set_leader(True)
     harness.charm.on.start.emit()
@@ -360,6 +361,7 @@ def test_start_already_initialised(harness, mocker, mock_refresh, mock_fs_intera
     set_fcv = mocker.patch(
         "single_kernel_mongo.managers.mongo.MongoManager.set_feature_compatibility_version"
     )
+    mocker.patch("single_kernel_mongo.core.operator.OperatorProtocol.setup_systemd_overrides")
     # presets
     harness.set_leader(True)
 
@@ -481,6 +483,7 @@ def test_start_fail_mongodb_exporter(harness, mocker, mock_fs_interactions):
     mocker.patch("single_kernel_mongo.managers.mongo.MongoManager.initialise_replica_set")
     mocker.patch("single_kernel_mongo.managers.mongo.MongoManager.initialise_charm_admin_users")
     mocker.patch("single_kernel_mongo.core.operator.OperatorProtocol.build_local_tls_directory")
+    mocker.patch("single_kernel_mongo.core.operator.OperatorProtocol.setup_systemd_overrides")
     harness.set_leader(True)
     harness.charm.operator.state.db_initialised = False
 
@@ -492,6 +495,7 @@ def test_start_fail_mongodb_exporter(harness, mocker, mock_fs_interactions):
 
 def test_start_fail_pbm_agent(harness, mocker, mock_fs_interactions):
     mocker.patch("single_kernel_mongo.managers.config.CommonConfigManager.set_environment")
+    mocker.patch("single_kernel_mongo.core.operator.OperatorProtocol.setup_systemd_overrides")
     mocker.patch("single_kernel_mongo.core.vm_workload.VMWorkload.start", return_value=True)
     mocker.patch(
         "single_kernel_mongo.core.k8s_workload.KubernetesWorkload.start", return_value=True

--- a/tests/unit/test_mongos_operator.py
+++ b/tests/unit/test_mongos_operator.py
@@ -31,6 +31,8 @@ def test_start(
             "single_kernel_mongo.core.k8s_workload.KubernetesWorkload.copy_to_unit"
         )
 
+    mocker.patch("single_kernel_mongo.core.operator.OperatorProtocol.setup_systemd_overrides")
+
     mongos_harness.charm.on.start.emit()
     mongos_harness.evaluate_status()
     assert mongos_harness.charm.unit.status == as_status(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷️ Type of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling and CI
- [ ] Dependencies upgrade or change
- [ ] Chores / refactoring

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and feature scope of this PR (what)
  - the motivation behind this change (why)
  - the impacted components (often matches conventional commit scope)
  - explanation/algorithm if required (how)
-->
It was raised in https://github.com/canonical/mongodb-operator/issues/576 that mongodb could struggle under high load and cut connections due to the systemd default parameter of `TasksMax`.
It is recommended by MongoDB directly to set that value to infinity.
This PR does that, on top of adding integration testing checking that this value is the right one.

## 🧪 Manual testing steps
<!--- Give a list of instructions to manually test your change. -->
<!--- These instructions are meant for reviewers to test the PR -->
<!--- on their development environment. -->

```text
1. juju deploy <my-app>
2. juju ssh mongodb/0
3. systemctl show --property TasksMax snap.charmed-mongodb.mongod
4. This value should be infinity.
```

## 🔬 Automated testing steps
<!--- Describe the unit and integration tests that you added -->
<!--- to ensure that this feature works as expected. Include details -->
<!--- on the positive and negative test cases, as well as any changes -->
<!--- made to the existing tests to ensure they are still relevant. -->
Unit testing has been patched to mock those calls.
Integration testing now has a test reproducing the manual steps to ensure that the values are as expected.

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have added or updated any relevant documentation.
- [x] I have read the [**CONTRIBUTING**](../blob/8/edge/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
