### PR TITLE
patch: Backport Invalid MongoDB Exporter URI

### DIFF
--- a/single_kernel_mongo/state/charm_state.py
+++ b/single_kernel_mongo/state/charm_state.py
@@ -819,7 +819,7 @@ class CharmState(Object, StatusesStateProtocol):
     @property
     def monitor_config(self) -> MongoConfiguration:
         """Mongo Configuration for the monitoring user."""
-        return self.mongodb_config_for_user(MonitorUser, hosts=self.internal_hosts)
+        return self.mongodb_config_for_user(MonitorUser)
 
     @property
     def logrotate_config(self) -> MongoConfiguration:

--- a/tests/integration/mongodb/test_metrics.py
+++ b/tests/integration/mongodb/test_metrics.py
@@ -115,3 +115,4 @@ async def verify_endpoints(ops_test: OpsTest, substrate: Substrate, unit: JujuUn
     # if configured correctly there should be more than one mongodb metric present
     mongodb_metrics = mongo_resp.text
     assert mongodb_metrics.count("mongo") > 1
+    assert mongodb_metrics.count(f'rs_nm="{app_name}"') > 1

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1092,7 +1092,6 @@ def test_on_secret_changed_unknown(harness: Harness[MongoTestCharm], mocker):
 def test_connect_mongodb_exporter_success(
     harness: Harness[MongoTestCharm],
     mocker,
-    mongodb_hostname: str,
     mongodb_name,
 ):
     """Tests the correct config is done."""
@@ -1102,6 +1101,8 @@ def test_connect_mongodb_exporter_success(
     mocker.patch("single_kernel_mongo.managers.config.BackupConfigManager.configure_and_restart")
     mocker.patch("single_kernel_mongo.utils.mongo_connection.MongoConnection.set_user_password")
     mocker.patch("single_kernel_mongo.managers.config.LogRotateConfigManager.configure_and_restart")
+
+    mongodb_hostname = "127.0.0.1"
 
     harness.set_leader(True)
     harness.charm.operator.state.db_initialised = True

--- a/tests/unit/test_charm_state.py
+++ b/tests/unit/test_charm_state.py
@@ -104,6 +104,6 @@ def test_mongodb_status_user(harness: Harness[MongoTestCharm]):
     harness.set_leader(True)
     state = harness.charm.operator.state
     password = state.get_user_password(user=MonitorUser)
-    assert state.stats_config.uri.startswith(
+    assert state.monitor_config.uri.startswith(
         f"mongodb://charmed-stats:{password}@127.0.0.1:27017/admin?"
     )

--- a/tests/unit/test_charm_state.py
+++ b/tests/unit/test_charm_state.py
@@ -105,5 +105,5 @@ def test_mongodb_status_user(harness: Harness[MongoTestCharm]):
     state = harness.charm.operator.state
     password = state.get_user_password(user=MonitorUser)
     assert state.monitor_config.uri.startswith(
-        f"mongodb://charmed-stats:{password}@127.0.0.1:27017/admin?"
+        f"mongodb://monitor:{password}@127.0.0.1:27017/admin?"
     )

--- a/tests/unit/test_charm_state.py
+++ b/tests/unit/test_charm_state.py
@@ -98,3 +98,12 @@ def test_unit_peer_data(
     state = harness.charm.operator.state
 
     assert state.unit_peer_data.internal_address == mongodb_hostname
+
+
+def test_mongodb_status_user(harness: Harness[MongoTestCharm]):
+    harness.set_leader(True)
+    state = harness.charm.operator.state
+    password = state.get_user_password(user=MonitorUser)
+    assert state.stats_config.uri.startswith(
+        f"mongodb://charmed-stats:{password}@127.0.0.1:27017/admin?"
+    )


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷️ Type of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling and CI
- [ ] Dependencies upgrade or change
- [x] Chores / refactoring

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and feature scope of this PR (what)
  - the motivation behind this change (why)
  - the impacted components (often matches conventional commit scope)
  - explanation/algorithm if required (how)
-->
Port https://github.com/canonical/mongo-single-kernel-library/pull/151 from 8 

## 🧪 Manual testing steps
<!--- Give a list of instructions to manually test your change. -->
<!--- These instructions are meant for reviewers to test the PR -->
<!--- on their development environment. -->

```text
1. juju deploy mongodb -n 3
2. juju ssh mongodb/0
3. sudo journalctl --no-pager -u snap.charmed-mongodb.mongodb-exporter | grep invalid
```
This should not return any line containing `Cannot connect to MongoDB: invalid MongoDB options: a direct connection cannot be made if multiple hosts are specified`

## 🔬 Automated testing steps
<!--- Describe the unit and integration tests that you added -->
<!--- to ensure that this feature works as expected. Include details -->
<!--- on the positive and negative test cases, as well as any changes -->
<!--- made to the existing tests to ensure they are still relevant. -->

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have added or updated any relevant documentation.
- [ ] I have read the [**CONTRIBUTING**](../blob/8-transition/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
