### PR TITLE
patch: Set IPv4 TCP Keepalive time

### DIFF
--- a/single_kernel_mongo/config/literals.py
+++ b/single_kernel_mongo/config/literals.py
@@ -102,7 +102,11 @@ PBM_RESTART_DELAY = 5
 FEATURE_VERSION = "8.0"
 
 
-OS_REQUIREMENTS = {"vm.max_map_count": "262144", "vm.overcommit_memory": "1"}
+OS_REQUIREMENTS = {
+    "vm.max_map_count": "262144",
+    "vm.overcommit_memory": "1",
+    "net.ipv4.tcp_keepalive_time": "120",
+}
 
 TRUST_STORE_PATH = Path("/usr/local/share/ca-certificates")
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷️ Type of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling and CI
- [ ] Dependencies upgrade or change
- [ ] Chores / refactoring

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and feature scope of this PR (what)
  - the motivation behind this change (why)
  - the impacted components (often matches conventional commit scope)
  - explanation/algorithm if required (how)
-->
This PR sets the last kernel parameter we can set for MongoDB production settings.
Set the ipv4 TCP keepalive to 120s according to [official docs](https://www.mongodb.com/docs/manual/administration/production-notes/#adjust-tcp_keepalive_time).

## 🧪 Manual testing steps
<!--- Give a list of instructions to manually test your change. -->
<!--- These instructions are meant for reviewers to test the PR -->
<!--- on their development environment. -->

To test properly, deploy on lxd vm (not container) and check that the sysctl sets the values correctly.


## 🔬 Automated testing steps
<!--- Describe the unit and integration tests that you added -->
<!--- to ensure that this feature works as expected. Include details -->
<!--- on the positive and negative test cases, as well as any changes -->
<!--- made to the existing tests to ensure they are still relevant. -->

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have added or updated any relevant documentation.
- [x] I have read the [**CONTRIBUTING**](../blob/8/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
