### PR TITLE
patch: Handle more error cases

### DIFF
--- a/single_kernel_mongo/core/k8s_workload.py
+++ b/single_kernel_mongo/core/k8s_workload.py
@@ -9,7 +9,7 @@ from logging import getLogger
 from pathlib import Path
 
 from ops import Container
-from ops.pebble import ChangeError, ExecError
+from ops.pebble import APIError, ChangeError, ConnectionError, ExecError, TimeoutError
 from typing_extensions import override
 
 from single_kernel_mongo.config.literals import KubernetesUser
@@ -67,8 +67,14 @@ class KubernetesWorkload(WorkloadBase):
             self.container.add_layer(self.layer_name, self.layer, combine=True)
             self.container.restart(self.service)
         except ChangeError as e:
-            logger.exception(str(e))
+            logger.exception(f"Change Error: {e}")
             raise WorkloadServiceError(e.err) from e
+        except TimeoutError as e:
+            logger.exception(f"Timeout Error: {e}")
+            raise WorkloadServiceError(*e.args) from e
+        except ConnectionError as e:
+            logger.exception(f"Connection Error: {e}")
+            raise WorkloadServiceError(*e.args) from e
 
     @override
     def mkdir(self, path: Path, make_parents: bool = False) -> None:
@@ -151,6 +157,21 @@ class KubernetesWorkload(WorkloadBase):
                 e.stdout,
                 e.stderr,
             ) from e
+        except APIError as e:
+            logger.debug(e)
+            raise WorkloadExecError(
+                command,
+                e.code,
+                f"{e.status}: {e.message}",
+            ) from e
+        except ConnectionError as e:
+            logger.debug(e)
+            raise WorkloadExecError(
+                command, -1, "Pebble client can't connect to the socket."
+            ) from e
+        except TimeoutError as e:
+            logger.debug(e)
+            raise WorkloadExecError(command, -1, "Pebble client polling timeout.") from e
 
     @override
     def run_bin_command(

--- a/single_kernel_mongo/exceptions.py
+++ b/single_kernel_mongo/exceptions.py
@@ -28,8 +28,8 @@ class WorkloadExecError(Exception):
         self,
         cmd: str | list[str],
         return_code: int,
-        stdout: str | None,
-        stderr: str | None,
+        stdout: str | None = None,
+        stderr: str | None = None,
     ):
         super().__init__(self)
         self.cmd = cmd


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷️ Type of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling and CI
- [ ] Dependencies upgrade or change
- [ ] Chores / refactoring

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and feature scope of this PR (what)
  - the motivation behind this change (why)
  - the impacted components (often matches conventional commit scope)
  - explanation/algorithm if required (how)
-->
This PR introduces more error handling when communicating with Pebble.
It happens that some latencies introduces timeouts or API error, or even connection errors.
This PR ensures that this is not the case anymore and provides some unified error handling for those cases.

## 🧪 Manual testing steps
<!--- Give a list of instructions to manually test your change. -->
<!--- These instructions are meant for reviewers to test the PR -->
<!--- on their development environment. -->

Those errors appeared mainly on CI, it is hard to reproduce manually.

## 🔬 Automated testing steps
<!--- Describe the unit and integration tests that you added -->
<!--- to ensure that this feature works as expected. Include details -->
<!--- on the positive and negative test cases, as well as any changes -->
<!--- made to the existing tests to ensure they are still relevant. -->

This PR fixes some issues, after it it should be more stable.

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have added or updated any relevant documentation.
- [x] I have read the [**CONTRIBUTING**](../blob/8/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
