### PR TITLE
patch: fix previous tag retrieval in bump mongo-single-kernel library automated workflow

### DIFF
--- a/.github/workflows/bump_dependent_charms.yaml
+++ b/.github/workflows/bump_dependent_charms.yaml
@@ -53,7 +53,7 @@ jobs:
         id: get-tag
         run: |
           git fetch --tags
-          PREV_TAG=$(git describe --tags --abbrev=0 "${VERSION}"^)
+          PREV_TAG=$(git describe --tags --abbrev=0 --exclude="${VERSION}" "${VERSION}")
           VERSION_CONTENT=$(git log --pretty=format:"- %h %s" "${PREV_TAG}..${VERSION}" | sed -E 's/\(#([0-9]+)\)/[#\1](https:\/\/github.com\/canonical\/mongo-single-kernel-library\/pull\/\1)/')
 
           {


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷️ Type of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tooling and CI
- [ ] Dependencies upgrade or change
- [ ] Chores / refactoring

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and feature scope of this PR (what)
  - the motivation behind this change (why)
  - the impacted components (often matches conventional commit scope)
  - explanation/algorithm if required (how)
-->

The workflow was not able to find the parent tag of the a given tag. See [this failure](https://github.com/canonical/mongo-single-kernel-library/actions/runs/21253563648/job/61161579869)

## 🧪 Manual testing steps
<!--- Give a list of instructions to manually test your change. -->
<!--- These instructions are meant for reviewers to test the PR -->
<!--- on their development environment. -->

https://github.com/canonical/mongo-single-kernel-library/actions/runs/21253946522
I use this branch to bump the mongo-single-kernel lib to v1.8.26 


## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have added or updated any relevant documentation.
- [x] I have read the [**CONTRIBUTING**](../blob/8/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
