### PR TITLE
patch: bump single kernel workflow - fix tag content retrieval

### DIFF
--- a/.github/workflows/bump_dependent_charms.yaml
+++ b/.github/workflows/bump_dependent_charms.yaml
@@ -49,14 +49,15 @@ jobs:
       - name: Checkout mongo-single-kernel repo
         uses: actions/checkout@v6
         with:
-          fetch-depth: 0     # get full history
+          fetch-depth: 20
           fetch-tags: true
 
       - name: Get new tag content
         id: get-tag
         run: |
           git fetch --tags
-          PREV_TAG=$(git describe --tags --abbrev=0 --exclude="${VERSION}" "${VERSION}")
+          SERIES="${VERSION%.*}.*" # -> v1.8.*
+          PREV_TAG="$(git describe --tags --abbrev=0 --match "${SERIES}" "${VERSION}^")"
           VERSION_CONTENT=$(git log --pretty=format:"- %h %s" "${PREV_TAG}..${VERSION}" | sed -E 's/\(#([0-9]+)\)/[#\1](https:\/\/github.com\/canonical\/mongo-single-kernel-library\/pull\/\1)/')
 
           {

--- a/.github/workflows/bump_dependent_charms.yaml
+++ b/.github/workflows/bump_dependent_charms.yaml
@@ -48,6 +48,9 @@ jobs:
     steps:
       - name: Checkout mongo-single-kernel repo
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0     # get full history
+          fetch-tags: true
 
       - name: Get new tag content
         id: get-tag


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷️ Type of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tooling and CI
- [ ] Dependencies upgrade or change
- [ ] Chores / refactoring

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and feature scope of this PR (what)
  - the motivation behind this change (why)
  - the impacted components (often matches conventional commit scope)
  - explanation/algorithm if required (how)
-->

There is a weird issue that we can only see when we run the whole workflow. We cannot reproduce it locally or triggering the workflow using the dispatch.

After checking out the repo, the workflow cannot find the commit associated to a tag. We can see that the tag exists.

We'll try to get the information of 20 commits when checking out the repo


<img width="1109" height="146" alt="image" src="https://github.com/user-attachments/assets/fdf0d47c-6c1a-49e9-9f90-e883f4f8b27e" />


## 🧪 Manual testing steps
<!--- Give a list of instructions to manually test your change. -->
<!--- These instructions are meant for reviewers to test the PR -->
<!--- on their development environment. -->

Successful run: https://github.com/canonical/mongo-single-kernel-library/actions/runs/21626889628

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have added or updated any relevant documentation.
- [ ] I have read the [**CONTRIBUTING**](../blob/8/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
