### PR TITLE
patch(DPE-9342): Backport backup changes to MongoDB 6

### DIFF
--- a/single_kernel_mongo/config/models.py
+++ b/single_kernel_mongo/config/models.py
@@ -158,4 +158,5 @@ class BackupState(Enum):
     RESTORE_RUNNING = auto()
     WAITING_TO_SYNC = auto()
     FAILED_TO_CREATE_BUCKET = auto()
+    CANT_CONFIGURE = auto()
     ACTIVE = auto()

--- a/single_kernel_mongo/events/backups.py
+++ b/single_kernel_mongo/events/backups.py
@@ -13,6 +13,7 @@ from botocore.exceptions import ConnectTimeoutError, SSLError
 from ops.charm import ActionEvent, RelationBrokenEvent, RelationJoinedEvent
 from ops.framework import Object
 
+from single_kernel_mongo.config.models import BackupState
 from single_kernel_mongo.config.relations import ExternalRequirerRelations
 from single_kernel_mongo.config.statuses import BackupStatuses, MongoDBStatuses
 from single_kernel_mongo.exceptions import (
@@ -110,7 +111,7 @@ class BackupEventsHandler(Object):
             self.manager.state.statuses.add(
                 MongoDBStatuses.INVALID_S3_REL.value,
                 scope="unit",
-                component=self.manager.name,
+                component=self.dependent.name,
             )
             return
         if not self.manager.workload.active():
@@ -145,70 +146,36 @@ class BackupEventsHandler(Object):
             )
             # First create the bucket if it does not exist.
             self.manager.create_bucket(credentials=credentials)
-            # Then set the config options on PBM.
-            self.manager.set_config_options(credentials=credentials)
-            # Finally, resync the configuration.
+            self.manager.set_certificate(credentials=credentials)
+            if not self.charm.unit.is_leader():
+                return
+                # Then set the config options on PBM.
+                self.manager.set_config_options(credentials=credentials)
+                # Finally, resync the configuration.
             self.manager.resync_config_options()
+            backup_state = BackupState.ACTIVE
         except InvalidS3CredentialsError:
-            logger.error("Incorrect S3 credentials")
-            self.manager.state.statuses.add(
-                BackupStatuses.PBM_INCORRECT_CREDS.value, scope="unit", component=self.manager.name
-            )
-            return
-        except (FailedToCreateS3BucketError, SSLError, ConnectTimeoutError) as err:
-            logger.error("Failed to create bucket: %s", err)
-            self.manager.state.statuses.add(
-                BackupStatuses.FAILED_TO_CREATE_BUCKET.value,
-                scope="unit",
-                component=self.manager.name,
-            )
+            backup_state = BackupState.INCORRECT_CREDS
+        except (FailedToCreateS3BucketError, SSLError, ConnectTimeoutError):
+            backup_state = BackupState.FAILED_TO_CREATE_BUCKET
             event.defer()
-            return
         except SetPBMConfigError:
-            self.manager.state.statuses.add(
-                BackupStatuses.CANT_CONFIGURE.value, scope="unit", component=self.manager.name
-            )
+            backup_state = BackupState.CANT_CONFIGURE
             event.defer()
-            return
-        except WorkloadServiceError as e:
-            logger.error("An exception occurred when starting pbm agent, error: %s.", str(e))
-            self.manager.state.statuses.add(
-                BackupStatuses.WAITING_FOR_PBM_START.value,
-                scope="unit",
-                component=self.manager.name,
-            )
-            return
-        except ResyncError:
-            self.manager.state.statuses.add(
-                BackupStatuses.PBM_WAITING_TO_SYNC.value,
-                scope="unit",
-                component=self.manager.name,
-            )
+        except WorkloadServiceError:
+            backup_state = BackupState.WAITING_PBM_START
+        except (ResyncError, PBMBusyError):
+            backup_state = BackupState.WAITING_TO_SYNC
             defer_event_with_info_log(
                 logger, event, action, "Sync-ing configurations needs more time."
             )
-            return
-        except PBMBusyError:
-            self.manager.state.statuses.add(
-                BackupStatuses.PBM_WAITING_TO_SYNC.value,
-                scope="unit",
-                component=self.manager.name,
-            )
-            defer_event_with_info_log(
-                logger,
-                event,
-                action,
-                "Cannot update configs while PBM is running, must wait for PBM action to finish.",
-            )
-            return
         except WorkloadExecError as e:
             if status := self.manager.process_pbm_error_as_status(e.stdout):
                 self.manager.state.statuses.add(status, scope="unit", component=self.manager.name)
             return
 
-        # Safer here, don't add a status if we don't have a status to add…
-        if pbm_status := self.manager.get_main_status():
-            self.manager.state.statuses.add(pbm_status, scope="unit", component=self.manager.name)
+        pbm_status = self.manager.map_backup_state_to_status(backup_state)[0]
+        self.manager.state.statuses.add(pbm_status, scope="unit", component=self.manager.name)
 
     def _on_s3_relation_broken(self, event: RelationBrokenEvent) -> None:
         """Proceed on s3 relation broken."""

--- a/single_kernel_mongo/events/backups.py
+++ b/single_kernel_mongo/events/backups.py
@@ -149,9 +149,9 @@ class BackupEventsHandler(Object):
             self.manager.set_certificate(credentials=credentials)
             if not self.charm.unit.is_leader():
                 return
-                # Then set the config options on PBM.
-                self.manager.set_config_options(credentials=credentials)
-                # Finally, resync the configuration.
+            # Then set the config options on PBM.
+            self.manager.set_config_options(credentials=credentials)
+            # Finally, resync the configuration.
             self.manager.resync_config_options()
             backup_state = BackupState.ACTIVE
         except InvalidS3CredentialsError:

--- a/single_kernel_mongo/events/backups.py
+++ b/single_kernel_mongo/events/backups.py
@@ -93,7 +93,7 @@ class BackupEventsHandler(Object):
             self.manager.state.statuses.add(
                 MongoDBStatuses.INVALID_S3_REL.value,
                 scope="unit",
-                component=self.manager.name,
+                component=self.dependent.name,
             )
 
     def _on_s3_credential_changed(self, event: CredentialsChangedEvent) -> None:  # noqa: C901

--- a/single_kernel_mongo/managers/backups.py
+++ b/single_kernel_mongo/managers/backups.py
@@ -459,6 +459,8 @@ class BackupManager(Object, BackupConfigManager, ManagerStatusProtocol):
                 return []
             case BackupState.MISSING_CONFIG:
                 return [BackupStatuses.PBM_MISSING_CONF.value]
+            case BackupState.CANT_CONFIGURE:
+                return [BackupStatuses.CANT_CONFIGURE.value]
             case BackupState.WAITING_PBM_START:
                 return [BackupStatuses.WAITING_FOR_PBM_START.value]
             case BackupState.INCORRECT_CREDS:
@@ -499,6 +501,15 @@ class BackupManager(Object, BackupConfigManager, ManagerStatusProtocol):
         """Returns the first status of the list."""
         pbm_statuses = self.get_statuses(scope="unit", recompute=True)
         return next(iter(pbm_statuses), None)
+
+    def set_certificate(self, credentials: dict) -> None:
+        """Sets the certificate on the file system if needed."""
+        # Add certificate to trust store
+        if cert_chain_list := credentials.get("tls-ca-chain", None):
+            self.dependent.save_ca_cert_to_trust_store(TrustStoreFiles.PBM, cert_chain_list)
+            self.share_certificate_with_shards(cert_chain_list)
+            # Restart after setting all configurations
+            self.configure_and_restart(force=True)
 
     def resync_config_options(self):  # pragma: nocover
         """Attempts to resync config options and sets status in case of failure."""
@@ -572,13 +583,6 @@ class BackupManager(Object, BackupConfigManager, ManagerStatusProtocol):
         Args:
             credentials: A dictionary provided by backup event handler.
         """
-        # Add certificate to trust store
-        if cert_chain_list := credentials.get("tls-ca-chain", None):
-            self.dependent.save_ca_cert_to_trust_store(TrustStoreFiles.PBM, cert_chain_list)
-            self.share_certificate_with_shards(cert_chain_list)
-            # Restart after setting all configurations
-            self.configure_and_restart(force=True)
-
         # First check if we ever had received a config
         with MongoConnection(self.state.backup_config) as conn:
             has_config = conn.client.admin["pbmConfig"].find_one()
@@ -605,7 +609,10 @@ class BackupManager(Object, BackupConfigManager, ManagerStatusProtocol):
         except WorkloadExecError as err:
             # In case of resync in progress, raise a ResyncError that will set a waiting status.
             if "resync" in err.stderr.lower():
-                logger.error("Waiting for resync to finish before setting configuration: %s", err)
+                logger.error(
+                    "Waiting for resync to finish before setting configuration: %s",
+                    {"return_code": err.return_code, "stdout": err.stdout, "stderr": err.stderr},
+                )
                 raise ResyncError
             # Don't log the credentials that are part of the cmd]
             logger.error(

--- a/tests/integration/mongodb/backups/test_backups.py
+++ b/tests/integration/mongodb/backups/test_backups.py
@@ -63,7 +63,9 @@ async def test_deploy_charms(
     # deploy the s3 integrator charm
     await ops_test.model.deploy(S3_APP_NAME, channel="edge")
 
-    await ops_test.model.wait_for_idle(timeout=DEPLOYMENT_TIMEOUT)
+    await ops_test.model.wait_for_idle(
+        apps=[base_app_name], timeout=DEPLOYMENT_TIMEOUT, status="active"
+    )
 
 
 @pytest.mark.abort_on_fail
@@ -147,11 +149,12 @@ async def test_create_and_list_backups(ops_test: OpsTest, cloud_configs) -> None
     """Tests that we can create a backup, and that it is listed in the backups."""
     db_app_name = await get_app_name(ops_test)
     leader_unit = await find_unit(ops_test, leader=True, app_name=db_app_name)
-    await set_credentials(ops_test, cloud_configs, cloud="AWS")
+
     # verify backup list works
     logger.info("!!!!! test_create_and_list_backups >>>  %s", leader_unit)
     action = await leader_unit.run_action(action_name="list-backups")
     list_result = await action.wait()
+
     logger.info("!!!!! test_create_and_list_backups >>>  %s", list_result.results)
     backups = list_result.results["backups"]
     assert backups, "backups not outputted"

--- a/tests/unit/test_backup_manager.py
+++ b/tests/unit/test_backup_manager.py
@@ -77,7 +77,7 @@ def test_invalid_s3_integration(
         relation=relation
     )
     statuses = backup_manager.state.statuses.get(
-        scope=Scope.UNIT, component=backup_manager.name
+        scope=Scope.UNIT, component=harness.charm.operator.name
     ).root
 
     assert MongoDBStatuses.INVALID_S3_REL.value in statuses


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷️ Type of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling and CI
- [ ] Dependencies upgrade or change
- [x] Chores / refactoring

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and feature scope of this PR (what)
  - the motivation behind this change (why)
  - the impacted components (often matches conventional commit scope)
  - explanation/algorithm if required (how)
-->
Port the changes to the backup manager that improve stability.
There shouldn't be any behavioral change except a better stability.
The reasons mainly being removing multiple configurations of the service, hence preventing the resync config errors.

## 🧪 Manual testing steps
<!--- Give a list of instructions to manually test your change. -->
<!--- These instructions are meant for reviewers to test the PR -->
<!--- on their development environment. -->


```text
1. juju deploy <my-app>
2. …
```

## 🔬 Automated testing steps
<!--- Describe the unit and integration tests that you added -->
<!--- to ensure that this feature works as expected. Include details -->
<!--- on the positive and negative test cases, as well as any changes -->
<!--- made to the existing tests to ensure they are still relevant. -->

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have added or updated any relevant documentation.
- [ ] I have read the [**CONTRIBUTING**](../blob/8/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
