### PR TITLE
patch: Ensure no credentials are leaked

### DIFF
--- a/single_kernel_mongo/core/k8s_workload.py
+++ b/single_kernel_mongo/core/k8s_workload.py
@@ -16,6 +16,7 @@ from single_kernel_mongo.config.literals import KubernetesUser
 from single_kernel_mongo.config.models import CharmSpec
 from single_kernel_mongo.core.workload import WorkloadBase
 from single_kernel_mongo.exceptions import WorkloadExecError, WorkloadServiceError
+from single_kernel_mongo.utils.helpers import mask_sensitive_information
 
 logger = getLogger(__name__)
 
@@ -144,9 +145,10 @@ class KubernetesWorkload(WorkloadBase):
             output, _ = process.wait_output()
             return output
         except ExecError as e:
-            logger.debug(e)
+            masked_cmd = mask_sensitive_information(command)
+            logger.error(f"cmd failed - cmd={masked_cmd}, stdout={e.stdout}, stderr={e.stderr}")
             raise WorkloadExecError(
-                e.command,
+                masked_cmd,
                 e.exit_code,
                 e.stdout,
                 e.stderr,

--- a/single_kernel_mongo/core/vm_workload.py
+++ b/single_kernel_mongo/core/vm_workload.py
@@ -28,6 +28,7 @@ from single_kernel_mongo.exceptions import (
     WorkloadServiceError,
 )
 from single_kernel_mongo.lib.charms.operator_libs_linux.v2 import snap
+from single_kernel_mongo.utils.helpers import mask_sensitive_information
 
 logger = getLogger(__name__)
 
@@ -145,9 +146,10 @@ class VMWorkload(WorkloadBase):
             logger.debug(f"{output=}")
             return output
         except subprocess.CalledProcessError as e:
-            logger.error(f"cmd failed - cmd={e.cmd}, stdout={e.stdout}, stderr={e.stderr}")
+            masked_cmd = mask_sensitive_information(command)
+            logger.error(f"cmd failed - cmd={masked_cmd}, stdout={e.stdout}, stderr={e.stderr}")
             raise WorkloadExecError(
-                e.cmd,
+                masked_cmd,
                 e.returncode,
                 e.stdout,
                 e.stderr,

--- a/single_kernel_mongo/utils/helpers.py
+++ b/single_kernel_mongo/utils/helpers.py
@@ -119,3 +119,22 @@ def charm_kind_only(func, charm_kind: CharmKind):
 
 mongodb_only = partial(charm_kind_only, charm_kind=CharmKind.MONGOD)
 mongos_only = partial(charm_kind_only, charm_kind=CharmKind.MONGOS)
+
+CREDENTIALS_HOLDERS: tuple[str, ...] = (
+    "hmacAccessKey",
+    "hmacSecret",
+    "access-key-id",
+    "secret-access-key",
+    "pass",
+)
+
+
+def mask_sensitive_information(cmd: str | list[str]) -> str:
+    """Replace passwords or secrets by 'xxx' and return the masked str."""
+    formatted = "|".join(CREDENTIALS_HOLDERS)
+    if isinstance(cmd, list):
+        cmd = " ".join(cmd)
+
+    pattern = re.compile(rf"({formatted})(:|=| )(\S+)")
+
+    return re.sub(pattern, r"\1\2" + "xxx", cmd)

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -25,4 +25,4 @@ def test_parse_tls_file_raw():
 
 
 def test_mask_cmd():
-    assert mask_sensitive_information("hmacSecretKey=deadbeef") == "hmacSecretKey=xxx"
+    assert mask_sensitive_information("hmacSecret=deadbeef") == "hmacSecret=xxx"

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -3,7 +3,11 @@
 
 import base64
 
-from single_kernel_mongo.utils.helpers import hostname_from_hostport, parse_tls_file
+from single_kernel_mongo.utils.helpers import (
+    hostname_from_hostport,
+    mask_sensitive_information,
+    parse_tls_file,
+)
 
 
 def test_hostname_from_hostport():
@@ -18,3 +22,7 @@ def test_parse_tls_file_raw():
     decoded = parse_tls_file(certificate)
     assert decoded == certificate.encode("utf-8")
     assert decoded == parse_tls_file(certificate_b64)
+
+
+def test_mask_cmd():
+    assert mask_sensitive_information("hmacSecretKey=deadbeef") == "hmacSecretKey=xxx"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷️ Type of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling and CI
- [ ] Dependencies upgrade or change
- [ ] Chores / refactoring

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and feature scope of this PR (what)
  - the motivation behind this change (why)
  - the impacted components (often matches conventional commit scope)
  - explanation/algorithm if required (how)
-->
This command could log sensitive informations if the command failed.
We now introduce a handler that will ensure that no sensitive information is leaked.
It is best effort, based on a list of strings built by the developers.

## 🧪 Manual testing steps
<!--- Give a list of instructions to manually test your change. -->
<!--- These instructions are meant for reviewers to test the PR -->
<!--- on their development environment. -->
In a python shell:
```python
from single_kernel_mongo.utils.helpers import mask_sensitive_information

my_sensitive_string = "a command with hmacSecretKey=apassword"
masked = mask_sensitive_information(my_sensitive_string)
assert my_sensitive_string == "a command with hmacSecretKey=xxx"
```

## 🔬 Automated testing steps
<!--- Describe the unit and integration tests that you added -->
<!--- to ensure that this feature works as expected. Include details -->
<!--- on the positive and negative test cases, as well as any changes -->
<!--- made to the existing tests to ensure they are still relevant. -->
Unit tested have been added to ensure that this functionality works.

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have added or updated any relevant documentation.
- [ ] I have read the [**CONTRIBUTING**](../blob/8/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
