### PR TITLE
patch: CI - wait for pypi release to be found before trigger mongo-single-kernel bumping workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,24 +62,40 @@ jobs:
     permissions:
       contents: write  # Needed to create GitHub release
 
-  sleep-after-release:
-    name: Sleep after release to PyPI
+  wait-for-pypi-available:
+    name: Wait for PyPI release to be available
     runs-on: ubuntu-latest
     needs:
       - release-part1
       - release-part2
     steps:
-      - name: Sleep
+      - name: Wait for PyPI release to be available
         run: |
-          echo "Waiting 60 seconds to avoid PyPI race conditions..."
-          sleep 60
+          set -euo pipefail
+          TAG="${{ needs.release-part1.outputs.git-tag }}"
+          DEP_NAME="mongo-charms-single-kernel"
+          VERSION_NUMBER="${TAG#v}"
+          URL="https://pypi.org/pypi/${DEP_NAME}/${VERSION_NUMBER}/json"
+
+          echo "Waiting for ${DEP_NAME}==${VERSION_NUMBER} to be available on PyPI..."
+          for i in {1..30}; do
+            if curl -fsS "$URL" >/dev/null; then
+              echo "Found ${DEP_NAME}==${VERSION_NUMBER} on PyPI."
+              exit 0
+            fi
+            echo "Not yet available (attempt $i/30). Sleeping..."
+            sleep 60
+          done
+
+          echo "Timed out waiting for ${DEP_NAME}==${VERSION_NUMBER} on PyPI."
+          exit 1
 
   trigger-bump-dependent-charms:
     name: Trigger bump-dependent-charms workflow
     needs:
       - release-part1
       - release-part2
-      - sleep-after-release
+      - wait-for-pypi-available
     uses: ./.github/workflows/bump_dependent_charms.yaml
     with:
       version: ${{ needs.release-part1.outputs.git-tag }}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷️ Type of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tooling and CI
- [ ] Dependencies upgrade or change
- [ ] Chores / refactoring

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and feature scope of this PR (what)
  - the motivation behind this change (why)
  - the impacted components (often matches conventional commit scope)
  - explanation/algorithm if required (how)
-->

After releasing the `mongo-charms-single-kernel` lib in PyPi, we need to wait until it is available before bumping the version on the 4 mongo charms. 

This PRs adds a polling to check if the library is available before trigerring the bump-dependent-charms workflow
- Interval: 1 minute
- Timeout: 30 minutes

<img width="679" height="290" alt="image" src="https://github.com/user-attachments/assets/c0b25b2f-a705-47ea-8544-d68e405398f1" />

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have added or updated any relevant documentation.
- [x] I have read the [**CONTRIBUTING**](../blob/8/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
