### PR TITLE
patch(DPE-9341) mongo db juju spaces support implement juju spaces support

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -446,14 +446,14 @@ charm-api = ">=0.1.1"
 
 [[package]]
 name = "charm-refresh"
-version = "3.1.1.2"
+version = "3.1.1.3"
 description = "In-place rolling refreshes (upgrades) of stateful charmed applications"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "charm_refresh-3.1.1.2-py3-none-any.whl", hash = "sha256:01143532a8021cd0ab9ad9686b73acccc289a8d51881f627575b0f25ab58c7e0"},
-    {file = "charm_refresh-3.1.1.2.tar.gz", hash = "sha256:1f0156799d338f2d74f27ed2439ed631a107bf46fe69fc5a5eec4877f48489b6"},
+    {file = "charm_refresh-3.1.1.3-py3-none-any.whl", hash = "sha256:4ef022b398498f46b992a777708e16a078d414c9b71d4c7522c7da574062345b"},
+    {file = "charm_refresh-3.1.1.3.tar.gz", hash = "sha256:f610642c652dd109b544d3e7e1010ebb15c0c2f97220b6c9676b4b28da47c3b2"},
 ]
 
 [package.dependencies]
@@ -641,104 +641,118 @@ typing-extensions = "*"
 
 [[package]]
 name = "coverage"
-version = "7.13.1"
+version = "7.13.4"
 description = "Code coverage measurement for Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["integration", "unit"]
 files = [
-    {file = "coverage-7.13.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e1fa280b3ad78eea5be86f94f461c04943d942697e0dac889fa18fff8f5f9147"},
-    {file = "coverage-7.13.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c3d8c679607220979434f494b139dfb00131ebf70bb406553d69c1ff01a5c33d"},
-    {file = "coverage-7.13.1-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:339dc63b3eba969067b00f41f15ad161bf2946613156fb131266d8debc8e44d0"},
-    {file = "coverage-7.13.1-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:db622b999ffe49cb891f2fff3b340cdc2f9797d01a0a202a0973ba2562501d90"},
-    {file = "coverage-7.13.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d1443ba9acbb593fa7c1c29e011d7c9761545fe35e7652e85ce7f51a16f7e08d"},
-    {file = "coverage-7.13.1-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c832ec92c4499ac463186af72f9ed4d8daec15499b16f0a879b0d1c8e5cf4a3b"},
-    {file = "coverage-7.13.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:562ec27dfa3f311e0db1ba243ec6e5f6ab96b1edfcfc6cf86f28038bc4961ce6"},
-    {file = "coverage-7.13.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:4de84e71173d4dada2897e5a0e1b7877e5eefbfe0d6a44edee6ce31d9b8ec09e"},
-    {file = "coverage-7.13.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:a5a68357f686f8c4d527a2dc04f52e669c2fc1cbde38f6f7eb6a0e58cbd17cae"},
-    {file = "coverage-7.13.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:77cc258aeb29a3417062758975521eae60af6f79e930d6993555eeac6a8eac29"},
-    {file = "coverage-7.13.1-cp310-cp310-win32.whl", hash = "sha256:bb4f8c3c9a9f34423dba193f241f617b08ffc63e27f67159f60ae6baf2dcfe0f"},
-    {file = "coverage-7.13.1-cp310-cp310-win_amd64.whl", hash = "sha256:c8e2706ceb622bc63bac98ebb10ef5da80ed70fbd8a7999a5076de3afaef0fb1"},
-    {file = "coverage-7.13.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1a55d509a1dc5a5b708b5dad3b5334e07a16ad4c2185e27b40e4dba796ab7f88"},
-    {file = "coverage-7.13.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4d010d080c4888371033baab27e47c9df7d6fb28d0b7b7adf85a4a49be9298b3"},
-    {file = "coverage-7.13.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d938b4a840fb1523b9dfbbb454f652967f18e197569c32266d4d13f37244c3d9"},
-    {file = "coverage-7.13.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bf100a3288f9bb7f919b87eb84f87101e197535b9bd0e2c2b5b3179633324fee"},
-    {file = "coverage-7.13.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef6688db9bf91ba111ae734ba6ef1a063304a881749726e0d3575f5c10a9facf"},
-    {file = "coverage-7.13.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0b609fc9cdbd1f02e51f67f51e5aee60a841ef58a68d00d5ee2c0faf357481a3"},
-    {file = "coverage-7.13.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c43257717611ff5e9a1d79dce8e47566235ebda63328718d9b65dd640bc832ef"},
-    {file = "coverage-7.13.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e09fbecc007f7b6afdfb3b07ce5bd9f8494b6856dd4f577d26c66c391b829851"},
-    {file = "coverage-7.13.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:a03a4f3a19a189919c7055098790285cc5c5b0b3976f8d227aea39dbf9f8bfdb"},
-    {file = "coverage-7.13.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3820778ea1387c2b6a818caec01c63adc5b3750211af6447e8dcfb9b6f08dbba"},
-    {file = "coverage-7.13.1-cp311-cp311-win32.whl", hash = "sha256:ff10896fa55167371960c5908150b434b71c876dfab97b69478f22c8b445ea19"},
-    {file = "coverage-7.13.1-cp311-cp311-win_amd64.whl", hash = "sha256:a998cc0aeeea4c6d5622a3754da5a493055d2d95186bad877b0a34ea6e6dbe0a"},
-    {file = "coverage-7.13.1-cp311-cp311-win_arm64.whl", hash = "sha256:fea07c1a39a22614acb762e3fbbb4011f65eedafcb2948feeef641ac78b4ee5c"},
-    {file = "coverage-7.13.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6f34591000f06e62085b1865c9bc5f7858df748834662a51edadfd2c3bfe0dd3"},
-    {file = "coverage-7.13.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b67e47c5595b9224599016e333f5ec25392597a89d5744658f837d204e16c63e"},
-    {file = "coverage-7.13.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3e7b8bd70c48ffb28461ebe092c2345536fb18bbbf19d287c8913699735f505c"},
-    {file = "coverage-7.13.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c223d078112e90dc0e5c4e35b98b9584164bea9fbbd221c0b21c5241f6d51b62"},
-    {file = "coverage-7.13.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:794f7c05af0763b1bbd1b9e6eff0e52ad068be3b12cd96c87de037b01390c968"},
-    {file = "coverage-7.13.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0642eae483cc8c2902e4af7298bf886d605e80f26382124cddc3967c2a3df09e"},
-    {file = "coverage-7.13.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9f5e772ed5fef25b3de9f2008fe67b92d46831bd2bc5bdc5dd6bfd06b83b316f"},
-    {file = "coverage-7.13.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:45980ea19277dc0a579e432aef6a504fe098ef3a9032ead15e446eb0f1191aee"},
-    {file = "coverage-7.13.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:e4f18eca6028ffa62adbd185a8f1e1dd242f2e68164dba5c2b74a5204850b4cf"},
-    {file = "coverage-7.13.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f8dca5590fec7a89ed6826fce625595279e586ead52e9e958d3237821fbc750c"},
-    {file = "coverage-7.13.1-cp312-cp312-win32.whl", hash = "sha256:ff86d4e85188bba72cfb876df3e11fa243439882c55957184af44a35bd5880b7"},
-    {file = "coverage-7.13.1-cp312-cp312-win_amd64.whl", hash = "sha256:16cc1da46c04fb0fb128b4dc430b78fa2aba8a6c0c9f8eb391fd5103409a6ac6"},
-    {file = "coverage-7.13.1-cp312-cp312-win_arm64.whl", hash = "sha256:8d9bc218650022a768f3775dd7fdac1886437325d8d295d923ebcfef4892ad5c"},
-    {file = "coverage-7.13.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:cb237bfd0ef4d5eb6a19e29f9e528ac67ac3be932ea6b44fb6cc09b9f3ecff78"},
-    {file = "coverage-7.13.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1dcb645d7e34dcbcc96cd7c132b1fc55c39263ca62eb961c064eb3928997363b"},
-    {file = "coverage-7.13.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3d42df8201e00384736f0df9be2ced39324c3907607d17d50d50116c989d84cd"},
-    {file = "coverage-7.13.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fa3edde1aa8807de1d05934982416cb3ec46d1d4d91e280bcce7cca01c507992"},
-    {file = "coverage-7.13.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9edd0e01a343766add6817bc448408858ba6b489039eaaa2018474e4001651a4"},
-    {file = "coverage-7.13.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:985b7836931d033570b94c94713c6dba5f9d3ff26045f72c3e5dbc5fe3361e5a"},
-    {file = "coverage-7.13.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ffed1e4980889765c84a5d1a566159e363b71d6b6fbaf0bebc9d3c30bc016766"},
-    {file = "coverage-7.13.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:8842af7f175078456b8b17f1b73a0d16a65dcbdc653ecefeb00a56b3c8c298c4"},
-    {file = "coverage-7.13.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ccd7a6fca48ca9c131d9b0a2972a581e28b13416fc313fb98b6d24a03ce9a398"},
-    {file = "coverage-7.13.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0403f647055de2609be776965108447deb8e384fe4a553c119e3ff6bfbab4784"},
-    {file = "coverage-7.13.1-cp313-cp313-win32.whl", hash = "sha256:549d195116a1ba1e1ae2f5ca143f9777800f6636eab917d4f02b5310d6d73461"},
-    {file = "coverage-7.13.1-cp313-cp313-win_amd64.whl", hash = "sha256:5899d28b5276f536fcf840b18b61a9fce23cc3aec1d114c44c07fe94ebeaa500"},
-    {file = "coverage-7.13.1-cp313-cp313-win_arm64.whl", hash = "sha256:868a2fae76dfb06e87291bcbd4dcbcc778a8500510b618d50496e520bd94d9b9"},
-    {file = "coverage-7.13.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:67170979de0dacac3f3097d02b0ad188d8edcea44ccc44aaa0550af49150c7dc"},
-    {file = "coverage-7.13.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:f80e2bb21bfab56ed7405c2d79d34b5dc0bc96c2c1d2a067b643a09fb756c43a"},
-    {file = "coverage-7.13.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f83351e0f7dcdb14d7326c3d8d8c4e915fa685cbfdc6281f9470d97a04e9dfe4"},
-    {file = "coverage-7.13.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bb3f6562e89bad0110afbe64e485aac2462efdce6232cdec7862a095dc3412f6"},
-    {file = "coverage-7.13.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77545b5dcda13b70f872c3b5974ac64c21d05e65b1590b441c8560115dc3a0d1"},
-    {file = "coverage-7.13.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4d240d260a1aed814790bbe1f10a5ff31ce6c21bc78f0da4a1e8268d6c80dbd"},
-    {file = "coverage-7.13.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d2287ac9360dec3837bfdad969963a5d073a09a85d898bd86bea82aa8876ef3c"},
-    {file = "coverage-7.13.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:0d2c11f3ea4db66b5cbded23b20185c35066892c67d80ec4be4bab257b9ad1e0"},
-    {file = "coverage-7.13.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:3fc6a169517ca0d7ca6846c3c5392ef2b9e38896f61d615cb75b9e7134d4ee1e"},
-    {file = "coverage-7.13.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:d10a2ed46386e850bb3de503a54f9fe8192e5917fcbb143bfef653a9355e9a53"},
-    {file = "coverage-7.13.1-cp313-cp313t-win32.whl", hash = "sha256:75a6f4aa904301dab8022397a22c0039edc1f51e90b83dbd4464b8a38dc87842"},
-    {file = "coverage-7.13.1-cp313-cp313t-win_amd64.whl", hash = "sha256:309ef5706e95e62578cda256b97f5e097916a2c26247c287bbe74794e7150df2"},
-    {file = "coverage-7.13.1-cp313-cp313t-win_arm64.whl", hash = "sha256:92f980729e79b5d16d221038dbf2e8f9a9136afa072f9d5d6ed4cb984b126a09"},
-    {file = "coverage-7.13.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:97ab3647280d458a1f9adb85244e81587505a43c0c7cff851f5116cd2814b894"},
-    {file = "coverage-7.13.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8f572d989142e0908e6acf57ad1b9b86989ff057c006d13b76c146ec6a20216a"},
-    {file = "coverage-7.13.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d72140ccf8a147e94274024ff6fd8fb7811354cf7ef88b1f0a988ebaa5bc774f"},
-    {file = "coverage-7.13.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d3c9f051b028810f5a87c88e5d6e9af3c0ff32ef62763bf15d29f740453ca909"},
-    {file = "coverage-7.13.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f398ba4df52d30b1763f62eed9de5620dcde96e6f491f4c62686736b155aa6e4"},
-    {file = "coverage-7.13.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:132718176cc723026d201e347f800cd1a9e4b62ccd3f82476950834dad501c75"},
-    {file = "coverage-7.13.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9e549d642426e3579b3f4b92d0431543b012dcb6e825c91619d4e93b7363c3f9"},
-    {file = "coverage-7.13.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:90480b2134999301eea795b3a9dbf606c6fbab1b489150c501da84a959442465"},
-    {file = "coverage-7.13.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e825dbb7f84dfa24663dd75835e7257f8882629fc11f03ecf77d84a75134b864"},
-    {file = "coverage-7.13.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:623dcc6d7a7ba450bbdbeedbaa0c42b329bdae16491af2282f12a7e809be7eb9"},
-    {file = "coverage-7.13.1-cp314-cp314-win32.whl", hash = "sha256:6e73ebb44dca5f708dc871fe0b90cf4cff1a13f9956f747cc87b535a840386f5"},
-    {file = "coverage-7.13.1-cp314-cp314-win_amd64.whl", hash = "sha256:be753b225d159feb397bd0bf91ae86f689bad0da09d3b301478cd39b878ab31a"},
-    {file = "coverage-7.13.1-cp314-cp314-win_arm64.whl", hash = "sha256:228b90f613b25ba0019361e4ab81520b343b622fc657daf7e501c4ed6a2366c0"},
-    {file = "coverage-7.13.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:60cfb538fe9ef86e5b2ab0ca8fc8d62524777f6c611dcaf76dc16fbe9b8e698a"},
-    {file = "coverage-7.13.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:57dfc8048c72ba48a8c45e188d811e5efd7e49b387effc8fb17e97936dde5bf6"},
-    {file = "coverage-7.13.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3f2f725aa3e909b3c5fdb8192490bdd8e1495e85906af74fe6e34a2a77ba0673"},
-    {file = "coverage-7.13.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ee68b21909686eeb21dfcba2c3b81fee70dcf38b140dcd5aa70680995fa3aa5"},
-    {file = "coverage-7.13.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:724b1b270cb13ea2e6503476e34541a0b1f62280bc997eab443f87790202033d"},
-    {file = "coverage-7.13.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:916abf1ac5cf7eb16bc540a5bf75c71c43a676f5c52fcb9fe75a2bd75fb944e8"},
-    {file = "coverage-7.13.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:776483fd35b58d8afe3acbd9988d5de592ab6da2d2a865edfdbc9fdb43e7c486"},
-    {file = "coverage-7.13.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:b6f3b96617e9852703f5b633ea01315ca45c77e879584f283c44127f0f1ec564"},
-    {file = "coverage-7.13.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:bd63e7b74661fed317212fab774e2a648bc4bb09b35f25474f8e3325d2945cd7"},
-    {file = "coverage-7.13.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:933082f161bbb3e9f90d00990dc956120f608cdbcaeea15c4d897f56ef4fe416"},
-    {file = "coverage-7.13.1-cp314-cp314t-win32.whl", hash = "sha256:18be793c4c87de2965e1c0f060f03d9e5aff66cfeae8e1dbe6e5b88056ec153f"},
-    {file = "coverage-7.13.1-cp314-cp314t-win_amd64.whl", hash = "sha256:0e42e0ec0cd3e0d851cb3c91f770c9301f48647cb2877cb78f74bdaa07639a79"},
-    {file = "coverage-7.13.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eaecf47ef10c72ece9a2a92118257da87e460e113b83cc0d2905cbbe931792b4"},
-    {file = "coverage-7.13.1-py3-none-any.whl", hash = "sha256:2016745cb3ba554469d02819d78958b571792bb68e31302610e898f80dd3a573"},
-    {file = "coverage-7.13.1.tar.gz", hash = "sha256:b7593fe7eb5feaa3fbb461ac79aac9f9fc0387a5ca8080b0c6fe2ca27b091afd"},
+    {file = "coverage-7.13.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0fc31c787a84f8cd6027eba44010517020e0d18487064cd3d8968941856d1415"},
+    {file = "coverage-7.13.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a32ebc02a1805adf637fc8dec324b5cdacd2e493515424f70ee33799573d661b"},
+    {file = "coverage-7.13.4-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e24f9156097ff9dc286f2f913df3a7f63c0e333dcafa3c196f2c18b4175ca09a"},
+    {file = "coverage-7.13.4-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8041b6c5bfdc03257666e9881d33b1abc88daccaf73f7b6340fb7946655cd10f"},
+    {file = "coverage-7.13.4-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2a09cfa6a5862bc2fc6ca7c3def5b2926194a56b8ab78ffcf617d28911123012"},
+    {file = "coverage-7.13.4-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:296f8b0af861d3970c2a4d8c91d48eb4dd4771bcef9baedec6a9b515d7de3def"},
+    {file = "coverage-7.13.4-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e101609bcbbfb04605ea1027b10dc3735c094d12d40826a60f897b98b1c30256"},
+    {file = "coverage-7.13.4-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:aa3feb8db2e87ff5e6d00d7e1480ae241876286691265657b500886c98f38bda"},
+    {file = "coverage-7.13.4-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:4fc7fa81bbaf5a02801b65346c8b3e657f1d93763e58c0abdf7c992addd81a92"},
+    {file = "coverage-7.13.4-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:33901f604424145c6e9c2398684b92e176c0b12df77d52db81c20abd48c3794c"},
+    {file = "coverage-7.13.4-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:bb28c0f2cf2782508a40cec377935829d5fcc3ad9a3681375af4e84eb34b6b58"},
+    {file = "coverage-7.13.4-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9d107aff57a83222ddbd8d9ee705ede2af2cc926608b57abed8ef96b50b7e8f9"},
+    {file = "coverage-7.13.4-cp310-cp310-win32.whl", hash = "sha256:a6f94a7d00eb18f1b6d403c91a88fd58cfc92d4b16080dfdb774afc8294469bf"},
+    {file = "coverage-7.13.4-cp310-cp310-win_amd64.whl", hash = "sha256:2cb0f1e000ebc419632bbe04366a8990b6e32c4e0b51543a6484ffe15eaeda95"},
+    {file = "coverage-7.13.4-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:d490ba50c3f35dd7c17953c68f3270e7ccd1c6642e2d2afe2d8e720b98f5a053"},
+    {file = "coverage-7.13.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:19bc3c88078789f8ef36acb014d7241961dbf883fd2533d18cb1e7a5b4e28b11"},
+    {file = "coverage-7.13.4-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3998e5a32e62fdf410c0dbd3115df86297995d6e3429af80b8798aad894ca7aa"},
+    {file = "coverage-7.13.4-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:8e264226ec98e01a8e1054314af91ee6cde0eacac4f465cc93b03dbe0bce2fd7"},
+    {file = "coverage-7.13.4-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a3aa4e7b9e416774b21797365b358a6e827ffadaaca81b69ee02946852449f00"},
+    {file = "coverage-7.13.4-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:71ca20079dd8f27fcf808817e281e90220475cd75115162218d0e27549f95fef"},
+    {file = "coverage-7.13.4-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e2f25215f1a359ab17320b47bcdaca3e6e6356652e8256f2441e4ef972052903"},
+    {file = "coverage-7.13.4-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d65b2d373032411e86960604dc4edac91fdfb5dca539461cf2cbe78327d1e64f"},
+    {file = "coverage-7.13.4-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94eb63f9b363180aff17de3e7c8760c3ba94664ea2695c52f10111244d16a299"},
+    {file = "coverage-7.13.4-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:e856bf6616714c3a9fbc270ab54103f4e685ba236fa98c054e8f87f266c93505"},
+    {file = "coverage-7.13.4-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:65dfcbe305c3dfe658492df2d85259e0d79ead4177f9ae724b6fb245198f55d6"},
+    {file = "coverage-7.13.4-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b507778ae8a4c915436ed5c2e05b4a6cecfa70f734e19c22a005152a11c7b6a9"},
+    {file = "coverage-7.13.4-cp311-cp311-win32.whl", hash = "sha256:784fc3cf8be001197b652d51d3fd259b1e2262888693a4636e18879f613a62a9"},
+    {file = "coverage-7.13.4-cp311-cp311-win_amd64.whl", hash = "sha256:2421d591f8ca05b308cf0092807308b2facbefe54af7c02ac22548b88b95c98f"},
+    {file = "coverage-7.13.4-cp311-cp311-win_arm64.whl", hash = "sha256:79e73a76b854d9c6088fe5d8b2ebe745f8681c55f7397c3c0a016192d681045f"},
+    {file = "coverage-7.13.4-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:02231499b08dabbe2b96612993e5fc34217cdae907a51b906ac7fca8027a4459"},
+    {file = "coverage-7.13.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:40aa8808140e55dc022b15d8aa7f651b6b3d68b365ea0398f1441e0b04d859c3"},
+    {file = "coverage-7.13.4-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5b856a8ccf749480024ff3bd7310adaef57bf31fd17e1bfc404b7940b6986634"},
+    {file = "coverage-7.13.4-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2c048ea43875fbf8b45d476ad79f179809c590ec7b79e2035c662e7afa3192e3"},
+    {file = "coverage-7.13.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b7b38448866e83176e28086674fe7368ab8590e4610fb662b44e345b86d63ffa"},
+    {file = "coverage-7.13.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:de6defc1c9badbf8b9e67ae90fd00519186d6ab64e5cc5f3d21359c2a9b2c1d3"},
+    {file = "coverage-7.13.4-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7eda778067ad7ffccd23ecffce537dface96212576a07924cbf0d8799d2ded5a"},
+    {file = "coverage-7.13.4-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e87f6c587c3f34356c3759f0420693e35e7eb0e2e41e4c011cb6ec6ecbbf1db7"},
+    {file = "coverage-7.13.4-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:8248977c2e33aecb2ced42fef99f2d319e9904a36e55a8a68b69207fb7e43edc"},
+    {file = "coverage-7.13.4-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:25381386e80ae727608e662474db537d4df1ecd42379b5ba33c84633a2b36d47"},
+    {file = "coverage-7.13.4-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:ee756f00726693e5ba94d6df2bdfd64d4852d23b09bb0bc700e3b30e6f333985"},
+    {file = "coverage-7.13.4-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fdfc1e28e7c7cdce44985b3043bc13bbd9c747520f94a4d7164af8260b3d91f0"},
+    {file = "coverage-7.13.4-cp312-cp312-win32.whl", hash = "sha256:01d4cbc3c283a17fc1e42d614a119f7f438eabb593391283adca8dc86eff1246"},
+    {file = "coverage-7.13.4-cp312-cp312-win_amd64.whl", hash = "sha256:9401ebc7ef522f01d01d45532c68c5ac40fb27113019b6b7d8b208f6e9baa126"},
+    {file = "coverage-7.13.4-cp312-cp312-win_arm64.whl", hash = "sha256:b1ec7b6b6e93255f952e27ab58fbc68dcc468844b16ecbee881aeb29b6ab4d8d"},
+    {file = "coverage-7.13.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:b66a2da594b6068b48b2692f043f35d4d3693fb639d5ea8b39533c2ad9ac3ab9"},
+    {file = "coverage-7.13.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3599eb3992d814d23b35c536c28df1a882caa950f8f507cef23d1cbf334995ac"},
+    {file = "coverage-7.13.4-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:93550784d9281e374fb5a12bf1324cc8a963fd63b2d2f223503ef0fd4aa339ea"},
+    {file = "coverage-7.13.4-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b720ce6a88a2755f7c697c23268ddc47a571b88052e6b155224347389fdf6a3b"},
+    {file = "coverage-7.13.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7b322db1284a2ed3aa28ffd8ebe3db91c929b7a333c0820abec3d838ef5b3525"},
+    {file = "coverage-7.13.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f4594c67d8a7c89cf922d9df0438c7c7bb022ad506eddb0fdb2863359ff78242"},
+    {file = "coverage-7.13.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:53d133df809c743eb8bce33b24bcababb371f4441340578cd406e084d94a6148"},
+    {file = "coverage-7.13.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:76451d1978b95ba6507a039090ba076105c87cc76fc3efd5d35d72093964d49a"},
+    {file = "coverage-7.13.4-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:7f57b33491e281e962021de110b451ab8a24182589be17e12a22c79047935e23"},
+    {file = "coverage-7.13.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:1731dc33dc276dafc410a885cbf5992f1ff171393e48a21453b78727d090de80"},
+    {file = "coverage-7.13.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:bd60d4fe2f6fa7dff9223ca1bbc9f05d2b6697bc5961072e5d3b952d46e1b1ea"},
+    {file = "coverage-7.13.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9181a3ccead280b828fae232df12b16652702b49d41e99d657f46cc7b1f6ec7a"},
+    {file = "coverage-7.13.4-cp313-cp313-win32.whl", hash = "sha256:f53d492307962561ac7de4cd1de3e363589b000ab69617c6156a16ba7237998d"},
+    {file = "coverage-7.13.4-cp313-cp313-win_amd64.whl", hash = "sha256:e6f70dec1cc557e52df5306d051ef56003f74d56e9c4dd7ddb07e07ef32a84dd"},
+    {file = "coverage-7.13.4-cp313-cp313-win_arm64.whl", hash = "sha256:fb07dc5da7e849e2ad31a5d74e9bece81f30ecf5a42909d0a695f8bd1874d6af"},
+    {file = "coverage-7.13.4-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:40d74da8e6c4b9ac18b15331c4b5ebc35a17069410cad462ad4f40dcd2d50c0d"},
+    {file = "coverage-7.13.4-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4223b4230a376138939a9173f1bdd6521994f2aff8047fae100d6d94d50c5a12"},
+    {file = "coverage-7.13.4-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:1d4be36a5114c499f9f1f9195e95ebf979460dbe2d88e6816ea202010ba1c34b"},
+    {file = "coverage-7.13.4-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:200dea7d1e8095cc6e98cdabe3fd1d21ab17d3cee6dab00cadbb2fe35d9c15b9"},
+    {file = "coverage-7.13.4-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b8eb931ee8e6d8243e253e5ed7336deea6904369d2fd8ae6e43f68abbf167092"},
+    {file = "coverage-7.13.4-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:75eab1ebe4f2f64d9509b984f9314d4aa788540368218b858dad56dc8f3e5eb9"},
+    {file = "coverage-7.13.4-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c35eb28c1d085eb7d8c9b3296567a1bebe03ce72962e932431b9a61f28facf26"},
+    {file = "coverage-7.13.4-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:eb88b316ec33760714a4720feb2816a3a59180fd58c1985012054fa7aebee4c2"},
+    {file = "coverage-7.13.4-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:7d41eead3cc673cbd38a4417deb7fd0b4ca26954ff7dc6078e33f6ff97bed940"},
+    {file = "coverage-7.13.4-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:fb26a934946a6afe0e326aebe0730cdff393a8bc0bbb65a2f41e30feddca399c"},
+    {file = "coverage-7.13.4-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:dae88bc0fc77edaa65c14be099bd57ee140cf507e6bfdeea7938457ab387efb0"},
+    {file = "coverage-7.13.4-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:845f352911777a8e722bfce168958214951e07e47e5d5d9744109fa5fe77f79b"},
+    {file = "coverage-7.13.4-cp313-cp313t-win32.whl", hash = "sha256:2fa8d5f8de70688a28240de9e139fa16b153cc3cbb01c5f16d88d6505ebdadf9"},
+    {file = "coverage-7.13.4-cp313-cp313t-win_amd64.whl", hash = "sha256:9351229c8c8407645840edcc277f4a2d44814d1bc34a2128c11c2a031d45a5dd"},
+    {file = "coverage-7.13.4-cp313-cp313t-win_arm64.whl", hash = "sha256:30b8d0512f2dc8c8747557e8fb459d6176a2c9e5731e2b74d311c03b78451997"},
+    {file = "coverage-7.13.4-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:300deaee342f90696ed186e3a00c71b5b3d27bffe9e827677954f4ee56969601"},
+    {file = "coverage-7.13.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:29e3220258d682b6226a9b0925bc563ed9a1ebcff3cad30f043eceea7eaf2689"},
+    {file = "coverage-7.13.4-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:391ee8f19bef69210978363ca930f7328081c6a0152f1166c91f0b5fdd2a773c"},
+    {file = "coverage-7.13.4-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0dd7ab8278f0d58a0128ba2fca25824321f05d059c1441800e934ff2efa52129"},
+    {file = "coverage-7.13.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:78cdf0d578b15148b009ccf18c686aa4f719d887e76e6b40c38ffb61d264a552"},
+    {file = "coverage-7.13.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:48685fee12c2eb3b27c62f2658e7ea21e9c3239cba5a8a242801a0a3f6a8c62a"},
+    {file = "coverage-7.13.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4e83efc079eb39480e6346a15a1bcb3e9b04759c5202d157e1dd4303cd619356"},
+    {file = "coverage-7.13.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ecae9737b72408d6a950f7e525f30aca12d4bd8dd95e37342e5beb3a2a8c4f71"},
+    {file = "coverage-7.13.4-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ae4578f8528569d3cf303fef2ea569c7f4c4059a38c8667ccef15c6e1f118aa5"},
+    {file = "coverage-7.13.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:6fdef321fdfbb30a197efa02d48fcd9981f0d8ad2ae8903ac318adc653f5df98"},
+    {file = "coverage-7.13.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2b0f6ccf3dbe577170bebfce1318707d0e8c3650003cb4b3a9dd744575daa8b5"},
+    {file = "coverage-7.13.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:75fcd519f2a5765db3f0e391eb3b7d150cce1a771bf4c9f861aeab86c767a3c0"},
+    {file = "coverage-7.13.4-cp314-cp314-win32.whl", hash = "sha256:8e798c266c378da2bd819b0677df41ab46d78065fb2a399558f3f6cae78b2fbb"},
+    {file = "coverage-7.13.4-cp314-cp314-win_amd64.whl", hash = "sha256:245e37f664d89861cf2329c9afa2c1fe9e6d4e1a09d872c947e70718aeeac505"},
+    {file = "coverage-7.13.4-cp314-cp314-win_arm64.whl", hash = "sha256:ad27098a189e5838900ce4c2a99f2fe42a0bf0c2093c17c69b45a71579e8d4a2"},
+    {file = "coverage-7.13.4-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:85480adfb35ffc32d40918aad81b89c69c9cc5661a9b8a81476d3e645321a056"},
+    {file = "coverage-7.13.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:79be69cf7f3bf9b0deeeb062eab7ac7f36cd4cc4c4dd694bd28921ba4d8596cc"},
+    {file = "coverage-7.13.4-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:caa421e2684e382c5d8973ac55e4f36bed6821a9bad5c953494de960c74595c9"},
+    {file = "coverage-7.13.4-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:14375934243ee05f56c45393fe2ce81fe5cc503c07cee2bdf1725fb8bef3ffaf"},
+    {file = "coverage-7.13.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:25a41c3104d08edb094d9db0d905ca54d0cd41c928bb6be3c4c799a54753af55"},
+    {file = "coverage-7.13.4-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f01afcff62bf9a08fb32b2c1d6e924236c0383c02c790732b6537269e466a72"},
+    {file = "coverage-7.13.4-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:eb9078108fbf0bcdde37c3f4779303673c2fa1fe8f7956e68d447d0dd426d38a"},
+    {file = "coverage-7.13.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:0e086334e8537ddd17e5f16a344777c1ab8194986ec533711cbe6c41cde841b6"},
+    {file = "coverage-7.13.4-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:725d985c5ab621268b2edb8e50dfe57633dc69bda071abc470fed55a14935fd3"},
+    {file = "coverage-7.13.4-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:3c06f0f1337c667b971ca2f975523347e63ec5e500b9aa5882d91931cd3ef750"},
+    {file = "coverage-7.13.4-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:590c0ed4bf8e85f745e6b805b2e1c457b2e33d5255dd9729743165253bc9ad39"},
+    {file = "coverage-7.13.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:eb30bf180de3f632cd043322dad5751390e5385108b2807368997d1a92a509d0"},
+    {file = "coverage-7.13.4-cp314-cp314t-win32.whl", hash = "sha256:c4240e7eded42d131a2d2c4dec70374b781b043ddc79a9de4d55ca71f8e98aea"},
+    {file = "coverage-7.13.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4c7d3cc01e7350f2f0f6f7036caaf5673fb56b6998889ccfe9e1c1fe75a9c932"},
+    {file = "coverage-7.13.4-cp314-cp314t-win_arm64.whl", hash = "sha256:23e3f687cf945070d1c90f85db66d11e3025665d8dafa831301a0e0038f3db9b"},
+    {file = "coverage-7.13.4-py3-none-any.whl", hash = "sha256:1af1641e57cf7ba1bd67d677c9abdbcd6cc2ab7da3bca7fa1e2b7e50e65f2ad0"},
+    {file = "coverage-7.13.4.tar.gz", hash = "sha256:e5c8f6ed1e61a8b2dcdf31eb0b9bbf0130750ca79c1c49eb898e2ad86f5ccc91"},
 ]
 
 [package.dependencies]
@@ -749,66 +763,61 @@ toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
 name = "cryptography"
-version = "46.0.3"
+version = "46.0.5"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = "!=3.9.0,!=3.9.1,>=3.8"
 groups = ["main", "charm-libs", "integration"]
 files = [
-    {file = "cryptography-46.0.3-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:109d4ddfadf17e8e7779c39f9b18111a09efb969a301a31e987416a0191ed93a"},
-    {file = "cryptography-46.0.3-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:09859af8466b69bc3c27bdf4f5d84a665e0f7ab5088412e9e2ec49758eca5cbc"},
-    {file = "cryptography-46.0.3-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:01ca9ff2885f3acc98c29f1860552e37f6d7c7d013d7334ff2a9de43a449315d"},
-    {file = "cryptography-46.0.3-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:6eae65d4c3d33da080cff9c4ab1f711b15c1d9760809dad6ea763f3812d254cb"},
-    {file = "cryptography-46.0.3-cp311-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e5bf0ed4490068a2e72ac03d786693adeb909981cc596425d09032d372bcc849"},
-    {file = "cryptography-46.0.3-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:5ecfccd2329e37e9b7112a888e76d9feca2347f12f37918facbb893d7bb88ee8"},
-    {file = "cryptography-46.0.3-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a2c0cd47381a3229c403062f764160d57d4d175e022c1df84e168c6251a22eec"},
-    {file = "cryptography-46.0.3-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:549e234ff32571b1f4076ac269fcce7a808d3bf98b76c8dd560e42dbc66d7d91"},
-    {file = "cryptography-46.0.3-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:c0a7bb1a68a5d3471880e264621346c48665b3bf1c3759d682fc0864c540bd9e"},
-    {file = "cryptography-46.0.3-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:10b01676fc208c3e6feeb25a8b83d81767e8059e1fe86e1dc62d10a3018fa926"},
-    {file = "cryptography-46.0.3-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0abf1ffd6e57c67e92af68330d05760b7b7efb243aab8377e583284dbab72c71"},
-    {file = "cryptography-46.0.3-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a04bee9ab6a4da801eb9b51f1b708a1b5b5c9eb48c03f74198464c66f0d344ac"},
-    {file = "cryptography-46.0.3-cp311-abi3-win32.whl", hash = "sha256:f260d0d41e9b4da1ed1e0f1ce571f97fe370b152ab18778e9e8f67d6af432018"},
-    {file = "cryptography-46.0.3-cp311-abi3-win_amd64.whl", hash = "sha256:a9a3008438615669153eb86b26b61e09993921ebdd75385ddd748702c5adfddb"},
-    {file = "cryptography-46.0.3-cp311-abi3-win_arm64.whl", hash = "sha256:5d7f93296ee28f68447397bf5198428c9aeeab45705a55d53a6343455dcb2c3c"},
-    {file = "cryptography-46.0.3-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:00a5e7e87938e5ff9ff5447ab086a5706a957137e6e433841e9d24f38a065217"},
-    {file = "cryptography-46.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c8daeb2d2174beb4575b77482320303f3d39b8e81153da4f0fb08eb5fe86a6c5"},
-    {file = "cryptography-46.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:39b6755623145ad5eff1dab323f4eae2a32a77a7abef2c5089a04a3d04366715"},
-    {file = "cryptography-46.0.3-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:db391fa7c66df6762ee3f00c95a89e6d428f4d60e7abc8328f4fe155b5ac6e54"},
-    {file = "cryptography-46.0.3-cp314-cp314t-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:78a97cf6a8839a48c49271cdcbd5cf37ca2c1d6b7fdd86cc864f302b5e9bf459"},
-    {file = "cryptography-46.0.3-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:dfb781ff7eaa91a6f7fd41776ec37c5853c795d3b358d4896fdbb5df168af422"},
-    {file = "cryptography-46.0.3-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:6f61efb26e76c45c4a227835ddeae96d83624fb0d29eb5df5b96e14ed1a0afb7"},
-    {file = "cryptography-46.0.3-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:23b1a8f26e43f47ceb6d6a43115f33a5a37d57df4ea0ca295b780ae8546e8044"},
-    {file = "cryptography-46.0.3-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b419ae593c86b87014b9be7396b385491ad7f320bde96826d0dd174459e54665"},
-    {file = "cryptography-46.0.3-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:50fc3343ac490c6b08c0cf0d704e881d0d660be923fd3076db3e932007e726e3"},
-    {file = "cryptography-46.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:22d7e97932f511d6b0b04f2bfd818d73dcd5928db509460aaf48384778eb6d20"},
-    {file = "cryptography-46.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d55f3dffadd674514ad19451161118fd010988540cee43d8bc20675e775925de"},
-    {file = "cryptography-46.0.3-cp314-cp314t-win32.whl", hash = "sha256:8a6e050cb6164d3f830453754094c086ff2d0b2f3a897a1d9820f6139a1f0914"},
-    {file = "cryptography-46.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:760f83faa07f8b64e9c33fc963d790a2edb24efb479e3520c14a45741cd9b2db"},
-    {file = "cryptography-46.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:516ea134e703e9fe26bcd1277a4b59ad30586ea90c365a87781d7887a646fe21"},
-    {file = "cryptography-46.0.3-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:cb3d760a6117f621261d662bccc8ef5bc32ca673e037c83fbe565324f5c46936"},
-    {file = "cryptography-46.0.3-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:4b7387121ac7d15e550f5cb4a43aef2559ed759c35df7336c402bb8275ac9683"},
-    {file = "cryptography-46.0.3-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:15ab9b093e8f09daab0f2159bb7e47532596075139dd74365da52ecc9cb46c5d"},
-    {file = "cryptography-46.0.3-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:46acf53b40ea38f9c6c229599a4a13f0d46a6c3fa9ef19fc1a124d62e338dfa0"},
-    {file = "cryptography-46.0.3-cp38-abi3-manylinux_2_28_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:10ca84c4668d066a9878890047f03546f3ae0a6b8b39b697457b7757aaf18dbc"},
-    {file = "cryptography-46.0.3-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:36e627112085bb3b81b19fed209c05ce2a52ee8b15d161b7c643a7d5a88491f3"},
-    {file = "cryptography-46.0.3-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1000713389b75c449a6e979ffc7dcc8ac90b437048766cef052d4d30b8220971"},
-    {file = "cryptography-46.0.3-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:b02cf04496f6576afffef5ddd04a0cb7d49cf6be16a9059d793a30b035f6b6ac"},
-    {file = "cryptography-46.0.3-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:71e842ec9bc7abf543b47cf86b9a743baa95f4677d22baa4c7d5c69e49e9bc04"},
-    {file = "cryptography-46.0.3-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:402b58fc32614f00980b66d6e56a5b4118e6cb362ae8f3fda141ba4689bd4506"},
-    {file = "cryptography-46.0.3-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef639cb3372f69ec44915fafcd6698b6cc78fbe0c2ea41be867f6ed612811963"},
-    {file = "cryptography-46.0.3-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:3b51b8ca4f1c6453d8829e1eb7299499ca7f313900dd4d89a24b8b87c0a780d4"},
-    {file = "cryptography-46.0.3-cp38-abi3-win32.whl", hash = "sha256:6276eb85ef938dc035d59b87c8a7dc559a232f954962520137529d77b18ff1df"},
-    {file = "cryptography-46.0.3-cp38-abi3-win_amd64.whl", hash = "sha256:416260257577718c05135c55958b674000baef9a1c7d9e8f306ec60d71db850f"},
-    {file = "cryptography-46.0.3-cp38-abi3-win_arm64.whl", hash = "sha256:d89c3468de4cdc4f08a57e214384d0471911a3830fcdaf7a8cc587e42a866372"},
-    {file = "cryptography-46.0.3-pp310-pypy310_pp73-macosx_10_9_x86_64.whl", hash = "sha256:a23582810fedb8c0bc47524558fb6c56aac3fc252cb306072fd2815da2a47c32"},
-    {file = "cryptography-46.0.3-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:e7aec276d68421f9574040c26e2a7c3771060bc0cff408bae1dcb19d3ab1e63c"},
-    {file = "cryptography-46.0.3-pp311-pypy311_pp73-macosx_10_9_x86_64.whl", hash = "sha256:7ce938a99998ed3c8aa7e7272dca1a610401ede816d36d0693907d863b10d9ea"},
-    {file = "cryptography-46.0.3-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:191bb60a7be5e6f54e30ba16fdfae78ad3a342a0599eb4193ba88e3f3d6e185b"},
-    {file = "cryptography-46.0.3-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:c70cc23f12726be8f8bc72e41d5065d77e4515efae3690326764ea1b07845cfb"},
-    {file = "cryptography-46.0.3-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:9394673a9f4de09e28b5356e7fff97d778f8abad85c9d5ac4a4b7e25a0de7717"},
-    {file = "cryptography-46.0.3-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:94cd0549accc38d1494e1f8de71eca837d0509d0d44bf11d158524b0e12cebf9"},
-    {file = "cryptography-46.0.3-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:6b5063083824e5509fdba180721d55909ffacccc8adbec85268b48439423d78c"},
-    {file = "cryptography-46.0.3.tar.gz", hash = "sha256:a8b17438104fed022ce745b362294d9ce35b4c2e45c1d958ad4a4b019285f4a1"},
+    {file = "cryptography-46.0.5-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:351695ada9ea9618b3500b490ad54c739860883df6c1f555e088eaf25b1bbaad"},
+    {file = "cryptography-46.0.5-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c18ff11e86df2e28854939acde2d003f7984f721eba450b56a200ad90eeb0e6b"},
+    {file = "cryptography-46.0.5-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d7e3d356b8cd4ea5aff04f129d5f66ebdc7b6f8eae802b93739ed520c47c79b"},
+    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:50bfb6925eff619c9c023b967d5b77a54e04256c4281b0e21336a130cd7fc263"},
+    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:803812e111e75d1aa73690d2facc295eaefd4439be1023fefc4995eaea2af90d"},
+    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ee190460e2fbe447175cda91b88b84ae8322a104fc27766ad09428754a618ed"},
+    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:f145bba11b878005c496e93e257c1e88f154d278d2638e6450d17e0f31e558d2"},
+    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e9251e3be159d1020c4030bd2e5f84d6a43fe54b6c19c12f51cde9542a2817b2"},
+    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:47fb8a66058b80e509c47118ef8a75d14c455e81ac369050f20ba0d23e77fee0"},
+    {file = "cryptography-46.0.5-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4c3341037c136030cb46e4b1e17b7418ea4cbd9dd207e4a6f3b2b24e0d4ac731"},
+    {file = "cryptography-46.0.5-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:890bcb4abd5a2d3f852196437129eb3667d62630333aacc13dfd470fad3aaa82"},
+    {file = "cryptography-46.0.5-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80a8d7bfdf38f87ca30a5391c0c9ce4ed2926918e017c29ddf643d0ed2778ea1"},
+    {file = "cryptography-46.0.5-cp311-abi3-win32.whl", hash = "sha256:60ee7e19e95104d4c03871d7d7dfb3d22ef8a9b9c6778c94e1c8fcc8365afd48"},
+    {file = "cryptography-46.0.5-cp311-abi3-win_amd64.whl", hash = "sha256:38946c54b16c885c72c4f59846be9743d699eee2b69b6988e0a00a01f46a61a4"},
+    {file = "cryptography-46.0.5-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:94a76daa32eb78d61339aff7952ea819b1734b46f73646a07decb40e5b3448e2"},
+    {file = "cryptography-46.0.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5be7bf2fb40769e05739dd0046e7b26f9d4670badc7b032d6ce4db64dddc0678"},
+    {file = "cryptography-46.0.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe346b143ff9685e40192a4960938545c699054ba11d4f9029f94751e3f71d87"},
+    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c69fd885df7d089548a42d5ec05be26050ebcd2283d89b3d30676eb32ff87dee"},
+    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:8293f3dea7fc929ef7240796ba231413afa7b68ce38fd21da2995549f5961981"},
+    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:1abfdb89b41c3be0365328a410baa9df3ff8a9110fb75e7b52e66803ddabc9a9"},
+    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:d66e421495fdb797610a08f43b05269e0a5ea7f5e652a89bfd5a7d3c1dee3648"},
+    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:4e817a8920bfbcff8940ecfd60f23d01836408242b30f1a708d93198393a80b4"},
+    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:68f68d13f2e1cb95163fa3b4db4bf9a159a418f5f6e7242564fc75fcae667fd0"},
+    {file = "cryptography-46.0.5-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:a3d1fae9863299076f05cb8a778c467578262fae09f9dc0ee9b12eb4268ce663"},
+    {file = "cryptography-46.0.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4143987a42a2397f2fc3b4d7e3a7d313fbe684f67ff443999e803dd75a76826"},
+    {file = "cryptography-46.0.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7d731d4b107030987fd61a7f8ab512b25b53cef8f233a97379ede116f30eb67d"},
+    {file = "cryptography-46.0.5-cp314-cp314t-win32.whl", hash = "sha256:c3bcce8521d785d510b2aad26ae2c966092b7daa8f45dd8f44734a104dc0bc1a"},
+    {file = "cryptography-46.0.5-cp314-cp314t-win_amd64.whl", hash = "sha256:4d8ae8659ab18c65ced284993c2265910f6c9e650189d4e3f68445ef82a810e4"},
+    {file = "cryptography-46.0.5-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:4108d4c09fbbf2789d0c926eb4152ae1760d5a2d97612b92d508d96c861e4d31"},
+    {file = "cryptography-46.0.5-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1f30a86d2757199cb2d56e48cce14deddf1f9c95f1ef1b64ee91ea43fe2e18"},
+    {file = "cryptography-46.0.5-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:039917b0dc418bb9f6edce8a906572d69e74bd330b0b3fea4f79dab7f8ddd235"},
+    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ba2a27ff02f48193fc4daeadf8ad2590516fa3d0adeeb34336b96f7fa64c1e3a"},
+    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:61aa400dce22cb001a98014f647dc21cda08f7915ceb95df0c9eaf84b4b6af76"},
+    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ce58ba46e1bc2aac4f7d9290223cead56743fa6ab94a5d53292ffaac6a91614"},
+    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:420d0e909050490d04359e7fdb5ed7e667ca5c3c402b809ae2563d7e66a92229"},
+    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:582f5fcd2afa31622f317f80426a027f30dc792e9c80ffee87b993200ea115f1"},
+    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:bfd56bb4b37ed4f330b82402f6f435845a5f5648edf1ad497da51a8452d5d62d"},
+    {file = "cryptography-46.0.5-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:a3d507bb6a513ca96ba84443226af944b0f7f47dcc9a399d110cd6146481d24c"},
+    {file = "cryptography-46.0.5-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9f16fbdf4da055efb21c22d81b89f155f02ba420558db21288b3d0035bafd5f4"},
+    {file = "cryptography-46.0.5-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ced80795227d70549a411a4ab66e8ce307899fad2220ce5ab2f296e687eacde9"},
+    {file = "cryptography-46.0.5-cp38-abi3-win32.whl", hash = "sha256:02f547fce831f5096c9a567fd41bc12ca8f11df260959ecc7c3202555cc47a72"},
+    {file = "cryptography-46.0.5-cp38-abi3-win_amd64.whl", hash = "sha256:556e106ee01aa13484ce9b0239bca667be5004efb0aabbed28d353df86445595"},
+    {file = "cryptography-46.0.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:3b4995dc971c9fb83c25aa44cf45f02ba86f71ee600d81091c2f0cbae116b06c"},
+    {file = "cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:bc84e875994c3b445871ea7181d424588171efec3e185dced958dad9e001950a"},
+    {file = "cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:2ae6971afd6246710480e3f15824ed3029a60fc16991db250034efd0b9fb4356"},
+    {file = "cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:d861ee9e76ace6cf36a6a89b959ec08e7bc2493ee39d07ffe5acb23ef46d27da"},
+    {file = "cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:2b7a67c9cd56372f3249b39699f2ad479f6991e62ea15800973b956f4b73e257"},
+    {file = "cryptography-46.0.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:8456928655f856c6e1533ff59d5be76578a7157224dbd9ce6872f25055ab9ab7"},
+    {file = "cryptography-46.0.5.tar.gz", hash = "sha256:abace499247268e3757271b2f1e244b36b06f8515cf27c4d49468fc9eb16e93d"},
 ]
 
 [package.dependencies]
@@ -822,7 +831,7 @@ nox = ["nox[uv] (>=2024.4.15)"]
 pep8test = ["check-sdist", "click (>=8.0.1)", "mypy (>=1.14)", "ruff (>=0.11.11)"]
 sdist = ["build (>=1.0.0)"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["certifi (>=2024)", "cryptography-vectors (==46.0.3)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
+test = ["certifi (>=2024)", "cryptography-vectors (==46.0.5)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
 test-randomorder = ["pytest-randomly"]
 
 [[package]]
@@ -976,14 +985,14 @@ doc = ["Sphinx", "sphinx-rtd-theme", "sphinxcontrib-spelling"]
 
 [[package]]
 name = "faker"
-version = "40.1.2"
+version = "40.4.0"
 description = "Faker is a Python package that generates fake data for you."
 optional = false
 python-versions = ">=3.10"
 groups = ["unit"]
 files = [
-    {file = "faker-40.1.2-py3-none-any.whl", hash = "sha256:93503165c165d330260e4379fd6dc07c94da90c611ed3191a0174d2ab9966a42"},
-    {file = "faker-40.1.2.tar.gz", hash = "sha256:b76a68163aa5f171d260fc24827a8349bc1db672f6a665359e8d0095e8135d30"},
+    {file = "faker-40.4.0-py3-none-any.whl", hash = "sha256:486d43c67ebbb136bc932406418744f9a0bdf2c07f77703ea78b58b77e9aa443"},
+    {file = "faker-40.4.0.tar.gz", hash = "sha256:76f8e74a3df28c3e2ec2caafa956e19e37a132fdc7ea067bc41783affcfee364"},
 ]
 
 [package.dependencies]
@@ -994,14 +1003,14 @@ tzdata = ["tzdata"]
 
 [[package]]
 name = "filelock"
-version = "3.20.3"
+version = "3.24.2"
 description = "A platform independent file lock."
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "filelock-3.20.3-py3-none-any.whl", hash = "sha256:4b0dda527ee31078689fc205ec4f1c1bf7d56cf88b6dc9426c4f230e46c2dce1"},
-    {file = "filelock-3.20.3.tar.gz", hash = "sha256:18c57ee915c7ec61cff0ecf7f0f869936c7c30191bb0cf406f1341778d0834e1"},
+    {file = "filelock-3.24.2-py3-none-any.whl", hash = "sha256:667d7dc0b7d1e1064dd5f8f8e80bdac157a6482e8d2e02cd16fd3b6b33bd6556"},
+    {file = "filelock-3.24.2.tar.gz", hash = "sha256:c22803117490f156e59fafce621f0550a7a853e2bbf4f87f112b11d469b6c81b"},
 ]
 
 [[package]]
@@ -1029,29 +1038,30 @@ grpcio-gcp = ["grpcio-gcp (>=0.2.2,<1.0.dev0)"]
 
 [[package]]
 name = "google-auth"
-version = "2.47.0"
+version = "2.48.0"
 description = "Google Authentication Library"
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "integration"]
 files = [
-    {file = "google_auth-2.47.0-py3-none-any.whl", hash = "sha256:c516d68336bfde7cf0da26aab674a36fedcf04b37ac4edd59c597178760c3498"},
-    {file = "google_auth-2.47.0.tar.gz", hash = "sha256:833229070a9dfee1a353ae9877dcd2dec069a8281a4e72e72f77d4a70ff945da"},
+    {file = "google_auth-2.48.0-py3-none-any.whl", hash = "sha256:2e2a537873d449434252a9632c28bfc268b0adb1e53f9fb62afc5333a975903f"},
+    {file = "google_auth-2.48.0.tar.gz", hash = "sha256:4f7e706b0cd3208a3d940a19a822c37a476ddba5450156c3e6624a71f7c841ce"},
 ]
 
 [package.dependencies]
+cryptography = ">=38.0.3"
 pyasn1-modules = ">=0.2.1"
 rsa = ">=3.1.4,<5"
 
 [package.extras]
 aiohttp = ["aiohttp (>=3.6.2,<4.0.0)", "requests (>=2.20.0,<3.0.0)"]
 cryptography = ["cryptography (>=38.0.3)"]
-enterprise-cert = ["cryptography", "pyopenssl"]
-pyjwt = ["cryptography (>=38.0.3)", "pyjwt (>=2.0)"]
-pyopenssl = ["cryptography (>=38.0.3)", "pyopenssl (>=20.0.0)"]
+enterprise-cert = ["pyopenssl"]
+pyjwt = ["pyjwt (>=2.0)"]
+pyopenssl = ["pyopenssl (>=20.0.0)"]
 reauth = ["pyu2f (>=0.1.5)"]
 requests = ["requests (>=2.20.0,<3.0.0)"]
-testing = ["aiohttp (<3.10.0)", "aiohttp (>=3.6.2,<4.0.0)", "aioresponses", "cryptography (>=38.0.3)", "cryptography (>=38.0.3)", "flask", "freezegun", "grpcio", "oauth2client", "packaging", "pyjwt (>=2.0)", "pyopenssl (<24.3.0)", "pyopenssl (>=20.0.0)", "pytest", "pytest-asyncio", "pytest-cov", "pytest-localserver", "pyu2f (>=0.1.5)", "requests (>=2.20.0,<3.0.0)", "responses", "urllib3"]
+testing = ["aiohttp (<3.10.0)", "aiohttp (>=3.6.2,<4.0.0)", "aioresponses", "flask", "freezegun", "grpcio", "oauth2client", "packaging", "pyjwt (>=2.0)", "pyopenssl (<24.3.0)", "pyopenssl (>=20.0.0)", "pytest", "pytest-asyncio", "pytest-cov", "pytest-localserver", "pyu2f (>=0.1.5)", "requests (>=2.20.0,<3.0.0)", "responses", "urllib3"]
 urllib3 = ["packaging", "urllib3"]
 
 [[package]]
@@ -1575,89 +1585,103 @@ adal = ["adal (>=1.0.2)"]
 
 [[package]]
 name = "librt"
-version = "0.7.8"
+version = "0.8.0"
 description = "Mypyc runtime library"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev", "format", "lint"]
 markers = "platform_python_implementation != \"PyPy\""
 files = [
-    {file = "librt-0.7.8-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b45306a1fc5f53c9330fbee134d8b3227fe5da2ab09813b892790400aa49352d"},
-    {file = "librt-0.7.8-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:864c4b7083eeee250ed55135d2127b260d7eb4b5e953a9e5df09c852e327961b"},
-    {file = "librt-0.7.8-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6938cc2de153bc927ed8d71c7d2f2ae01b4e96359126c602721340eb7ce1a92d"},
-    {file = "librt-0.7.8-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:66daa6ac5de4288a5bbfbe55b4caa7bf0cd26b3269c7a476ffe8ce45f837f87d"},
-    {file = "librt-0.7.8-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4864045f49dc9c974dadb942ac56a74cd0479a2aafa51ce272c490a82322ea3c"},
-    {file = "librt-0.7.8-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:a36515b1328dc5b3ffce79fe204985ca8572525452eacabee2166f44bb387b2c"},
-    {file = "librt-0.7.8-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:b7e7f140c5169798f90b80d6e607ed2ba5059784968a004107c88ad61fb3641d"},
-    {file = "librt-0.7.8-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:ff71447cb778a4f772ddc4ce360e6ba9c95527ed84a52096bd1bbf9fee2ec7c0"},
-    {file = "librt-0.7.8-cp310-cp310-win32.whl", hash = "sha256:047164e5f68b7a8ebdf9fae91a3c2161d3192418aadd61ddd3a86a56cbe3dc85"},
-    {file = "librt-0.7.8-cp310-cp310-win_amd64.whl", hash = "sha256:d6f254d096d84156a46a84861183c183d30734e52383602443292644d895047c"},
-    {file = "librt-0.7.8-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:ff3e9c11aa260c31493d4b3197d1e28dd07768594a4f92bec4506849d736248f"},
-    {file = "librt-0.7.8-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ddb52499d0b3ed4aa88746aaf6f36a08314677d5c346234c3987ddc506404eac"},
-    {file = "librt-0.7.8-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:e9c0afebbe6ce177ae8edba0c7c4d626f2a0fc12c33bb993d163817c41a7a05c"},
-    {file = "librt-0.7.8-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:631599598e2c76ded400c0a8722dec09217c89ff64dc54b060f598ed68e7d2a8"},
-    {file = "librt-0.7.8-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9c1ba843ae20db09b9d5c80475376168feb2640ce91cd9906414f23cc267a1ff"},
-    {file = "librt-0.7.8-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b5b007bb22ea4b255d3ee39dfd06d12534de2fcc3438567d9f48cdaf67ae1ae3"},
-    {file = "librt-0.7.8-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:dbd79caaf77a3f590cbe32dc2447f718772d6eea59656a7dcb9311161b10fa75"},
-    {file = "librt-0.7.8-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:87808a8d1e0bd62a01cafc41f0fd6818b5a5d0ca0d8a55326a81643cdda8f873"},
-    {file = "librt-0.7.8-cp311-cp311-win32.whl", hash = "sha256:31724b93baa91512bd0a376e7cf0b59d8b631ee17923b1218a65456fa9bda2e7"},
-    {file = "librt-0.7.8-cp311-cp311-win_amd64.whl", hash = "sha256:978e8b5f13e52cf23a9e80f3286d7546baa70bc4ef35b51d97a709d0b28e537c"},
-    {file = "librt-0.7.8-cp311-cp311-win_arm64.whl", hash = "sha256:20e3946863d872f7cabf7f77c6c9d370b8b3d74333d3a32471c50d3a86c0a232"},
-    {file = "librt-0.7.8-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9b6943885b2d49c48d0cff23b16be830ba46b0152d98f62de49e735c6e655a63"},
-    {file = "librt-0.7.8-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:46ef1f4b9b6cc364b11eea0ecc0897314447a66029ee1e55859acb3dd8757c93"},
-    {file = "librt-0.7.8-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:907ad09cfab21e3c86e8f1f87858f7049d1097f77196959c033612f532b4e592"},
-    {file = "librt-0.7.8-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2991b6c3775383752b3ca0204842743256f3ad3deeb1d0adc227d56b78a9a850"},
-    {file = "librt-0.7.8-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:03679b9856932b8c8f674e87aa3c55ea11c9274301f76ae8dc4d281bda55cf62"},
-    {file = "librt-0.7.8-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3968762fec1b2ad34ce57458b6de25dbb4142713e9ca6279a0d352fa4e9f452b"},
-    {file = "librt-0.7.8-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:bb7a7807523a31f03061288cc4ffc065d684c39db7644c676b47d89553c0d714"},
-    {file = "librt-0.7.8-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ad64a14b1e56e702e19b24aae108f18ad1bf7777f3af5fcd39f87d0c5a814449"},
-    {file = "librt-0.7.8-cp312-cp312-win32.whl", hash = "sha256:0241a6ed65e6666236ea78203a73d800dbed896cf12ae25d026d75dc1fcd1dac"},
-    {file = "librt-0.7.8-cp312-cp312-win_amd64.whl", hash = "sha256:6db5faf064b5bab9675c32a873436b31e01d66ca6984c6f7f92621656033a708"},
-    {file = "librt-0.7.8-cp312-cp312-win_arm64.whl", hash = "sha256:57175aa93f804d2c08d2edb7213e09276bd49097611aefc37e3fa38d1fb99ad0"},
-    {file = "librt-0.7.8-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4c3995abbbb60b3c129490fa985dfe6cac11d88fc3c36eeb4fb1449efbbb04fc"},
-    {file = "librt-0.7.8-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:44e0c2cbc9bebd074cf2cdbe472ca185e824be4e74b1c63a8e934cea674bebf2"},
-    {file = "librt-0.7.8-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:4d2f1e492cae964b3463a03dc77a7fe8742f7855d7258c7643f0ee32b6651dd3"},
-    {file = "librt-0.7.8-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:451e7ffcef8f785831fdb791bd69211f47e95dc4c6ddff68e589058806f044c6"},
-    {file = "librt-0.7.8-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3469e1af9f1380e093ae06bedcbdd11e407ac0b303a56bbe9afb1d6824d4982d"},
-    {file = "librt-0.7.8-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f11b300027ce19a34f6d24ebb0a25fd0e24a9d53353225a5c1e6cadbf2916b2e"},
-    {file = "librt-0.7.8-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:4adc73614f0d3c97874f02f2c7fd2a27854e7e24ad532ea6b965459c5b757eca"},
-    {file = "librt-0.7.8-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:60c299e555f87e4c01b2eca085dfccda1dde87f5a604bb45c2906b8305819a93"},
-    {file = "librt-0.7.8-cp313-cp313-win32.whl", hash = "sha256:b09c52ed43a461994716082ee7d87618096851319bf695d57ec123f2ab708951"},
-    {file = "librt-0.7.8-cp313-cp313-win_amd64.whl", hash = "sha256:f8f4a901a3fa28969d6e4519deceab56c55a09d691ea7b12ca830e2fa3461e34"},
-    {file = "librt-0.7.8-cp313-cp313-win_arm64.whl", hash = "sha256:43d4e71b50763fcdcf64725ac680d8cfa1706c928b844794a7aa0fa9ac8e5f09"},
-    {file = "librt-0.7.8-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:be927c3c94c74b05128089a955fba86501c3b544d1d300282cc1b4bd370cb418"},
-    {file = "librt-0.7.8-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:7b0803e9008c62a7ef79058233db7ff6f37a9933b8f2573c05b07ddafa226611"},
-    {file = "librt-0.7.8-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:79feb4d00b2a4e0e05c9c56df707934f41fcb5fe53fd9efb7549068d0495b758"},
-    {file = "librt-0.7.8-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b9122094e3f24aa759c38f46bd8863433820654927370250f460ae75488b66ea"},
-    {file = "librt-0.7.8-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7e03bea66af33c95ce3addf87a9bf1fcad8d33e757bc479957ddbc0e4f7207ac"},
-    {file = "librt-0.7.8-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:f1ade7f31675db00b514b98f9ab9a7698c7282dad4be7492589109471852d398"},
-    {file = "librt-0.7.8-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:a14229ac62adcf1b90a15992f1ab9c69ae8b99ffb23cb64a90878a6e8a2f5b81"},
-    {file = "librt-0.7.8-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5bcaaf624fd24e6a0cb14beac37677f90793a96864c67c064a91458611446e83"},
-    {file = "librt-0.7.8-cp314-cp314-win32.whl", hash = "sha256:7aa7d5457b6c542ecaed79cec4ad98534373c9757383973e638ccced0f11f46d"},
-    {file = "librt-0.7.8-cp314-cp314-win_amd64.whl", hash = "sha256:3d1322800771bee4a91f3b4bd4e49abc7d35e65166821086e5afd1e6c0d9be44"},
-    {file = "librt-0.7.8-cp314-cp314-win_arm64.whl", hash = "sha256:5363427bc6a8c3b1719f8f3845ea53553d301382928a86e8fab7984426949bce"},
-    {file = "librt-0.7.8-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:ca916919793a77e4a98d4a1701e345d337ce53be4a16620f063191f7322ac80f"},
-    {file = "librt-0.7.8-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:54feb7b4f2f6706bb82325e836a01be805770443e2400f706e824e91f6441dde"},
-    {file = "librt-0.7.8-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:39a4c76fee41007070f872b648cc2f711f9abf9a13d0c7162478043377b52c8e"},
-    {file = "librt-0.7.8-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ac9c8a458245c7de80bc1b9765b177055efff5803f08e548dd4bb9ab9a8d789b"},
-    {file = "librt-0.7.8-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:95b67aa7eff150f075fda09d11f6bfb26edffd300f6ab1666759547581e8f666"},
-    {file = "librt-0.7.8-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:535929b6eff670c593c34ff435d5440c3096f20fa72d63444608a5aef64dd581"},
-    {file = "librt-0.7.8-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:63937bd0f4d1cb56653dc7ae900d6c52c41f0015e25aaf9902481ee79943b33a"},
-    {file = "librt-0.7.8-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cf243da9e42d914036fd362ac3fa77d80a41cadcd11ad789b1b5eec4daaf67ca"},
-    {file = "librt-0.7.8-cp314-cp314t-win32.whl", hash = "sha256:171ca3a0a06c643bd0a2f62a8944e1902c94aa8e5da4db1ea9a8daf872685365"},
-    {file = "librt-0.7.8-cp314-cp314t-win_amd64.whl", hash = "sha256:445b7304145e24c60288a2f172b5ce2ca35c0f81605f5299f3fa567e189d2e32"},
-    {file = "librt-0.7.8-cp314-cp314t-win_arm64.whl", hash = "sha256:8766ece9de08527deabcd7cb1b4f1a967a385d26e33e536d6d8913db6ef74f06"},
-    {file = "librt-0.7.8-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c7e8f88f79308d86d8f39c491773cbb533d6cb7fa6476f35d711076ee04fceb6"},
-    {file = "librt-0.7.8-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:389bd25a0db916e1d6bcb014f11aa9676cedaa485e9ec3752dfe19f196fd377b"},
-    {file = "librt-0.7.8-cp39-cp39-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:73fd300f501a052f2ba52ede721232212f3b06503fa12665408ecfc9d8fd149c"},
-    {file = "librt-0.7.8-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d772edc6a5f7835635c7562f6688e031f0b97e31d538412a852c49c9a6c92d5"},
-    {file = "librt-0.7.8-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bfde8a130bd0f239e45503ab39fab239ace094d63ee1d6b67c25a63d741c0f71"},
-    {file = "librt-0.7.8-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:fdec6e2368ae4f796fc72fad7fd4bd1753715187e6d870932b0904609e7c878e"},
-    {file = "librt-0.7.8-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:00105e7d541a8f2ee5be52caacea98a005e0478cfe78c8080fbb7b5d2b340c63"},
-    {file = "librt-0.7.8-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:c6f8947d3dfd7f91066c5b4385812c18be26c9d5a99ca56667547f2c39149d94"},
-    {file = "librt-0.7.8-cp39-cp39-win32.whl", hash = "sha256:41d7bb1e07916aeb12ae4a44e3025db3691c4149ab788d0315781b4d29b86afb"},
-    {file = "librt-0.7.8-cp39-cp39-win_amd64.whl", hash = "sha256:e90a8e237753c83b8e484d478d9a996dc5e39fd5bd4c6ce32563bc8123f132be"},
-    {file = "librt-0.7.8.tar.gz", hash = "sha256:1a4ede613941d9c3470b0368be851df6bb78ab218635512d0370b27a277a0862"},
+    {file = "librt-0.8.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:db63cf3586a24241e89ca1ce0b56baaec9d371a328bd186c529b27c914c9a1ef"},
+    {file = "librt-0.8.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:ba9d9e60651615bc614be5e21a82cdb7b1769a029369cf4b4d861e4f19686fb6"},
+    {file = "librt-0.8.0-cp310-cp310-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:cb4b3ad543084ed79f186741470b251b9d269cd8b03556f15a8d1a99a64b7de5"},
+    {file = "librt-0.8.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3d2720335020219197380ccfa5c895f079ac364b4c429e96952cd6509934d8eb"},
+    {file = "librt-0.8.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9726305d3e53419d27fc8cdfcd3f9571f0ceae22fa6b5ea1b3662c2e538f833e"},
+    {file = "librt-0.8.0-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:cc3d107f603b5ee7a79b6aa6f166551b99b32fb4a5303c4dfcb4222fc6a0335e"},
+    {file = "librt-0.8.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:41064a0c07b4cc7a81355ccc305cb097d6027002209ffca51306e65ee8293630"},
+    {file = "librt-0.8.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:c6e4c10761ddbc0d67d2f6e2753daf99908db85d8b901729bf2bf5eaa60e0567"},
+    {file = "librt-0.8.0-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:ba581acad5ac8f33e2ff1746e8a57e001b47c6721873121bf8bbcf7ba8bd3aa4"},
+    {file = "librt-0.8.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:bdab762e2c0b48bab76f1a08acb3f4c77afd2123bedac59446aeaaeed3d086cf"},
+    {file = "librt-0.8.0-cp310-cp310-win32.whl", hash = "sha256:6a3146c63220d814c4a2c7d6a1eacc8d5c14aed0ff85115c1dfea868080cd18f"},
+    {file = "librt-0.8.0-cp310-cp310-win_amd64.whl", hash = "sha256:bbebd2bba5c6ae02907df49150e55870fdd7440d727b6192c46b6f754723dde9"},
+    {file = "librt-0.8.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0ce33a9778e294507f3a0e3468eccb6a698b5166df7db85661543eca1cfc5369"},
+    {file = "librt-0.8.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:8070aa3368559de81061ef752770d03ca1f5fc9467d4d512d405bd0483bfffe6"},
+    {file = "librt-0.8.0-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:20f73d4fecba969efc15cdefd030e382502d56bb6f1fc66b580cce582836c9fa"},
+    {file = "librt-0.8.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a512c88900bdb1d448882f5623a0b1ad27ba81a9bd75dacfe17080b72272ca1f"},
+    {file = "librt-0.8.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:015e2dde6e096d27c10238bf9f6492ba6c65822dfb69d2bf74c41a8e88b7ddef"},
+    {file = "librt-0.8.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1c25a131013eadd3c600686a0c0333eb2896483cbc7f65baa6a7ee761017aef9"},
+    {file = "librt-0.8.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:21b14464bee0b604d80a638cf1ee3148d84ca4cc163dcdcecb46060c1b3605e4"},
+    {file = "librt-0.8.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:05a3dd3f116747f7e1a2b475ccdc6fb637fd4987126d109e03013a79d40bf9e6"},
+    {file = "librt-0.8.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:fa37f99bff354ff191c6bcdffbc9d7cdd4fc37faccfc9be0ef3a4fd5613977da"},
+    {file = "librt-0.8.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:1566dbb9d1eb0987264c9b9460d212e809ba908d2f4a3999383a84d765f2f3f1"},
+    {file = "librt-0.8.0-cp311-cp311-win32.whl", hash = "sha256:70defb797c4d5402166787a6b3c66dfb3fa7f93d118c0509ffafa35a392f4258"},
+    {file = "librt-0.8.0-cp311-cp311-win_amd64.whl", hash = "sha256:db953b675079884ffda33d1dca7189fb961b6d372153750beb81880384300817"},
+    {file = "librt-0.8.0-cp311-cp311-win_arm64.whl", hash = "sha256:75d1a8cab20b2043f03f7aab730551e9e440adc034d776f15f6f8d582b0a5ad4"},
+    {file = "librt-0.8.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:17269dd2745dbe8e42475acb28e419ad92dfa38214224b1b01020b8cac70b645"},
+    {file = "librt-0.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f4617cef654fca552f00ce5ffdf4f4b68770f18950e4246ce94629b789b92467"},
+    {file = "librt-0.8.0-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:5cb11061a736a9db45e3c1293cfcb1e3caf205912dfa085734ba750f2197ff9a"},
+    {file = "librt-0.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b4bb00bd71b448f16749909b08a0ff16f58b079e2261c2e1000f2bbb2a4f0a45"},
+    {file = "librt-0.8.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:95a719a049f0eefaf1952673223cf00d442952273cbd20cf2ed7ec423a0ef58d"},
+    {file = "librt-0.8.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:bd32add59b58fba3439d48d6f36ac695830388e3da3e92e4fc26d2d02670d19c"},
+    {file = "librt-0.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4f764b2424cb04524ff7a486b9c391e93f93dc1bd8305b2136d25e582e99aa2f"},
+    {file = "librt-0.8.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:f04ca50e847abc486fa8f4107250566441e693779a5374ba211e96e238f298b9"},
+    {file = "librt-0.8.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:9ab3a3475a55b89b87ffd7e6665838e8458e0b596c22e0177e0f961434ec474a"},
+    {file = "librt-0.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3e36a8da17134ffc29373775d88c04832f9ecfab1880470661813e6c7991ef79"},
+    {file = "librt-0.8.0-cp312-cp312-win32.whl", hash = "sha256:4eb5e06ebcc668677ed6389164f52f13f71737fc8be471101fa8b4ce77baeb0c"},
+    {file = "librt-0.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:0a33335eb59921e77c9acc05d0e654e4e32e45b014a4d61517897c11591094f8"},
+    {file = "librt-0.8.0-cp312-cp312-win_arm64.whl", hash = "sha256:24a01c13a2a9bdad20997a4443ebe6e329df063d1978bbe2ebbf637878a46d1e"},
+    {file = "librt-0.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:7f820210e21e3a8bf8fde2ae3c3d10106d4de9ead28cbfdf6d0f0f41f5b12fa1"},
+    {file = "librt-0.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4831c44b8919e75ca0dfb52052897c1ef59fdae19d3589893fbd068f1e41afbf"},
+    {file = "librt-0.8.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:88c6e75540f1f10f5e0fc5e87b4b6c290f0e90d1db8c6734f670840494764af8"},
+    {file = "librt-0.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9646178cd794704d722306c2c920c221abbf080fede3ba539d5afdec16c46dad"},
+    {file = "librt-0.8.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6e1af31a710e17891d9adf0dbd9a5fcd94901a3922a96499abdbf7ce658f4e01"},
+    {file = "librt-0.8.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:507e94f4bec00b2f590fbe55f48cd518a208e2474a3b90a60aa8f29136ddbada"},
+    {file = "librt-0.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f1178e0de0c271231a660fbef9be6acdfa1d596803464706862bef6644cc1cae"},
+    {file = "librt-0.8.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:71fc517efc14f75c2f74b1f0a5d5eb4a8e06aa135c34d18eaf3522f4a53cd62d"},
+    {file = "librt-0.8.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:0583aef7e9a720dd40f26a2ad5a1bf2ccbb90059dac2b32ac516df232c701db3"},
+    {file = "librt-0.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5d0f76fc73480d42285c609c0ea74d79856c160fa828ff9aceab574ea4ecfd7b"},
+    {file = "librt-0.8.0-cp313-cp313-win32.whl", hash = "sha256:e79dbc8f57de360f0ed987dc7de7be814b4803ef0e8fc6d3ff86e16798c99935"},
+    {file = "librt-0.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:25b3e667cbfc9000c4740b282df599ebd91dbdcc1aa6785050e4c1d6be5329ab"},
+    {file = "librt-0.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:e9a3a38eb4134ad33122a6d575e6324831f930a771d951a15ce232e0237412c2"},
+    {file = "librt-0.8.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:421765e8c6b18e64d21c8ead315708a56fc24f44075059702e421d164575fdda"},
+    {file = "librt-0.8.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:48f84830a8f8ad7918afd743fd7c4eb558728bceab7b0e38fd5a5cf78206a556"},
+    {file = "librt-0.8.0-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:9f09d4884f882baa39a7e36bbf3eae124c4ca2a223efb91e567381d1c55c6b06"},
+    {file = "librt-0.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:693697133c3b32aa9b27f040e3691be210e9ac4d905061859a9ed519b1d5a376"},
+    {file = "librt-0.8.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5512aae4648152abaf4d48b59890503fcbe86e85abc12fb9b096fe948bdd816"},
+    {file = "librt-0.8.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:995d24caa6bbb34bcdd4a41df98ac6d1af637cfa8975cb0790e47d6623e70e3e"},
+    {file = "librt-0.8.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b9aef96d7593584e31ef6ac1eb9775355b0099fee7651fae3a15bc8657b67b52"},
+    {file = "librt-0.8.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:4f6e975377fbc4c9567cb33ea9ab826031b6c7ec0515bfae66a4fb110d40d6da"},
+    {file = "librt-0.8.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:daae5e955764be8fd70a93e9e5133c75297f8bce1e802e1d3683b98f77e1c5ab"},
+    {file = "librt-0.8.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7bd68cebf3131bb920d5984f75fe302d758db33264e44b45ad139385662d7bc3"},
+    {file = "librt-0.8.0-cp314-cp314-win32.whl", hash = "sha256:1e6811cac1dcb27ca4c74e0ca4a5917a8e06db0d8408d30daee3a41724bfde7a"},
+    {file = "librt-0.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:178707cda89d910c3b28bf5aa5f69d3d4734e0f6ae102f753ad79edef83a83c7"},
+    {file = "librt-0.8.0-cp314-cp314-win_arm64.whl", hash = "sha256:3e8b77b5f54d0937b26512774916041756c9eb3e66f1031971e626eea49d0bf4"},
+    {file = "librt-0.8.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:789911e8fa40a2e82f41120c936b1965f3213c67f5a483fc5a41f5839a05dcbb"},
+    {file = "librt-0.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:2b37437e7e4ef5e15a297b36ba9e577f73e29564131d86dd75875705e97402b5"},
+    {file = "librt-0.8.0-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:671a6152edf3b924d98a5ed5e6982ec9cb30894085482acadce0975f031d4c5c"},
+    {file = "librt-0.8.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8992ca186a1678107b0af3d0c9303d8c7305981b9914989b9788319ed4d89546"},
+    {file = "librt-0.8.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:001e5330093d887b8b9165823eca6c5c4db183fe4edea4fdc0680bbac5f46944"},
+    {file = "librt-0.8.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d920789eca7ef71df7f31fd547ec0d3002e04d77f30ba6881e08a630e7b2c30e"},
+    {file = "librt-0.8.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:82fb4602d1b3e303a58bfe6165992b5a78d823ec646445356c332cd5f5bbaa61"},
+    {file = "librt-0.8.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:4d3e38797eb482485b486898f89415a6ab163bc291476bd95712e42cf4383c05"},
+    {file = "librt-0.8.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:a905091a13e0884701226860836d0386b88c72ce5c2fdfba6618e14c72be9f25"},
+    {file = "librt-0.8.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:375eda7acfce1f15f5ed56cfc960669eefa1ec8732e3e9087c3c4c3f2066759c"},
+    {file = "librt-0.8.0-cp314-cp314t-win32.whl", hash = "sha256:2ccdd20d9a72c562ffb73098ac411de351b53a6fbb3390903b2d33078ef90447"},
+    {file = "librt-0.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:25e82d920d4d62ad741592fcf8d0f3bda0e3fc388a184cb7d2f566c681c5f7b9"},
+    {file = "librt-0.8.0-cp314-cp314t-win_arm64.whl", hash = "sha256:92249938ab744a5890580d3cb2b22042f0dce71cdaa7c1369823df62bedf7cbc"},
+    {file = "librt-0.8.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4b705f85311ee76acec5ee70806990a51f0deb519ea0c29c1d1652d79127604d"},
+    {file = "librt-0.8.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7ce0a8cb67e702dcb06342b2aaaa3da9fb0ddc670417879adfa088b44cf7b3b6"},
+    {file = "librt-0.8.0-cp39-cp39-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:aaadec87f45a3612b6818d1db5fbfe93630669b7ee5d6bdb6427ae08a1aa2141"},
+    {file = "librt-0.8.0-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:56901f1eec031396f230db71c59a01d450715cbbef9856bf636726994331195d"},
+    {file = "librt-0.8.0-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b055bb3abaf69abed25743d8fc1ab691e4f51a912ee0a6f9a6c84f4bbddb283d"},
+    {file = "librt-0.8.0-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1ef3bd856373cf8e7382402731f43bfe978a8613b4039e49e166e1e0dc590216"},
+    {file = "librt-0.8.0-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:2e0ffe88ebb5962f8fb0ddcbaaff30f1ea06a79501069310e1e030eafb1ad787"},
+    {file = "librt-0.8.0-cp39-cp39-musllinux_1_2_i686.whl", hash = "sha256:82e61cd1c563745ad495387c3b65806bfd453badb4adbc019df3389dddee1bf6"},
+    {file = "librt-0.8.0-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:667e2513cf69bfd1e1ed9a00d6c736d5108714ec071192afb737987955888a25"},
+    {file = "librt-0.8.0-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:6b6caff69e25d80c269b1952be8493b4d94ef745f438fa619d7931066bdd26de"},
+    {file = "librt-0.8.0-cp39-cp39-win32.whl", hash = "sha256:02a9fe85410cc9bef045e7cb7fd26fdde6669e6d173f99df659aa7f6335961e9"},
+    {file = "librt-0.8.0-cp39-cp39-win_amd64.whl", hash = "sha256:de076eaba208d16efb5962f99539867f8e2c73480988cb513fcf1b5dbb0c9dcf"},
+    {file = "librt-0.8.0.tar.gz", hash = "sha256:cb74cdcbc0103fc988e04e5c58b0b31e8e5dd2babb9182b6f9490488eb36324b"},
 ]
 
 [[package]]
@@ -2034,26 +2058,24 @@ typing-extensions = ">=4.5.0"
 
 [[package]]
 name = "ops"
-version = "2.21.1"
+version = "3.5.2"
 description = "The Python library behind great charms"
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["main", "charm-libs", "integration"]
 files = [
-    {file = "ops-2.21.1-py3-none-any.whl", hash = "sha256:6745084c8e73bc485c254f95664bd85ddcf786c91b90782f2830c8333a1440b2"},
-    {file = "ops-2.21.1.tar.gz", hash = "sha256:4a8190420813ba37e7a0399d656008f99c79015d7f72e138bad7cb1ac403d0b0"},
+    {file = "ops-3.5.2-py3-none-any.whl", hash = "sha256:c715128a51ddcdf0fff463428b0f56a93e5963187e599b66594b4fc74458781b"},
+    {file = "ops-3.5.2.tar.gz", hash = "sha256:849c9ed85eadf265b8a927d5e857cd112221dd71b35e4b13329ccb938c3afd18"},
 ]
 
 [package.dependencies]
-importlib-metadata = "*"
 opentelemetry-api = ">=1.0,<2.0"
 PyYAML = "==6.*"
 websocket-client = "==1.*"
 
 [package.extras]
-docs = ["canonical-sphinx-extensions", "furo", "linkify-it-py", "myst-parser", "pyspelling", "sphinx (>=8.0.0,<8.1.0)", "sphinx-autobuild", "sphinx-copybutton", "sphinx-design", "sphinx-notfound-page", "sphinx-tabs", "sphinxcontrib-jquery", "sphinxext-opengraph"]
-testing = ["ops-scenario (==7.21.1)"]
-tracing = ["ops-tracing (==2.21.1)"]
+testing = ["ops-scenario (==8.5.2)"]
+tracing = ["ops-tracing (==3.5.2)"]
 
 [[package]]
 name = "overrides"
@@ -2117,30 +2139,30 @@ gssapi = ["gssapi (>=1.4.1) ; platform_system != \"Windows\"", "pyasn1 (>=0.1.7)
 
 [[package]]
 name = "parso"
-version = "0.8.5"
+version = "0.8.6"
 description = "A Python Parser"
 optional = false
 python-versions = ">=3.6"
 groups = ["integration"]
 files = [
-    {file = "parso-0.8.5-py2.py3-none-any.whl", hash = "sha256:646204b5ee239c396d040b90f9e272e9a8017c630092bf59980beb62fd033887"},
-    {file = "parso-0.8.5.tar.gz", hash = "sha256:034d7354a9a018bdce352f48b2a8a450f05e9d6ee85db84764e9b6bd96dafe5a"},
+    {file = "parso-0.8.6-py2.py3-none-any.whl", hash = "sha256:2c549f800b70a5c4952197248825584cb00f033b29c692671d3bf08bf380baff"},
+    {file = "parso-0.8.6.tar.gz", hash = "sha256:2b9a0332696df97d454fa67b81618fd69c35a7b90327cbe6ba5c92d2c68a7bfd"},
 ]
 
 [package.extras]
-qa = ["flake8 (==5.0.4)", "mypy (==0.971)", "types-setuptools (==67.2.0.1)"]
+qa = ["flake8 (==5.0.4)", "types-setuptools (==67.2.0.1)", "zuban (==0.5.1)"]
 testing = ["docopt", "pytest"]
 
 [[package]]
 name = "pathspec"
-version = "1.0.3"
+version = "1.0.4"
 description = "Utility library for gitignore style pattern matching of file paths."
 optional = false
 python-versions = ">=3.9"
 groups = ["dev", "format", "lint"]
 files = [
-    {file = "pathspec-1.0.3-py3-none-any.whl", hash = "sha256:e80767021c1cc524aa3fb14bedda9c34406591343cc42797b386ce7b9354fb6c"},
-    {file = "pathspec-1.0.3.tar.gz", hash = "sha256:bac5cf97ae2c2876e2d25ebb15078eb04d76e4b98921ee31c6f85ade8b59444d"},
+    {file = "pathspec-1.0.4-py3-none-any.whl", hash = "sha256:fb6ae2fd4e7c921a165808a552060e722767cfa526f99ca5156ed2ce45a5c723"},
+    {file = "pathspec-1.0.4.tar.gz", hash = "sha256:0210e2ae8a21a9137c0d470578cb0e595af87edaa6ebf12ff176f14a02e0e645"},
 ]
 
 [package.extras]
@@ -2167,20 +2189,15 @@ ptyprocess = ">=0.5"
 
 [[package]]
 name = "platformdirs"
-version = "4.5.1"
+version = "4.9.2"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "platformdirs-4.5.1-py3-none-any.whl", hash = "sha256:d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31"},
-    {file = "platformdirs-4.5.1.tar.gz", hash = "sha256:61d5cdcc6065745cdd94f0f878977f8de9437be93de97c1c12f853c9c0cdcbda"},
+    {file = "platformdirs-4.9.2-py3-none-any.whl", hash = "sha256:9170634f126f8efdae22fb58ae8a0eaa86f38365bc57897a6c4f781d1f5875bd"},
+    {file = "platformdirs-4.9.2.tar.gz", hash = "sha256:9a33809944b9db043ad67ca0db94b14bf452cc6aeaac46a88ea55b26e2e9d291"},
 ]
-
-[package.extras]
-docs = ["furo (>=2025.9.25)", "proselint (>=0.14)", "sphinx (>=8.2.3)", "sphinx-autodoc-typehints (>=3.2)"]
-test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=8.4.2)", "pytest-cov (>=7)", "pytest-mock (>=3.15.1)"]
-type = ["mypy (>=1.18.2)"]
 
 [[package]]
 name = "pluggy"
@@ -2200,14 +2217,14 @@ testing = ["coverage", "pytest", "pytest-benchmark"]
 
 [[package]]
 name = "poetry-core"
-version = "2.3.0"
+version = "2.3.1"
 description = "Poetry PEP 517 Build Backend"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "poetry_core-2.3.0-py3-none-any.whl", hash = "sha256:fc42f3854e346e4b96fb2b38d29e6873ec2ed25fbd7b8f1afba06613a966eaef"},
-    {file = "poetry_core-2.3.0.tar.gz", hash = "sha256:f6da8f021fe380d8c9716085f4dcc5d26a5120a2452e077196333892af5de307"},
+    {file = "poetry_core-2.3.1-py3-none-any.whl", hash = "sha256:db1cf63b782570deb38bfba61e2304a553eef0740dc17959a50cc0f5115ee634"},
+    {file = "poetry_core-2.3.1.tar.gz", hash = "sha256:96f791d5d7d4e040f3983d76779425cf9532690e2756a24fd5ca0f86af19ef82"},
 ]
 
 [[package]]
@@ -2469,14 +2486,14 @@ typing-extensions = ">=4.6.0,<4.7.0 || >4.7.0"
 
 [[package]]
 name = "pydantic-settings"
-version = "2.12.0"
+version = "2.13.0"
 description = "Settings management using Pydantic"
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "charm-libs"]
 files = [
-    {file = "pydantic_settings-2.12.0-py3-none-any.whl", hash = "sha256:fddb9fd99a5b18da837b29710391e945b1e30c135477f484084ee513adb93809"},
-    {file = "pydantic_settings-2.12.0.tar.gz", hash = "sha256:005538ef951e3c2a68e1c08b292b5f2e71490def8589d4221b95dab00dafcfd0"},
+    {file = "pydantic_settings-2.13.0-py3-none-any.whl", hash = "sha256:d67b576fff39cd086b595441bf9c75d4193ca9c0ed643b90360694d0f1240246"},
+    {file = "pydantic_settings-2.13.0.tar.gz", hash = "sha256:95d875514610e8595672800a5c40b073e99e4aae467fa7c8f9c263061ea2e1fe"},
 ]
 
 [package.dependencies]
@@ -2954,14 +2971,14 @@ rsa = ["oauthlib[signedtoken] (>=3.0.0)"]
 
 [[package]]
 name = "rich"
-version = "14.2.0"
+version = "14.3.2"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 optional = false
 python-versions = ">=3.8.0"
 groups = ["main"]
 files = [
-    {file = "rich-14.2.0-py3-none-any.whl", hash = "sha256:76bc51fe2e57d2b1be1f96c524b890b816e334ab4c1e45888799bfaab0021edd"},
-    {file = "rich-14.2.0.tar.gz", hash = "sha256:73ff50c7c0c1c77c8243079283f4edb376f0f6442433aecb8ce7e6d0b92d1fe4"},
+    {file = "rich-14.3.2-py3-none-any.whl", hash = "sha256:08e67c3e90884651da3239ea668222d19bea7b589149d8014a21c633420dbb69"},
+    {file = "rich-14.3.2.tar.gz", hash = "sha256:e712f11c1a562a11843306f5ed999475f09ac31ffb64281f73ab29ffdda8b3b8"},
 ]
 
 [package.dependencies]
@@ -3334,14 +3351,14 @@ test = ["argcomplete (>=3.0.3)", "mypy (>=1.7.0)", "pre-commit", "pytest (>=7.0,
 
 [[package]]
 name = "types-python-dateutil"
-version = "2.9.0.20251115"
+version = "2.9.0.20260124"
 description = "Typing stubs for python-dateutil"
 optional = false
 python-versions = ">=3.9"
 groups = ["dev"]
 files = [
-    {file = "types_python_dateutil-2.9.0.20251115-py3-none-any.whl", hash = "sha256:9cf9c1c582019753b8639a081deefd7e044b9fa36bd8217f565c6c4e36ee0624"},
-    {file = "types_python_dateutil-2.9.0.20251115.tar.gz", hash = "sha256:8a47f2c3920f52a994056b8786309b43143faa5a64d4cbb2722d6addabdf1a58"},
+    {file = "types_python_dateutil-2.9.0.20260124-py3-none-any.whl", hash = "sha256:f802977ae08bf2260142e7ca1ab9d4403772a254409f7bbdf652229997124951"},
+    {file = "types_python_dateutil-2.9.0.20260124.tar.gz", hash = "sha256:7d2db9f860820c30e5b8152bfe78dbdf795f7d1c6176057424e8b3fdd1f581af"},
 ]
 
 [[package]]
@@ -3455,14 +3472,14 @@ test = ["covdefaults (>=2.3)", "coverage (>=7.2.7)", "coverage-enable-subprocess
 
 [[package]]
 name = "wcwidth"
-version = "0.3.1"
+version = "0.6.0"
 description = "Measures the displayed width of unicode strings in a terminal"
 optional = false
 python-versions = ">=3.8"
 groups = ["integration"]
 files = [
-    {file = "wcwidth-0.3.1-py3-none-any.whl", hash = "sha256:b2d355df3ec5d51bfc973a22fb4ea9a03b12fdcbf00d0abd22a2c78b12ccc177"},
-    {file = "wcwidth-0.3.1.tar.gz", hash = "sha256:5aedb626a9c0d941b990cfebda848d538d45c9493a3384d080aff809143bd3be"},
+    {file = "wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad"},
+    {file = "wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159"},
 ]
 
 [[package]]
@@ -3576,4 +3593,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4.0"
-content-hash = "1cbaff9697ba94202755961d8f525ae5375ef7cca3134d9ee700659fd961e586"
+content-hash = "ae947d942ba3151cab6e58f5fa5c9dfd568faa2a5488215680f7ecdce4d1f453"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ requires-python = ">=3.10,<4.0"
 
 dependencies = [
     "poetry-core (>=2.0)",
-    "ops (~=2.21.1)",
+    "ops (~=3.5.2)",
     "overrides (~=7.7.0)",
     "cryptography",  # tls_certificates lib v3
     "jsonschema (~=4.24.0)",  # tls_certificates lib v3
@@ -79,7 +79,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 [tool.poetry.group.charm-libs.dependencies]
 cryptography = "*"  # tls_certificates lib v3
 jsonschema = "^4.24.0"  # tls_certificates lib v3
-ops = "~2.21.1"
+ops = "~3.5.2"
 pydantic = "~2.11.0"
 pydantic-settings = "*"
 pymongo = "*"
@@ -132,7 +132,7 @@ pytest-operator = "^0.36.0"
 parameterized = "^0.9.0"
 allure-pytest = "^2.13.5"
 allure-pytest-default-results = "^0.1.2"
-ops = "~2.21.1"
+ops = "~3.5.2"
 tenacity = "~9.0.0"
 more_itertools = "*"
 httpx = "*"

--- a/single_kernel_mongo/config/literals.py
+++ b/single_kernel_mongo/config/literals.py
@@ -116,3 +116,7 @@ class TrustStoreFiles(str, Enum):
 
     PBM = "pbm.crt"
     LDAP = "ldap.crt"
+
+
+# The specific extra-binding `juju-info`
+JUJU_INFO = "juju-info"

--- a/single_kernel_mongo/config/literals.py
+++ b/single_kernel_mongo/config/literals.py
@@ -116,7 +116,3 @@ class TrustStoreFiles(str, Enum):
 
     PBM = "pbm.crt"
     LDAP = "ldap.crt"
-
-
-# The specific extra-binding `juju-info`
-JUJU_INFO = "juju-info"

--- a/single_kernel_mongo/events/cluster.py
+++ b/single_kernel_mongo/events/cluster.py
@@ -78,6 +78,8 @@ class ClusterConfigServerEventHandler(Object):
             defer_event_with_info_log(logger, event, str(type(event)), str(e))
         except NonDeferrableFailedHookChecksError as e:
             logger.info(f"Skipping {str(type(event))}: {str(e)}")
+        except DatabaseRequestedHasNotRunYetError:
+            logger.info("Database requested has not run yet, skipping.")
 
     def _on_relation_event(self, event: RelationChangedEvent) -> None:
         """Handle relation changed events."""
@@ -87,6 +89,8 @@ class ClusterConfigServerEventHandler(Object):
             defer_event_with_info_log(logger, event, str(type(event)), str(e))
         except NonDeferrableFailedHookChecksError as e:
             logger.info(f"Skipping {str(type(event))}: {str(e)}")
+        except DatabaseRequestedHasNotRunYetError:
+            logger.info("Database requested has not run yet, skipping.")
 
     def _on_relation_broken_event(self, event: RelationBrokenEvent) -> None:
         """During a relation broken event, the manager will cleanup the users."""

--- a/single_kernel_mongo/managers/cluster.py
+++ b/single_kernel_mongo/managers/cluster.py
@@ -95,7 +95,7 @@ class ClusterProvider(Object):
         """
         self.assert_pass_hook_checks(initial_event=initial_event)
 
-        config_server_db = self.state.generate_config_server_db()
+        config_server_db = self.state.generate_config_server_db(relation)
         self.dependent.mongo_manager.reconcile_mongo_users_and_dbs(relation)
         relation_data = {
             ClusterStateKeys.KEYFILE.value: self.state.get_keyfile(),
@@ -159,11 +159,11 @@ class ClusterProvider(Object):
         """Updates the config server DB URI in the mongos relation."""
         self.assert_pass_hook_checks()
 
-        config_server_db = self.state.generate_config_server_db()
         for relation in self.state.cluster_relations:
             if not self.data_interface.fetch_relation_field(relation.id, "database"):
                 logger.info("Database Requested has not run yet, skipping.")
                 continue
+            config_server_db = self.state.generate_config_server_db(relation)
             self.data_interface.update_relation_data(
                 relation.id,
                 {

--- a/single_kernel_mongo/managers/config.py
+++ b/single_kernel_mongo/managers/config.py
@@ -314,7 +314,7 @@ class MongoConfigManager(FileBasedConfigManager, ABC):
                     },
                 },
             }
-        return {"net": {"bindIp": ",".join(self.state.listen_ips())}}
+        return {"net": {"bindIp": ",".join(self.state.listens_on())}}
 
     @property
     def log_options(self) -> dict[str, Any]:

--- a/single_kernel_mongo/managers/config.py
+++ b/single_kernel_mongo/managers/config.py
@@ -314,7 +314,7 @@ class MongoConfigManager(FileBasedConfigManager, ABC):
                     },
                 },
             }
-        return {"net": {"bindIp": ",".join(self.state.listens_on())}}
+        return {"net": {"bindIp": ",".join(sorted(self.state.listens_on()))}}
 
     @property
     def log_options(self) -> dict[str, Any]:

--- a/single_kernel_mongo/managers/config.py
+++ b/single_kernel_mongo/managers/config.py
@@ -414,12 +414,13 @@ class MongoDBConfigManager(MongoConfigManager):
     @override
     def cluster_ips(self) -> dict[str, Any]:
         """The allowed cluster IPs."""
-        ...
         # Always include IPs from the local peer relation
         cidrs_list = cidrs(self.state.peer_network().bind_addresses)
         # The config server should include the CIDR for the shards
         if self.state.is_role(MongoDBRoles.CONFIG_SERVER):
             cidrs_list.extend(cidrs(self.state.config_server_network().bind_addresses))
+            # For the local mongos
+            cidrs_list.append("127.0.0.1")
         # The shards should include the CIDR for the config server
         if self.state.is_role(MongoDBRoles.SHARD):
             cidrs_list.extend(cidrs(self.state.sharding_network().bind_addresses))
@@ -428,9 +429,6 @@ class MongoDBConfigManager(MongoConfigManager):
         # All cluster components (config server, mongos) should include the CIDRs of its counterpart
         if self.state.is_cluster_component:
             cidrs_list.extend(cidrs(self.state.cluster_network().bind_addresses))
-
-        # Always append the localhost just in case.
-        cidrs_list.append("127.0.0.1")
 
         # Deduplicate the list
         return {"security": {"clusterIpSourceAllowlist": sorted(set(cidrs_list))}}

--- a/single_kernel_mongo/managers/config.py
+++ b/single_kernel_mongo/managers/config.py
@@ -306,7 +306,7 @@ class MongoConfigManager(FileBasedConfigManager, ABC):
                     },
                 },
             }
-        return {"net": {"bindIpAll": True}}
+        return {"net": {"bindIp": ",".join(self.state.listen_ips())}}
 
     @property
     def log_options(self) -> dict[str, Any]:

--- a/single_kernel_mongo/managers/config.py
+++ b/single_kernel_mongo/managers/config.py
@@ -33,6 +33,7 @@ from single_kernel_mongo.utils.mongodb_users import (
     CharmedLogRotateUser,
     CharmedStatsUser,
 )
+from single_kernel_mongo.utils.network_helpers import cidrs
 from single_kernel_mongo.workload import (
     get_logrotate_workload_for_substrate,
     get_mongodb_exporter_workload_for_substrate,
@@ -271,6 +272,7 @@ class MongoConfigManager(FileBasedConfigManager, ABC):
             always_merger.merge,
             [
                 self.binding_ips,
+                self.cluster_ips,
                 self.port_parameter,
                 self.auth_parameter,
                 self.client_tls_parameters,
@@ -279,6 +281,12 @@ class MongoConfigManager(FileBasedConfigManager, ABC):
                 self.ldap_parameters,
             ],
         )
+
+    @property
+    @abstractmethod
+    def cluster_ips(self) -> dict[str, Any]:
+        """The allowed cluster IPs."""
+        ...
 
     @property
     @abstractmethod
@@ -401,6 +409,31 @@ class MongoDBConfigManager(MongoConfigManager):
         self.config = config
         self.file = self.workload.paths.config_file
         self.auth = True
+
+    @property
+    @override
+    def cluster_ips(self) -> dict[str, Any]:
+        """The allowed cluster IPs."""
+        ...
+        # Always include IPs from the local peer relation
+        cidrs_list = cidrs(self.state.peer_network().bind_addresses)
+        # The config server should include the CIDR for the shards
+        if self.state.is_role(MongoDBRoles.CONFIG_SERVER):
+            cidrs_list.extend(cidrs(self.state.config_server_network().bind_addresses))
+        # The shards should include the CIDR for the config server
+        if self.state.is_role(MongoDBRoles.SHARD):
+            cidrs_list.extend(cidrs(self.state.sharding_network().bind_addresses))
+            # The shard should include the cidrs of the mongos charms
+            cidrs_list.extend(self.state.shard_state.mongos_cidrs)
+        # All cluster components (config server, mongos) should include the CIDRs of its counterpart
+        if self.state.is_cluster_component:
+            cidrs_list.extend(cidrs(self.state.cluster_network().bind_addresses))
+
+        # Always append the localhost just in case.
+        cidrs_list.append("127.0.0.1")
+
+        # Deduplicate the list
+        return {"security": {"clusterIpSourceAllowlist": sorted(set(cidrs_list))}}
 
     @property
     def db_path_argument(self) -> dict[str, Any]:
@@ -541,6 +574,12 @@ class MongosConfigManager(MongoConfigManager):
                 self.state.ldap.ldap_user_to_dn_mapping
             )
         return ldap_params
+
+    @property
+    @override
+    def cluster_ips(self) -> dict[str, Any]:
+        """The allowed cluster IPs."""
+        return {}
 
     @override
     def build_config(self) -> dict[str, Any]:

--- a/single_kernel_mongo/managers/mongo.py
+++ b/single_kernel_mongo/managers/mongo.py
@@ -62,6 +62,7 @@ from single_kernel_mongo.utils.mongodb_users import (
 from single_kernel_mongo.utils.network_helpers import (
     cidrs,
     get_cidr_for_ip_list,
+    network_for_relation,
 )
 
 if TYPE_CHECKING:
@@ -646,6 +647,10 @@ class MongoManager(Object, ManagerStatusProtocol):
         ]
 
         return [
+            AuthRestrictions(
+                clientSource=cidrs(network_for_relation(relation).bind_addresses),
+                serverAddress=cidrs(self.state.peer_network().bind_addresses),
+            ),
             AuthRestrictions(
                 clientSource=[get_cidr_for_ip_list(ip_list)],
                 serverAddress=cidrs(self.state.peer_network().bind_addresses),

--- a/single_kernel_mongo/managers/mongo.py
+++ b/single_kernel_mongo/managers/mongo.py
@@ -59,7 +59,10 @@ from single_kernel_mongo.utils.mongodb_users import (
     CharmedStatsUser,
     MongoDBUser,
 )
-from single_kernel_mongo.utils.network_helpers import cidrs, network_for_relation
+from single_kernel_mongo.utils.network_helpers import (
+    cidrs,
+    get_cidr_for_ip_list,
+)
 
 if TYPE_CHECKING:
     from single_kernel_mongo.core.operator import MainWorkloadType, OperatorProtocol
@@ -249,6 +252,10 @@ class MongoManager(Object, ManagerStatusProtocol):
 
         # We do nothing if the Database Requested event has not run yet.
         if not data_interface.fetch_relation_field(relation.id, "database"):
+            logger.info(f"Database Requested for {relation} has not run yet, skipping.")
+            raise DatabaseRequestedHasNotRunYetError
+
+        if not relation.units:
             logger.info(f"Database Requested for {relation} has not run yet, skipping.")
             raise DatabaseRequestedHasNotRunYetError
 
@@ -632,9 +639,15 @@ class MongoManager(Object, ManagerStatusProtocol):
         # - Otherwise it's external connectivity, hence already handled.
         if self.state.is_cluster_component:
             return []
+
+        ip_list = [
+            self.state.unit_peer_data_for(unit, relation).internal_address
+            for unit in relation.units
+        ]
+
         return [
             AuthRestrictions(
-                clientSource=cidrs(network_for_relation(relation).bind_addresses),
+                clientSource=[get_cidr_for_ip_list(ip_list)],
                 serverAddress=cidrs(self.state.peer_network().bind_addresses),
             ),
             AuthRestrictions(

--- a/single_kernel_mongo/managers/mongo.py
+++ b/single_kernel_mongo/managers/mongo.py
@@ -265,10 +265,6 @@ class MongoManager(Object, ManagerStatusProtocol):
             logger.info(f"Database Requested for {relation} has not run yet, skipping.")
             raise DatabaseRequestedHasNotRunYetError
 
-        external_connectivity: bool = json.loads(
-            data_interface.fetch_relation_field(relation.id, "external-node-connectivity")
-            or "false"
-        )
         with MongoConnection(self.state.mongo_config) as mongo:
             has_user = mongo.user_exists(username)
 
@@ -276,9 +272,7 @@ class MongoManager(Object, ManagerStatusProtocol):
         if has_user:
             return
 
-        auth_restrictions = self._compute_auth_restrictions(
-            relation, external_connectivity=external_connectivity
-        )
+        auth_restrictions = self._compute_auth_restrictions(relation, data_interface)
 
         with MongoConnection(self.state.mongo_config) as mongo:
             config = self.get_config(
@@ -650,12 +644,17 @@ class MongoManager(Object, ManagerStatusProtocol):
                     raise FailedToElectNewPrimaryError()
 
     def _compute_auth_restrictions(
-        self, relation: Relation, external_connectivity: bool
+        self, relation: Relation, data_interface: DatabaseProviderData
     ) -> list[AuthRestrictions]:
         """Compute the correct auth restriction rules."""
         # No juju spaces support on K8S.
         if self.substrate == Substrates.K8S:
             return []
+
+        external_connectivity: bool = json.loads(
+            data_interface.fetch_relation_field(relation.id, "external-node-connectivity")
+            or "false"
+        )
         # No restriction on external connectivity for now.
         if external_connectivity:
             return []

--- a/single_kernel_mongo/managers/mongo.py
+++ b/single_kernel_mongo/managers/mongo.py
@@ -52,12 +52,14 @@ from single_kernel_mongo.utils.mongo_config import (
 from single_kernel_mongo.utils.mongo_connection import MongoConnection, NotReadyError
 from single_kernel_mongo.utils.mongodb_users import (
     OPERATOR_ROLE,
+    AuthRestrictions,
     CharmedBackupUser,
     CharmedLogRotateUser,
     CharmedOperatorUser,
     CharmedStatsUser,
     MongoDBUser,
 )
+from single_kernel_mongo.utils.network_helpers import cidrs, network_for_relation
 
 if TYPE_CHECKING:
     from single_kernel_mongo.core.operator import MainWorkloadType, OperatorProtocol
@@ -182,11 +184,14 @@ class MongoManager(Object, ManagerStatusProtocol):
                 privileges=user.privileges,
             )
             logger.info(f"Creating the {user.username} user...")
-            config = self.state.mongodb_config_for_user(user)
+            config = self.state.mongodb_config_for_user(
+                user, auth_restrictions=self.state.local_auth_restrictions
+            )
             mongo.create_user(
                 config.username,
                 config.password,
                 config.supported_roles,
+                auth_restrictions=config.auth_restrictions,
             )
 
         self.state.app_peer_data.set_user_created(user.username)
@@ -247,6 +252,10 @@ class MongoManager(Object, ManagerStatusProtocol):
             logger.info(f"Database Requested for {relation} has not run yet, skipping.")
             raise DatabaseRequestedHasNotRunYetError
 
+        external_connectivity: bool = json.loads(
+            data_interface.fetch_relation_field(relation.id, "external-node-connectivity")
+            or "false"
+        )
         with MongoConnection(self.state.mongo_config) as mongo:
             has_user = mongo.user_exists(username)
 
@@ -254,16 +263,25 @@ class MongoManager(Object, ManagerStatusProtocol):
         if has_user:
             return
 
+        auth_restrictions = self._compute_auth_restrictions(
+            relation, external_connectivity=external_connectivity
+        )
+
         with MongoConnection(self.state.mongo_config) as mongo:
             config = self.get_config(
                 username,
                 None,  # We are creating the user, which means we don't have password for it yet
                 data_interface,
-                relation.id,
+                relation,
             )
             logger.info("Create relation user: %s on %s", config.username, config.database)
 
-            mongo.create_user(config.username, config.password, config.supported_roles)
+            mongo.create_user(
+                config.username,
+                config.password,
+                config.supported_roles,
+                auth_restrictions=auth_restrictions,
+            )
             managed_users.add(username)
             data_interface.set_database(relation.id, config.database)
             data_interface.set_credentials(relation.id, config.username, config.password)
@@ -303,7 +321,7 @@ class MongoManager(Object, ManagerStatusProtocol):
                 username,
                 password,
                 data_interface,
-                relation.id,
+                relation,
             )
 
             logger.info("Update relation user: %s on %s", config.username, config.database)
@@ -375,7 +393,7 @@ class MongoManager(Object, ManagerStatusProtocol):
             username,
             password,
             data_interface,
-            relation.id,
+            relation,
         )
         self.update_app_relation_data_for_config(relation, config)
 
@@ -415,20 +433,21 @@ class MongoManager(Object, ManagerStatusProtocol):
         username: str,
         password: str | None,
         data_inteface: DatabaseProviderData,
-        relation_id: int,
+        relation: Relation,
     ) -> MongoConfiguration:
         """."""
         if not password:
             password = self.workload.generate_password()
-        database_name = data_inteface.fetch_relation_field(relation_id, "database")
-        roles = data_inteface.fetch_relation_field(relation_id, "extra-user-roles") or "default"
+        database_name = data_inteface.fetch_relation_field(relation.id, "database")
+        roles = data_inteface.fetch_relation_field(relation.id, "extra-user-roles") or "default"
         if not database_name or not roles:
             raise Exception("Missing database name or roles.")
+
         mongo_args = {
             "database": database_name,
             "username": username,
             "password": password,
-            "hosts": self.state.app_hosts,
+            "hosts": self.state.hosts_for(relation),
             "roles": set(roles.split(",")),
             "tls_enabled": False,
             "port": self.state.host_port,
@@ -597,3 +616,29 @@ class MongoManager(Object, ManagerStatusProtocol):
                 new_primary = self.dependent.primary_unit_name  # type: ignore
                 if new_primary == old_primary:
                     raise FailedToElectNewPrimaryError()
+
+    def _compute_auth_restrictions(
+        self, relation: Relation, external_connectivity: bool
+    ) -> list[AuthRestrictions]:
+        """Compute the correct auth restriction rules."""
+        # No juju spaces support on K8S.
+        if self.substrate == Substrates.K8S:
+            return []
+        # No restriction on external connectivity for now.
+        if external_connectivity:
+            return []
+        # We can't enforce rules on sharded deployments due to
+        # - No support for socket connection
+        # - Otherwise it's external connectivity, hence already handled.
+        if self.state.is_cluster_component:
+            return []
+        return [
+            AuthRestrictions(
+                clientSource=cidrs(network_for_relation(relation).bind_addresses),
+                serverAddress=cidrs(self.state.peer_network().bind_addresses),
+            ),
+            AuthRestrictions(
+                clientSource=cidrs(self.state.peer_network().bind_addresses),
+                serverAddress=cidrs(self.state.peer_network().bind_addresses),
+            ),
+        ]

--- a/single_kernel_mongo/managers/mongo.py
+++ b/single_kernel_mongo/managers/mongo.py
@@ -219,12 +219,16 @@ class MongoManager(Object, ManagerStatusProtocol):
         Raises:
             PyMongoError
         """
-        self.add_user(relation)
-        self.update_user(relation)
-        if relation_departing:
-            self.remove_user(relation)
-        if relation_changed:
-            self.update_diff(relation)
+        match (relation_departing, relation_changed):
+            case (False, False):
+                self.add_user(relation)
+                self.update_user(relation)
+            case (True, False):
+                self.remove_user(relation)
+            case (False, True):
+                self.update_diff(relation)
+            case (True, True):
+                raise ValueError("This case should never happen")
 
     def update_diff(self, relation: Relation):
         """Update the relation databag with the diff of data.

--- a/single_kernel_mongo/managers/mongo.py
+++ b/single_kernel_mongo/managers/mongo.py
@@ -366,6 +366,17 @@ class MongoManager(Object, ManagerStatusProtocol):
         if self.state.is_role(MongoDBRoles.MONGOS) and username == mongo_config.username:
             return
 
+        # Nothing to do if it's not a user we're managing.
+        if username not in managed_users:
+            return
+
+        with MongoConnection(self.state.mongo_config) as mongo:
+            has_user = mongo.user_exists(username)
+
+        # Don't remove a user that doesn't exist
+        if not has_user:
+            return
+
         # Dropping the admin-user for mongos-k8s-router is done by mongos-k8s charm.
         if self.substrate == Substrates.K8S and self.state.is_role(MongoDBRoles.CONFIG_SERVER):
             logger.info("K8s routers will remove themselves.")

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -107,6 +107,7 @@ from single_kernel_mongo.utils.mongodb_users import (
     get_user_from_username,
     validate_charm_user_password_config,
 )
+from single_kernel_mongo.utils.network_helpers import ip_addresses
 from single_kernel_mongo.workload import (
     get_mongodb_workload_for_substrate,
     get_mongos_workload_for_substrate,
@@ -731,12 +732,15 @@ class MongoDBOperator(OperatorProtocol, Object):
             )
             raise UpgradeInProgressError
 
+        self.update_ips_in_databag()
+
         if not self.charm.unit.is_leader():
             return
 
         self.peer_changed()
         self.update_related_hosts()
 
+    @override
     def peer_changed(self) -> None:
         """Handle relation changed events.
 
@@ -975,6 +979,8 @@ class MongoDBOperator(OperatorProtocol, Object):
             # We can use either manager, what matters is the BackupConfigManager below
             self.s3_backup_manager.configure_and_restart()
 
+        self.update_ips_in_databag()
+
         if not self.charm.unit.is_leader():
             logger.debug("Only the leader can perform reconfigurations to the replica set.")
             return
@@ -989,6 +995,18 @@ class MongoDBOperator(OperatorProtocol, Object):
         # necessary in the case that pre-upgrade hook fails to reset the priority of election for
         # cluster nodes.
         self.mongo_manager.set_election_priority(priority=1)
+
+    def update_ips_in_databag(self) -> None:
+        """Sets all the ips in the databag to be used by the leader."""
+        self.state.unit_peer_data.database_address = ip_addresses(
+            self.state.client_network().bind_addresses
+        )[0]
+        self.state.unit_peer_data.config_server_address = ip_addresses(
+            self.state.config_server_network().bind_addresses
+        )[0]
+        self.state.unit_peer_data.cluster_address = ip_addresses(
+            self.state.cluster_network().bind_addresses
+        )[0]
 
     def update_hosts(self) -> None:
         """Update the replica set hosts and remove any unremoved replica from the config."""
@@ -1013,6 +1031,9 @@ class MongoDBOperator(OperatorProtocol, Object):
             self.config_server_manager.remove_shards()
             # Update the config server DB URI on the remote mongos
             self.cluster_manager.update_config_server_db()
+
+        if self.state.is_role(MongoDBRoles.SHARD):
+            self.shard_manager.update_mongos_hosts()
 
     def open_ports(self) -> None:
         """Open ports on the workload.

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -485,6 +485,9 @@ class MongoDBOperator(OperatorProtocol, Object):
         # allowing that event to run.
         self._configure_workloads()
 
+        # Write IPs in databag
+        self.update_ips_in_databag()
+
         logger.info("Starting MongoDB.")
         self.charm.status_handler.set_running_status(
             MongoDBStatuses.STARTING_MONGODB.value, scope="unit"
@@ -735,8 +738,6 @@ class MongoDBOperator(OperatorProtocol, Object):
                 "Adding replicas during an upgrade is not supported. The charm may be in a broken, unrecoverable state"
             )
             raise UpgradeInProgressError
-
-        self.update_ips_in_databag()
 
         if not self.charm.unit.is_leader():
             return

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -602,6 +602,10 @@ class MongoDBOperator(OperatorProtocol, Object):
             raise ShardingMigrationError(
                 f"Migration of sharding components not permitted, revert config role to {self.state.app_peer_data.role.value}"
             )
+
+        # If we had an IP change, we must restart.
+        self.restart_charm_services()
+
         if not self.charm.unit.is_leader():
             return
         self._handle_ldap_config_changes()

--- a/single_kernel_mongo/managers/mongos_operator.py
+++ b/single_kernel_mongo/managers/mongos_operator.py
@@ -52,6 +52,7 @@ from single_kernel_mongo.managers.upgrade_v3 import MongoDBUpgradesManager
 from single_kernel_mongo.managers.upgrade_v3_status import MongoDBUpgradesStatusManager
 from single_kernel_mongo.state.app_peer_state import AppPeerDataKeys
 from single_kernel_mongo.state.charm_state import CharmState
+from single_kernel_mongo.utils.network_helpers import ip_addresses
 from single_kernel_mongo.workload import get_mongos_workload_for_substrate
 from single_kernel_mongo.workload.mongos_workload import MongosWorkload
 
@@ -412,6 +413,12 @@ class MongosOperator(OperatorProtocol, Object):
             )
             raise
 
+    def update_ips_in_databag(self) -> None:
+        """Sets all the ips in the databag to be used by the leader."""
+        self.state.unit_peer_data.database_address = ip_addresses(
+            self.state.client_network().bind_addresses
+        )[0]
+
     @override
     def get_relation_feasible_status(self, name: str) -> StatusObject | None:
         """Checks if the relation is feasible.
@@ -424,6 +431,9 @@ class MongosOperator(OperatorProtocol, Object):
 
     def share_connection_info(self):
         """Shares the connection information of clients."""
+        # Always update ips in databag.
+        self.update_ips_in_databag()
+
         if not self.state.db_initialised:
             return
         if not self.charm.unit.is_leader():
@@ -500,6 +510,8 @@ class MongosOperator(OperatorProtocol, Object):
             if self.state.mongos_cluster_relation:
                 self.state.cluster.extra_user_roles = new_extra_user_roles
 
+        if self.state.mongos_cluster_relation:
+            self.state.cluster.external_node_connectivity = external_connectivity
         self.state.app_peer_data.external_connectivity = external_connectivity
 
         if external_connectivity:

--- a/single_kernel_mongo/managers/sharding.py
+++ b/single_kernel_mongo/managers/sharding.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import json
 import time
 from logging import getLogger
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, final
 
 from data_platform_helpers.advanced_statuses.models import StatusObject
 from data_platform_helpers.advanced_statuses.protocol import ManagerStatusProtocol
@@ -61,6 +61,7 @@ from single_kernel_mongo.utils.mongodb_users import (
     CharmedOperatorUser,
     MongoDBUser,
 )
+from single_kernel_mongo.utils.network_helpers import cidrs
 from single_kernel_mongo.workload.mongodb_workload import MongoDBWorkload
 
 if TYPE_CHECKING:
@@ -69,6 +70,7 @@ if TYPE_CHECKING:
 logger = getLogger(__name__)
 
 
+@final
 class ConfigServerManager(Object, ManagerStatusProtocol):
     """Manage relations between the config server and the shard, on the config-server's side."""
 
@@ -110,6 +112,9 @@ class ConfigServerManager(Object, ManagerStatusProtocol):
             ),
             AppShardingComponentKeys.KEY_FILE.value: self.state.get_keyfile(),
             AppShardingComponentKeys.HOST.value: json.dumps(sorted(self.state.internal_hosts)),
+            AppShardingComponentKeys.MONGOS_CIDRS.value: json.dumps(
+                sorted(cidrs(self.state.cluster_network().bind_addresses))
+            ),
         }
 
         if self.state.s3_relation:
@@ -242,7 +247,10 @@ class ConfigServerManager(Object, ManagerStatusProtocol):
                 {
                     AppShardingComponentKeys.HOST.value: json.dumps(
                         sorted(self.state.internal_hosts)
-                    )
+                    ),
+                    AppShardingComponentKeys.MONGOS_CIDRS.value: json.dumps(
+                        sorted(cidrs(self.state.cluster_network().bind_addresses))
+                    ),
                 },
             )
 
@@ -336,10 +344,12 @@ class ConfigServerManager(Object, ManagerStatusProtocol):
         """Adds a shard to the cluster."""
         shard_name = relation.app.name
 
-        hosts = []
-        for unit in relation.units:
-            unit_state = self.state.unit_peer_data_for(unit, relation)
-            hosts.append(unit_state.internal_address)
+        hosts: list[str] = json.loads(
+            self.data_interface.fetch_relation_field(
+                relation.id, AppShardingComponentKeys.RS_HOSTS.value
+            )
+            or "[]"
+        )
         if not len(hosts):
             logger.info(f"host info for shard {shard_name} not yet added, skipping")
             return
@@ -606,8 +616,13 @@ class ShardManager(Object, ManagerStatusProtocol):
         if not self.charm.unit.is_leader():
             return
 
+        # Let's send the IPs of our replicaset.
+        self.state.shard_state.rs_hosts = list(self.state.internal_hosts)
+
         # We have updated our auth, config-server can add the shard.
-        self.data_requirer.update_relation_data(relation.id, {"auth-updated": "true"})
+        self.state.shard_state.auth_updated = True
+
+        # Store the mongos hosts on this side of the relation.
         self.state.app_peer_data.mongos_hosts = self.state.shard_state.mongos_hosts
 
     def handle_secret_changed(self, secret_label: str | None) -> None:
@@ -731,6 +746,7 @@ class ShardManager(Object, ManagerStatusProtocol):
         """Updates the hosts for mongos on the relation data."""
         if (hosts := self.state.shard_state.mongos_hosts) != self.state.app_peer_data.mongos_hosts:
             self.state.app_peer_data.mongos_hosts = hosts
+        self.state.shard_state.rs_hosts = self.state.internal_hosts
 
     def sync_cluster_passwords(self, operator_password: str, backup_password: str) -> None:
         """Update shared cluster passwords."""

--- a/single_kernel_mongo/managers/tls.py
+++ b/single_kernel_mongo/managers/tls.py
@@ -100,7 +100,12 @@ class TLSManager(ManagerStatusProtocol):
                 "localhost",
                 f"{self.charm.app.name}-{unit_id}.{self.charm.app.name}-endpoints",
             ],
-            sans_ips=sorted(self.state.listen_ips()),
+            sans_ips=sorted(
+                {
+                    *self.state.listen_ips(),
+                    self.state.bind_address,  # Adds the bind address for k8s, duplicated in VM case
+                }
+            ),
         )
 
         if self.state.is_role(MongoDBRoles.MONGOS) and self.state.is_external_client:

--- a/single_kernel_mongo/managers/tls.py
+++ b/single_kernel_mongo/managers/tls.py
@@ -100,7 +100,7 @@ class TLSManager(ManagerStatusProtocol):
                 "localhost",
                 f"{self.charm.app.name}-{unit_id}.{self.charm.app.name}-endpoints",
             ],
-            sans_ips=[str(self.state.bind_address)],
+            sans_ips=sorted(self.state.listen_ips()),
         )
 
         if self.state.is_role(MongoDBRoles.MONGOS) and self.state.is_external_client:

--- a/single_kernel_mongo/state/charm_state.py
+++ b/single_kernel_mongo/state/charm_state.py
@@ -682,9 +682,11 @@ class CharmState(Object, StatusesStateProtocol):
     def local_auth_restrictions(self) -> list[AuthRestrictions]:
         """Return auth restrictions for local users."""
         return [
+            AuthRestrictions(clientSource=[LOCALHOST], serverAddress=[LOCALHOST]),
             AuthRestrictions(
-                clientSource=cidrs(self.peer_network().bind_addresses), serverAddress=[LOCALHOST]
-            )
+                clientSource=cidrs(self.peer_network().bind_addresses),
+                serverAddress=cidrs(self.peer_network().bind_addresses),
+            ),
         ]
 
     def has_credentials(self) -> bool:

--- a/single_kernel_mongo/state/charm_state.py
+++ b/single_kernel_mongo/state/charm_state.py
@@ -912,7 +912,7 @@ class CharmState(Object, StatusesStateProtocol):
         ip_list.append("127.0.0.1")
 
         # Public IPs of the unit.
-        ip_list.extend(ip_addresses(self.sharding_network().bind_addresses))
+        ip_list.extend(ip_addresses(self.juju_info_network().bind_addresses))
 
         return {str(ip) for ip in ip_list if ip}
 

--- a/single_kernel_mongo/state/charm_state.py
+++ b/single_kernel_mongo/state/charm_state.py
@@ -477,14 +477,6 @@ class CharmState(Object, StatusesStateProtocol):
         """
         return quote(f"{self.paths.socket_path}", safe="")
 
-    @property
-    def app_hosts(self) -> set[str]:
-        """Retrieve the hosts associated with MongoDB application."""
-        if self.substrate == Substrates.K8S and self.charm_role.name == CharmKind.MONGOS:
-            if self.config.expose_external == ExposeExternal.NODEPORT:
-                return {f"{unit.node_ip}" for unit in self.units}
-        return self.internal_hosts
-
     def hosts_for(self, relation: Relation) -> set[str]:
         """Retrieve the hosts associated with MongoDB application."""
         if self.substrate == Substrates.K8S and self.charm_role.name == CharmKind.MONGOS:

--- a/single_kernel_mongo/state/charm_state.py
+++ b/single_kernel_mongo/state/charm_state.py
@@ -22,7 +22,6 @@ from pymongo.errors import (
 )
 
 from single_kernel_mongo.config.literals import (
-    JUJU_INFO,
     LOCALHOST,
     SECRETS_UNIT,
     CharmKind,
@@ -84,7 +83,7 @@ from single_kernel_mongo.utils.mongodb_users import (
     MongoDBUser,
     RoleNames,
 )
-from single_kernel_mongo.utils.network_helpers import cidrs, ip_addresses
+from single_kernel_mongo.utils.network_helpers import cidrs, get_host_public_ip, ip_addresses
 
 if TYPE_CHECKING:
     from single_kernel_mongo.abstract_charm import AbstractMongoCharm
@@ -862,10 +861,6 @@ class CharmState(Object, StatusesStateProtocol):
         return secret_content
 
     # BEGIN: Addresses accessors
-    def juju_info_network(self) -> Network:
-        """The special binding `juju-info`."""
-        return network_get(JUJU_INFO)
-
     def client_network(self) -> Network:
         """Listening IP for that unit on the client relation."""
         return network_get(self.client_relation_name)
@@ -894,11 +889,9 @@ class CharmState(Object, StatusesStateProtocol):
 
     def listen_ips(self) -> set[str]:
         """All the IPs to listen to."""
+        public_ip_set = get_host_public_ip()
         if self.substrate == Substrates.K8S:
-            return {
-                "127.0.0.1",
-                *ip_addresses(self.juju_info_network().bind_addresses),
-            }
+            return {"127.0.0.1", *public_ip_set}
         ip_list: list[str] = [
             *ip_addresses(self.client_network().bind_addresses),
             *ip_addresses(self.peer_network().bind_addresses),
@@ -915,7 +908,7 @@ class CharmState(Object, StatusesStateProtocol):
         ip_list.append("127.0.0.1")
 
         # Public IPs of the unit.
-        ip_list.extend(ip_addresses(self.juju_info_network().bind_addresses))
+        ip_list.extend(public_ip_set)
 
         return {str(ip) for ip in ip_list if ip}
 

--- a/single_kernel_mongo/state/charm_state.py
+++ b/single_kernel_mongo/state/charm_state.py
@@ -916,6 +916,6 @@ class CharmState(Object, StatusesStateProtocol):
 
         return {str(ip) for ip in ip_list if ip}
 
-    def listens_on(self):
+    def listens_on(self) -> set[str]:
         """Everything we should listen on."""
         return {*self.listen_ips(), *self.listen_hosts()}

--- a/single_kernel_mongo/state/charm_state.py
+++ b/single_kernel_mongo/state/charm_state.py
@@ -414,7 +414,10 @@ class CharmState(Object, StatusesStateProtocol):
         """The network binding address from the peer relation."""
         if not self.peer_relation:
             return ""
-        return str(self.peer_network().bind_addresses[0].addresses[0].value)
+        try:
+            return str(self.peer_network().bind_addresses[0].addresses[0].value)
+        except IndexError:
+            return ""
 
     def get_user_password(self, user: MongoDBUser) -> str:
         """Returns the user password for a system user."""

--- a/single_kernel_mongo/state/charm_state.py
+++ b/single_kernel_mongo/state/charm_state.py
@@ -12,7 +12,8 @@ from typing import TYPE_CHECKING, TypeVar, final
 from urllib.parse import quote
 
 from data_platform_helpers.advanced_statuses.protocol import StatusesState, StatusesStateProtocol
-from ops import Binding, ModelError, Object, Relation, SecretNotFoundError, Unit
+from ops import ModelError, Object, Relation, SecretNotFoundError, Unit
+from ops.hookcmds import Network, network_get
 from pymongo.errors import (
     AutoReconnect,
     NotPrimaryError,
@@ -21,6 +22,8 @@ from pymongo.errors import (
 )
 
 from single_kernel_mongo.config.literals import (
+    JUJU_INFO,
+    LOCALHOST,
     SECRETS_UNIT,
     CharmKind,
     MongoPorts,
@@ -72,6 +75,7 @@ from single_kernel_mongo.utils.mongo_config import MongoConfiguration
 from single_kernel_mongo.utils.mongo_connection import MongoConnection
 from single_kernel_mongo.utils.mongo_error_codes import MongoErrorCodes
 from single_kernel_mongo.utils.mongodb_users import (
+    AuthRestrictions,
     CharmedBackupUser,
     CharmedLogRotateUser,
     CharmedOperatorUser,
@@ -80,6 +84,7 @@ from single_kernel_mongo.utils.mongodb_users import (
     MongoDBUser,
     RoleNames,
 )
+from single_kernel_mongo.utils.network_helpers import cidrs, ip_addresses
 
 if TYPE_CHECKING:
     from single_kernel_mongo.abstract_charm import AbstractMongoCharm
@@ -156,6 +161,13 @@ class CharmState(Object, StatusesStateProtocol):
 
     # BEGIN: Relations
     @property
+    def client_relation_name(self) -> str:
+        """The correct client relation name."""
+        if self.charm_role.name == CharmKind.MONGOS:
+            return RelationNames.MONGOS_PROXY.value
+        return RelationNames.DATABASE.value
+
+    @property
     def peer_relation(self) -> Relation | None:
         """The replica set peer relation."""
         return self.model.get_relation(self.peer_relation_name)
@@ -187,9 +199,7 @@ class CharmState(Object, StatusesStateProtocol):
         which is exposed for mongos charms, and one for replication which is
         exposed for mongodb charms.
         """
-        if self.charm_role.name == CharmKind.MONGOS:
-            return set(self.model.relations[RelationNames.MONGOS_PROXY.value])
-        return set(self.model.relations[RelationNames.DATABASE.value])
+        return set(self.model.relations[self.client_relation_name])
 
     @property
     def mongos_cluster_relation(self) -> Relation | None:
@@ -404,7 +414,7 @@ class CharmState(Object, StatusesStateProtocol):
         """The network binding address from the peer relation."""
         if not self.peer_relation:
             return ""
-        return str(self.peer_network().network.bind_address)
+        return str(self.peer_network().bind_addresses[0].addresses[0].value)
 
     def get_user_password(self, user: MongoDBUser) -> str:
         """Returns the user password for a system user."""
@@ -464,6 +474,13 @@ class CharmState(Object, StatusesStateProtocol):
             if self.config.expose_external == ExposeExternal.NODEPORT:
                 return {f"{unit.node_ip}" for unit in self.units}
         return self.internal_hosts
+
+    def hosts_for(self, relation: Relation) -> set[str]:
+        """Retrieve the hosts associated with MongoDB application."""
+        if self.substrate == Substrates.K8S and self.charm_role.name == CharmKind.MONGOS:
+            if self.config.expose_external == ExposeExternal.NODEPORT:
+                return {f"{unit.node_ip}" for unit in self.units}
+        return {unit.address_for(relation.name) for unit in self.units}
 
     @property
     def unit_host(self) -> str | None:
@@ -563,10 +580,12 @@ class CharmState(Object, StatusesStateProtocol):
         # subject name
         return self.config_server_name or self.model.app.name
 
-    def generate_config_server_db(self) -> str:
+    def generate_config_server_db(self, relation: Relation) -> str:
         """Generates the config server DB URI."""
         replica_set_name = self.model.app.name
-        hosts = sorted(f"{host}:{MongoPorts.MONGODB_PORT.value}" for host in self.internal_hosts)
+        hosts = sorted(
+            f"{host}:{MongoPorts.MONGODB_PORT.value}" for host in self.hosts_for(relation)
+        )
         return f"{replica_set_name}/{','.join(hosts)}"
 
     # END: Helpers
@@ -659,6 +678,14 @@ class CharmState(Object, StatusesStateProtocol):
         return self.app_peer_data.replica_set in members
 
     # BEGIN: Configuration accessors
+    @property
+    def local_auth_restrictions(self) -> list[AuthRestrictions]:
+        """Return auth restrictions for local users."""
+        return [
+            AuthRestrictions(
+                clientSource=cidrs(self.peer_network().bind_addresses), serverAddress=[LOCALHOST]
+            )
+        ]
 
     def has_credentials(self) -> bool:
         """Checks if we have received credentials or not."""
@@ -674,6 +701,7 @@ class CharmState(Object, StatusesStateProtocol):
         hosts: set[str] | None = None,
         replset: str | None = None,
         standalone: bool = False,
+        auth_restrictions: list[AuthRestrictions] | None = None,
     ) -> MongoConfiguration:
         """Returns a mongodb-specific MongoConfiguration object for the provided user.
 
@@ -689,6 +717,8 @@ class CharmState(Object, StatusesStateProtocol):
             hosts = set()
         if not user.hosts and not hosts:
             raise Exception("Invalid call: no host in user nor as a parameter.")
+        if not auth_restrictions:
+            auth_restrictions = []
         return MongoConfiguration(
             replset=replset or self.app_peer_data.replica_set,
             database=user.database_name,
@@ -701,6 +731,7 @@ class CharmState(Object, StatusesStateProtocol):
             tls_external_keyfile=self.paths.ext_pem_file,
             tls_external_ca=self.paths.ext_ca_file,
             standalone=standalone,
+            auth_restrictions=auth_restrictions,
         )
 
     def mongos_config_for_user(
@@ -737,17 +768,23 @@ class CharmState(Object, StatusesStateProtocol):
     @property
     def backup_config(self) -> MongoConfiguration:
         """Mongo Configuration for the charmed-backup user."""
-        return self.mongodb_config_for_user(CharmedBackupUser, standalone=True)
+        return self.mongodb_config_for_user(
+            CharmedBackupUser, standalone=True, auth_restrictions=self.local_auth_restrictions
+        )
 
     @property
     def stats_config(self) -> MongoConfiguration:
         """Mongo Configuration for the charmed-stats user."""
-        return self.mongodb_config_for_user(CharmedStatsUser)
+        return self.mongodb_config_for_user(
+            CharmedStatsUser, auth_restrictions=self.local_auth_restrictions
+        )
 
     @property
     def logrotate_config(self) -> MongoConfiguration:
         """Mongo Configuration for the charmed-logrotate user."""
-        return self.mongodb_config_for_user(CharmedLogRotateUser, standalone=True)
+        return self.mongodb_config_for_user(
+            CharmedLogRotateUser, standalone=True, auth_restrictions=self.local_auth_restrictions
+        )
 
     @property
     def operator_config(self) -> MongoConfiguration:
@@ -820,42 +857,54 @@ class CharmState(Object, StatusesStateProtocol):
         return secret_content
 
     # BEGIN: Addresses accessors
-    def client_network(self) -> Binding:
+    def juju_info_network(self) -> Network:
+        """The special binding `juju-info`."""
+        return network_get(JUJU_INFO)
+
+    def client_network(self) -> Network:
         """Listening IP for that unit on the client relation."""
-        if self.is_role(MongoDBRoles.MONGOS):
-            return self.model.get_binding(RelationNames.MONGOS_PROXY.value)  # type: ignore[return-value]
-        return self.model.get_binding(RelationNames.DATABASE.value)  # type: ignore[return-value]
+        return network_get(self.client_relation_name)
 
-    def peer_network(self) -> Binding:
+    def peer_network(self) -> Network:
         """Listening IP for that unit on the peer relation."""
-        return self.model.get_binding(PeerRelationNames.PEERS.value)  # type: ignore[return-value]
+        return network_get(self.peer_relation_name)
 
-    def sharding_network(self) -> Binding:
+    def sharding_network(self) -> Network:
         """Listening IP for that unit on the sharding relation."""
-        return self.model.get_binding(RelationNames.SHARDING.value)  # type: ignore[return-value]
+        return network_get(RelationNames.SHARDING.value)
 
-    def config_server_network(self) -> Binding:
+    def config_server_network(self) -> Network:
         """Listening IP for that unit on the config-server relation."""
-        return self.model.get_binding(RelationNames.CONFIG_SERVER.value)  # type: ignore[return-value]
+        return network_get(RelationNames.CONFIG_SERVER.value)
 
-    def cluster_network(self) -> Binding:
+    def cluster_network(self) -> Network:
         """Listening IP for that unit on the sharding relation."""
-        return self.model.get_binding(RelationNames.CLUSTER.value)  # type: ignore[return-value]
+        return network_get(RelationNames.CLUSTER.value)
 
     def listen_ips(self) -> set[str]:
         """All the IPs to listen to."""
-        ip_list = [
-            self.client_network().network.bind_address,
-            self.peer_network().network.bind_address,
+        if self.substrate == Substrates.K8S:
+            return {
+                self.unit_peer_data.internal_address,
+                "127.0.0.1",
+                *ip_addresses(self.juju_info_network().bind_addresses),
+            }
+        ip_list: list[str] = [
+            *ip_addresses(self.client_network().bind_addresses),
+            *ip_addresses(self.peer_network().bind_addresses),
         ]
         if self.is_sharding_component:
-            ip_list.append(self.sharding_network().network.bind_address)
-            ip_list.append(
-                self.config_server_network().network.bind_address,
+            ip_list.extend(ip_addresses(self.sharding_network().bind_addresses))
+            ip_list.extend(
+                ip_addresses(self.config_server_network().bind_addresses),
             )
         if self.is_cluster_component:
-            ip_list.append(self.config_server_network().network.bind_address)
+            ip_list.extend(ip_addresses(self.cluster_network().bind_addresses))
 
+        # Localhost
         ip_list.append("127.0.0.1")
+
+        # Public IPs of the unit.
+        ip_list.extend(ip_addresses(self.sharding_network().bind_addresses))
 
         return {str(ip) for ip in ip_list if ip}

--- a/single_kernel_mongo/state/charm_state.py
+++ b/single_kernel_mongo/state/charm_state.py
@@ -8,12 +8,11 @@ from __future__ import annotations
 
 import json
 import logging
-from ipaddress import IPv4Address, IPv6Address
-from typing import TYPE_CHECKING, TypeVar
+from typing import TYPE_CHECKING, TypeVar, final
 from urllib.parse import quote
 
 from data_platform_helpers.advanced_statuses.protocol import StatusesState, StatusesStateProtocol
-from ops import ModelError, Object, Relation, SecretNotFoundError, Unit
+from ops import Binding, ModelError, Object, Relation, SecretNotFoundError, Unit
 from pymongo.errors import (
     AutoReconnect,
     NotPrimaryError,
@@ -92,6 +91,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger()
 
 
+@final
 class CharmState(Object, StatusesStateProtocol):
     """The Charm State object.
 
@@ -381,6 +381,11 @@ class CharmState(Object, StatusesStateProtocol):
         return self.is_role(MongoDBRoles.SHARD) or self.is_role(MongoDBRoles.CONFIG_SERVER)
 
     @property
+    def is_cluster_component(self) -> bool:
+        """Is the application a cluster component?"""
+        return self.is_role(MongoDBRoles.MONGOS) or self.is_role(MongoDBRoles.CONFIG_SERVER)
+
+    @property
     def has_sharding_integration(self) -> bool:
         """Has the sharding component a sharded deployment integration?"""
         return (self.shard_relation is not None) or bool(self.config_server_relation)
@@ -395,14 +400,11 @@ class CharmState(Object, StatusesStateProtocol):
         self.app_peer_data.db_initialised = other
 
     @property
-    def bind_address(self) -> IPv4Address | IPv6Address | str:
+    def bind_address(self) -> str:
         """The network binding address from the peer relation."""
-        bind_address = None
-        if self.peer_relation:
-            if binding := self.model.get_binding(self.peer_relation):
-                bind_address = binding.network.bind_address
-
-        return bind_address or ""
+        if not self.peer_relation:
+            return ""
+        return str(self.peer_network().network.bind_address)
 
     def get_user_password(self, user: MongoDBUser) -> str:
         """Returns the user password for a system user."""
@@ -669,7 +671,7 @@ class CharmState(Object, StatusesStateProtocol):
     def mongodb_config_for_user(
         self,
         user: MongoDBUser,
-        hosts: set[str] = set(),
+        hosts: set[str] | None = None,
         replset: str | None = None,
         standalone: bool = False,
     ) -> MongoConfiguration:
@@ -683,6 +685,8 @@ class CharmState(Object, StatusesStateProtocol):
         Raises:
             Exception if neither user.hosts nor hosts is non empty.
         """
+        if not hosts:
+            hosts = set()
         if not user.hosts and not hosts:
             raise Exception("Invalid call: no host in user nor as a parameter.")
         return MongoConfiguration(
@@ -702,7 +706,7 @@ class CharmState(Object, StatusesStateProtocol):
     def mongos_config_for_user(
         self,
         user: MongoDBUser,
-        hosts: set[str] = set(),
+        hosts: set[str] | None = None,
     ) -> MongoConfiguration:
         """Returns a mongos-specific MongoConfiguration object for the provided user.
 
@@ -714,6 +718,8 @@ class CharmState(Object, StatusesStateProtocol):
         Raises:
             Exception if neither user.hosts nor hosts is non empty.
         """
+        if not hosts:
+            hosts = set()
         if not user.hosts and not hosts:
             raise Exception("Invalid call: no host in user nor as a parameter.")
         return MongoConfiguration(
@@ -812,3 +818,44 @@ class CharmState(Object, StatusesStateProtocol):
             raise
 
         return secret_content
+
+    # BEGIN: Addresses accessors
+    def client_network(self) -> Binding:
+        """Listening IP for that unit on the client relation."""
+        if self.is_role(MongoDBRoles.MONGOS):
+            return self.model.get_binding(RelationNames.MONGOS_PROXY.value)  # type: ignore[return-value]
+        return self.model.get_binding(RelationNames.DATABASE.value)  # type: ignore[return-value]
+
+    def peer_network(self) -> Binding:
+        """Listening IP for that unit on the peer relation."""
+        return self.model.get_binding(PeerRelationNames.PEERS.value)  # type: ignore[return-value]
+
+    def sharding_network(self) -> Binding:
+        """Listening IP for that unit on the sharding relation."""
+        return self.model.get_binding(RelationNames.SHARDING.value)  # type: ignore[return-value]
+
+    def config_server_network(self) -> Binding:
+        """Listening IP for that unit on the config-server relation."""
+        return self.model.get_binding(RelationNames.CONFIG_SERVER.value)  # type: ignore[return-value]
+
+    def cluster_network(self) -> Binding:
+        """Listening IP for that unit on the sharding relation."""
+        return self.model.get_binding(RelationNames.CLUSTER.value)  # type: ignore[return-value]
+
+    def listen_ips(self) -> set[str]:
+        """All the IPs to listen to."""
+        ip_list = [
+            self.client_network().network.bind_address,
+            self.peer_network().network.bind_address,
+        ]
+        if self.is_sharding_component:
+            ip_list.append(self.sharding_network().network.bind_address)
+            ip_list.append(
+                self.config_server_network().network.bind_address,
+            )
+        if self.is_cluster_component:
+            ip_list.append(self.config_server_network().network.bind_address)
+
+        ip_list.append("127.0.0.1")
+
+        return {str(ip) for ip in ip_list if ip}

--- a/single_kernel_mongo/state/charm_state.py
+++ b/single_kernel_mongo/state/charm_state.py
@@ -881,11 +881,16 @@ class CharmState(Object, StatusesStateProtocol):
         """Listening IP for that unit on the sharding relation."""
         return network_get(RelationNames.CLUSTER.value)
 
+    def listen_hosts(self) -> set[str]:
+        """All the hosts to listen to."""
+        if self.substrate == Substrates.VM:
+            return set()
+        return {self.unit_peer_data.internal_address}
+
     def listen_ips(self) -> set[str]:
         """All the IPs to listen to."""
         if self.substrate == Substrates.K8S:
             return {
-                self.unit_peer_data.internal_address,
                 "127.0.0.1",
                 *ip_addresses(self.juju_info_network().bind_addresses),
             }
@@ -908,3 +913,7 @@ class CharmState(Object, StatusesStateProtocol):
         ip_list.extend(ip_addresses(self.sharding_network().bind_addresses))
 
         return {str(ip) for ip in ip_list if ip}
+
+    def listens_on(self):
+        """Everything we should listen on."""
+        return {*self.listen_ips(), *self.listen_hosts()}

--- a/single_kernel_mongo/state/charm_state.py
+++ b/single_kernel_mongo/state/charm_state.py
@@ -83,7 +83,7 @@ from single_kernel_mongo.utils.mongodb_users import (
     MongoDBUser,
     RoleNames,
 )
-from single_kernel_mongo.utils.network_helpers import cidrs, get_host_public_ip, ip_addresses
+from single_kernel_mongo.utils.network_helpers import cidrs, ip_addresses
 
 if TYPE_CHECKING:
     from single_kernel_mongo.abstract_charm import AbstractMongoCharm
@@ -912,9 +912,8 @@ class CharmState(Object, StatusesStateProtocol):
 
     def listen_ips(self) -> set[str]:
         """All the IPs to listen to."""
-        public_ip_set = get_host_public_ip()
         if self.substrate == Substrates.K8S:
-            return {"127.0.0.1", *public_ip_set}
+            return {"127.0.0.1"}
         ip_list: list[str] = [
             *ip_addresses(self.client_network().bind_addresses),
             *ip_addresses(self.peer_network().bind_addresses),
@@ -929,9 +928,6 @@ class CharmState(Object, StatusesStateProtocol):
 
         # Localhost
         ip_list.append("127.0.0.1")
-
-        # Public IPs of the unit.
-        ip_list.extend(public_ip_set)
 
         return {str(ip) for ip in ip_list if ip}
 

--- a/single_kernel_mongo/state/cluster_state.py
+++ b/single_kernel_mongo/state/cluster_state.py
@@ -4,6 +4,7 @@
 
 """The Cluster state."""
 
+import json
 from enum import Enum
 
 from ops import Application
@@ -91,3 +92,15 @@ class ClusterState(AbstractRelationState[Data]):
     def ldap_hash(self) -> str | None:
         """Returns the ldap hash shared by the config-server."""
         return self.relation_data.get(ClusterStateKeys.LDAP_HASH.value, None)
+
+    @property
+    def external_node_connectivity(self) -> bool:
+        """Returns the external-connectivity flag."""
+        return json.loads(
+            self.relation_data.get(ClusterStateKeys.EXTERNAL_NODE_CONNECTIVITY.value, "false")
+        )
+
+    @external_node_connectivity.setter
+    def external_node_connectivity(self, value: bool) -> None:
+        """Sets the external-connectivity flag."""
+        self.update({ClusterStateKeys.EXTERNAL_NODE_CONNECTIVITY.value: json.dumps(value)})

--- a/single_kernel_mongo/state/config_server_state.py
+++ b/single_kernel_mongo/state/config_server_state.py
@@ -6,6 +6,7 @@
 
 import json
 from enum import Enum
+from typing import final
 
 from ops import Application
 from ops.model import Relation, Unit
@@ -18,17 +19,20 @@ class AppShardingComponentKeys(str, Enum):
     """Config Server State Model for the application."""
 
     DATABASE = "database"
-    OPERATOR_PASSWORD = "charmed-operator-password"
-    BACKUP_PASSWORD = "charmed-backup-password"
+    OPERATOR_PASSWORD = "charmed-operator-password"  # nosec B105
+    BACKUP_PASSWORD = "charmed-backup-password"  # nosec B105
     HOST = "host"
     KEY_FILE = "key-file"
-    INT_CA_SECRET = "int-ca-secret"
-    EXT_CA_SECRET = "ext-ca-secret"
-    BACKUP_CA_SECRET = "backup-ca-secret"
+    INT_CA_SECRET = "int-ca-secret"  # nosec B105
+    EXT_CA_SECRET = "ext-ca-secret"  # nosec B105
+    BACKUP_CA_SECRET = "backup-ca-secret"  # nosec B105
+    MONGOS_CIDRS = "mongos-cidrs"
+    RS_HOSTS = "rs-hosts"
+    AUTH_UPDATED = "auth-updated"
 
     # We don't use those except to check if we've received credentials
     USERNAME = "username"
-    PASSWORD = "password"
+    PASSWORD = "password"  # nosec B105
 
 
 SECRETS_FIELDS = [
@@ -41,6 +45,7 @@ SECRETS_FIELDS = [
 ]
 
 
+@final
 class AppShardingComponentState(AbstractRelationState[Data]):
     """The stored state for the ConfigServer Relation."""
 
@@ -113,6 +118,39 @@ class AppShardingComponentState(AbstractRelationState[Data]):
         return json.loads(
             self.relation_data.get(AppShardingComponentKeys.BACKUP_CA_SECRET.value, "null")
         )
+
+    @property
+    def mongos_cidrs(self) -> list[str]:
+        """The list of CIDRs for mongos apps."""
+        if not self.relation:
+            return []
+        return json.loads(self.relation_data.get(AppShardingComponentKeys.MONGOS_CIDRS.value, "[]"))
+
+    @property
+    def rs_hosts(self) -> list[str]:
+        """The shard resplicaset hosts in the relation."""
+        if not self.relation:
+            return []
+        return json.loads(self.relation_data.get(AppShardingComponentKeys.RS_HOSTS.value, "[]"))
+
+    @rs_hosts.setter
+    def rs_hosts(self, value: list[str]):
+        """Sets the rs_hosts key."""
+        self.update({AppShardingComponentKeys.RS_HOSTS.value: json.dumps(sorted(value))})
+
+    @property
+    def auth_updated(self) -> bool:
+        """Has the shard updated its host?."""
+        if not self.relation:
+            return False
+        return json.loads(
+            self.relation_data.get(AppShardingComponentKeys.AUTH_UPDATED.value, "false")
+        )
+
+    @auth_updated.setter
+    def auth_updated(self, value: bool):
+        """Sets the auth-updated field."""
+        self.update({AppShardingComponentKeys.AUTH_UPDATED.value: json.dumps(value)})
 
 
 class UnitShardingComponentState(AbstractRelationState[Data]):

--- a/single_kernel_mongo/state/unit_peer_state.py
+++ b/single_kernel_mongo/state/unit_peer_state.py
@@ -165,7 +165,7 @@ class UnitPeerReplicaSet(AbstractRelationState[DataPeerUnitData]):
     def mongos_proxy_address(self, value: str):
         self.update({UnitPeerRelationKeys.MONGOS_PROXY_ADDRESS.value: value})
 
-    def address_for(self, relation_name: str):
+    def address_for(self, relation_name: str) -> str:
         """Address for the correct relation."""
         if self.substrate == Substrates.VM:
             return self.relation_data.get(f"{relation_name}-address", "")

--- a/single_kernel_mongo/state/unit_peer_state.py
+++ b/single_kernel_mongo/state/unit_peer_state.py
@@ -25,6 +25,12 @@ class UnitPeerRelationKeys(str, Enum):
     DRAINED = "drained"
     CURRENT_REVISION = "current_revision"
 
+    # IPs of the relations
+    DATABASE_ADDRESS = "database-address"
+    CONFIG_SERVER_ADDRESS = "config-server-address"
+    CLUSTER_ADDRESS = "cluster-address"
+    MONGOS_PROXY_ADDRESS = "mongos_proxy-address"
+
 
 class UnitPeerReplicaSet(AbstractRelationState[DataPeerUnitData]):
     """State collection for unit data."""
@@ -122,3 +128,46 @@ class UnitPeerReplicaSet(AbstractRelationState[DataPeerUnitData]):
     @current_revision.setter
     def current_revision(self, value: str):
         self.update({UnitPeerRelationKeys.CURRENT_REVISION.value: value})
+
+    @property
+    def database_address(self) -> str:
+        """The address of that unit on the database interface."""
+        return self.relation_data.get(UnitPeerRelationKeys.DATABASE_ADDRESS, "")
+
+    @database_address.setter
+    def database_address(self, value: str):
+        self.update({UnitPeerRelationKeys.DATABASE_ADDRESS.value: value})
+
+    @property
+    def config_server_address(self) -> str:
+        """The address of that unit on the config_server interface."""
+        return self.relation_data.get(UnitPeerRelationKeys.CONFIG_SERVER_ADDRESS, "")
+
+    @config_server_address.setter
+    def config_server_address(self, value: str):
+        self.update({UnitPeerRelationKeys.CONFIG_SERVER_ADDRESS.value: value})
+
+    @property
+    def cluster_address(self) -> str:
+        """The address of that unit on the cluster interface."""
+        return self.relation_data.get(UnitPeerRelationKeys.CLUSTER_ADDRESS, "")
+
+    @cluster_address.setter
+    def cluster_address(self, value: str):
+        self.update({UnitPeerRelationKeys.CLUSTER_ADDRESS.value: value})
+
+    @property
+    def mongos_proxy_address(self) -> str:
+        """The address of that unit on the mongos_proxy interface."""
+        return self.relation_data.get(UnitPeerRelationKeys.MONGOS_PROXY_ADDRESS, "")
+
+    @mongos_proxy_address.setter
+    def mongos_proxy_address(self, value: str):
+        self.update({UnitPeerRelationKeys.MONGOS_PROXY_ADDRESS.value: value})
+
+    def address_for(self, relation_name: str):
+        """Address for the correct relation."""
+        if self.substrate == Substrates.VM:
+            return self.relation_data.get(f"{relation_name}-address", "")
+        # K8s Case.
+        return f"{self.unit.name.split('/')[0]}-{self.unit_id}.{self.unit.name.split('/')[0]}-endpoints"

--- a/single_kernel_mongo/utils/mongo_config.py
+++ b/single_kernel_mongo/utils/mongo_config.py
@@ -23,13 +23,20 @@ ADMIN_AUTH_SOURCE = {"authSource": "admin"}
 class MongoConfiguration:
     """Class for Mongo configurations usable my mongos and mongodb.
 
-    — replset: name of replica set
-    — database: database name.
-    — username: username.
-    — password: password.
-    — hosts: full list of hosts to connect to, needed for the URI.
-    — tls_external: indicator for use of internal TLS connection.
-    — tls_internal: indicator for use of external TLS connection.
+    Args:
+        replset: name of replica set
+        database: database name.
+        username: username.
+        password: password.
+        hosts: full set of hosts to connect to, needed for the URI.
+        roles: set of roles for that user.
+        tls_enabled: Is TLS enabled on that configuration?
+        tls_external_keyfile: The path of the tls external certificate
+        tls_external_ca: The path of the tls external CA certificate
+        port: The port used to connect
+        replset: The replica set we connect to
+        standalone: Should that be a standalone connection ?
+        auth_restrictions: The list of authentication restrictions for that user
     """
 
     database: str

--- a/single_kernel_mongo/utils/mongo_config.py
+++ b/single_kernel_mongo/utils/mongo_config.py
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 """Code for interactions with MongoDB."""
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from itertools import chain
 from pathlib import Path
 from urllib.parse import quote_plus, urlencode
@@ -11,6 +11,7 @@ from single_kernel_mongo.config.literals import MongoPorts
 from single_kernel_mongo.exceptions import AmbiguousConfigError
 from single_kernel_mongo.utils.mongodb_users import (
     REGULAR_ROLES,
+    AuthRestrictions,
     DBPrivilege,
     UserRole,
 )
@@ -42,6 +43,7 @@ class MongoConfiguration:
     port: int | None = None
     replset: str | None = None
     standalone: bool = False
+    auth_restrictions: list[AuthRestrictions] = field(default_factory=list)
 
     @property
     def formatted_hosts(self) -> set[str]:

--- a/single_kernel_mongo/utils/mongo_connection.py
+++ b/single_kernel_mongo/utils/mongo_connection.py
@@ -31,7 +31,7 @@ from single_kernel_mongo.exceptions import (
 from single_kernel_mongo.utils.helpers import hostname_from_hostport, hostname_from_shardname
 from single_kernel_mongo.utils.mongo_config import MongoConfiguration
 from single_kernel_mongo.utils.mongo_error_codes import MongoErrorCodes
-from single_kernel_mongo.utils.mongodb_users import DBPrivilege
+from single_kernel_mongo.utils.mongodb_users import AuthRestrictions, DBPrivilege
 
 logger = logging.getLogger(__name__)
 
@@ -142,11 +142,19 @@ class MongoConnection:
                 logger.error("Cannot initialize replica set. error=%r", e)
                 raise e
 
-    def create_user(self, username: str, password: str, roles: list[DBPrivilege]):
+    def create_user(
+        self,
+        username: str,
+        password: str,
+        roles: list[DBPrivilege],
+        auth_restrictions: list[AuthRestrictions] | None = None,
+    ):
         """Create user.
 
         Grant read and write privileges for specified database.
         """
+        if not auth_restrictions:
+            auth_restrictions = []
         try:
             self.client.admin.command(
                 "createUser",
@@ -154,6 +162,7 @@ class MongoConnection:
                 pwd=password,
                 roles=roles,
                 mechanisms=["SCRAM-SHA-256"],
+                authenticationRestrictions=auth_restrictions,
             )
         except OperationFailure as e:
             if e.code == MongoErrorCodes.USER_ALREADY_EXISTS:

--- a/single_kernel_mongo/utils/mongodb_users.py
+++ b/single_kernel_mongo/utils/mongodb_users.py
@@ -11,6 +11,16 @@ from single_kernel_mongo.config.literals import LOCALHOST, MAX_PASSWORD_LENGTH, 
 from single_kernel_mongo.exceptions import InvalidPasswordError
 
 
+class AuthRestrictions(TypedDict, total=False):
+    """Authentication Restrictions.
+
+    See https://www.mongodb.com/docs/manual/reference/method/db.createUser/#authentication-restrictions.
+    """
+
+    clientSource: list[str]  # List of IPs / CIDRS
+    serverAddress: list[str]  # List of IPs / CIDRS
+
+
 class DBPrivilege(TypedDict, total=False):
     """A DB Privilege on db."""
 

--- a/single_kernel_mongo/utils/network_helpers.py
+++ b/single_kernel_mongo/utils/network_helpers.py
@@ -7,7 +7,7 @@
 import os
 import subprocess  # nosec: B404
 from collections.abc import Sequence
-from ipaddress import ip_address
+from ipaddress import ip_address, ip_network
 
 from ops import Relation
 from ops.hookcmds import BindAddress, Network, network_get
@@ -76,7 +76,7 @@ def get_cidr_for_ip_list(ip_list: list[str]) -> str:
     if not all(ip_address(ip).version == version for ip in ip_list):
         raise ValueError("Invalid IP list received, not all versions matching.")
 
-    ip_list_split = [ip.split(split_sign) for ip in ip_list]
+    ip_list_split = [ip_address(ip).exploded.split(split_sign) for ip in ip_list]
     first = ip_list_split[0]
     acc = []
 
@@ -90,4 +90,4 @@ def get_cidr_for_ip_list(ip_list: list[str]) -> str:
     while len(acc) < ip_length:
         acc.append("0")
 
-    return split_sign.join(acc) + f"/{slash}"
+    return ip_network(split_sign.join(acc) + f"/{slash}").compressed

--- a/single_kernel_mongo/utils/network_helpers.py
+++ b/single_kernel_mongo/utils/network_helpers.py
@@ -4,6 +4,8 @@
 
 """Helpers for network interfaces."""
 
+import os
+import subprocess  # nosec: B404
 from collections.abc import Sequence
 
 from ops import Relation
@@ -30,3 +32,20 @@ def cidrs(bind_addresses: Sequence[BindAddress]) -> list[str]:
 def network_for_relation(relation: Relation) -> Network:
     """Return network for a specific relation."""
     return network_get(binding_name=relation.name, relation_id=relation.id)
+
+
+def get_host_public_ip() -> set[str]:
+    """Fetches the Public IP address of the current unit."""
+    cmd = "unit-get public-address".split()
+    output = subprocess.run(  # nosec: B603
+        cmd,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        timeout=25,
+        env=os.environ,
+    )
+    if output.returncode != 0:
+        return set()
+
+    return {output.stdout.strip()}

--- a/single_kernel_mongo/utils/network_helpers.py
+++ b/single_kernel_mongo/utils/network_helpers.py
@@ -7,6 +7,7 @@
 import os
 import subprocess  # nosec: B404
 from collections.abc import Sequence
+from ipaddress import ip_address
 
 from ops import Relation
 from ops.hookcmds import BindAddress, Network, network_get
@@ -49,3 +50,44 @@ def get_host_public_ip() -> set[str]:
         return set()
 
     return {output.stdout.strip()}
+
+
+def get_cidr_for_ip_list(ip_list: list[str]) -> str:
+    """Returns a CIDR (/8, /16, ...) for a set of ip addresses.
+
+    Works for both IPv4 and IPv6.
+    """
+    ip_v4 = ip_address(ip_list[0]).version == 4
+    if ip_v4:
+        version = 4
+        ip_length = 4
+        block_length = 8
+        split_sign = "."
+    else:
+        version = 6
+        ip_length = 8
+        block_length = 16
+        split_sign = ":"
+
+    # Return smallest slash bound to a limiter (/24 for IPv4, /112 for IPv6
+    if len(ip_list) == 1:
+        return ip_list[0] + f"/{(ip_length - 1) * block_length}"
+
+    if not all(ip_address(ip).version == version for ip in ip_list):
+        raise ValueError("Invalid IP list received, not all versions matching.")
+
+    ip_list_split = [ip.split(split_sign) for ip in ip_list]
+    first = ip_list_split[0]
+    acc = []
+
+    for i in range(len(first)):
+        if any(ip[i] != ip_list_split[0][i] for ip in ip_list_split):
+            break
+        acc.append(ip_list_split[0][i])
+
+    slash = block_length * len(acc)
+
+    while len(acc) < ip_length:
+        acc.append("0")
+
+    return split_sign.join(acc) + f"/{slash}"

--- a/single_kernel_mongo/utils/network_helpers.py
+++ b/single_kernel_mongo/utils/network_helpers.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""Helpers for network interfaces."""
+
+from collections.abc import Sequence
+
+from ops import Relation
+from ops.hookcmds import BindAddress, Network, network_get
+
+
+def ip_addresses(bind_addresses: Sequence[BindAddress]) -> Sequence[str]:
+    """Returns all ip addresses for a sequence of bindaddress."""
+    return [address.value for bind_address in bind_addresses for address in bind_address.addresses]
+
+
+def cidrs(bind_addresses: Sequence[BindAddress]) -> list[str]:
+    """Returns all ip addresses for a sequence of bindaddress."""
+    return [address.cidr for bind_address in bind_addresses for address in bind_address.addresses]
+
+
+def network_for_relation(relation: Relation) -> Network:
+    """Return network for a specific relation."""
+    return network_get(binding_name=relation.name, relation_id=relation.id)

--- a/single_kernel_mongo/utils/network_helpers.py
+++ b/single_kernel_mongo/utils/network_helpers.py
@@ -17,7 +17,14 @@ def ip_addresses(bind_addresses: Sequence[BindAddress]) -> Sequence[str]:
 
 def cidrs(bind_addresses: Sequence[BindAddress]) -> list[str]:
     """Returns all ip addresses for a sequence of bindaddress."""
-    return [address.cidr for bind_address in bind_addresses for address in bind_address.addresses]
+    result: set[str] = set()
+    for bind_address in bind_addresses:
+        for address in bind_address.addresses:
+            if address.cidr:
+                result.add(address.cidr)
+            else:
+                result.add(f"{address.value}/24")
+    return sorted(result)
 
 
 def network_for_relation(relation: Relation) -> Network:

--- a/tests/integration/applications/continuous_write_charm/src/charm.py
+++ b/tests/integration/applications/continuous_write_charm/src/charm.py
@@ -154,16 +154,15 @@ class ContinuousWritesApplication(CharmBase):
         # read the last written_value
         try:
             for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(5)):
-                with attempt:
-                    with open(self.last_written_filename(db_name, collection_name)) as fd:
-                        last_written_value = int(fd.read())
+                with attempt, open(self.last_written_filename(db_name, collection_name)) as fd:
+                    last_written_value = int(fd.read())
+                    os.remove(self.last_written_filename(db_name, collection_name))
+                    logger.info(f"Stopped writing at {last_written_value=}")
+                    return last_written_value
         except RetryError as e:
             logger.exception("Unable to query the database", exc_info=e)
             return -1
 
-        os.remove(self.last_written_filename(db_name, collection_name))
-        logger.info(f"Stopped writing at {last_written_value=}")
-        return last_written_value
 
     def proc_id_key(self, db_name: str, collection_name: str) -> str:
         """Returns a process id key for the continuous writes process to a given db and coll."""

--- a/tests/integration/applications/continuous_write_charm/src/continuous_writes.py
+++ b/tests/integration/applications/continuous_write_charm/src/continuous_writes.py
@@ -31,14 +31,20 @@ def continous_writes(
 
     # First, create a unique index to avoid duplicate writes on upsert
     # https://www.mongodb.com/docs/manual/reference/method/db.collection.update/#upsert-with-duplicate-values
-    client = MongoClient(
-        connection_string,
-        socketTimeoutMS=5000,
-    )
-    db = client[db_name]
-    test_collection = db[coll_name]
-    test_collection.create_index([("number", ASCENDING)], unique=True, sparse=True)
-    client.close()
+    try:
+        client = MongoClient(
+            connection_string,
+            socketTimeoutMS=5000,
+        )
+        db = client[db_name]
+        test_collection = db[coll_name]
+        test_collection.create_index([("number", ASCENDING)], unique=True, sparse=True)
+        client.close()
+    except:
+        with open(f"last_written_value-{db_name}-{coll_name}", "w") as fd:
+            fd.write(str(0))
+        return
+
 
     while run:
         client = MongoClient(

--- a/tests/integration/applications/continuous_write_charm/src/continuous_writes.py
+++ b/tests/integration/applications/continuous_write_charm/src/continuous_writes.py
@@ -42,7 +42,7 @@ def continous_writes(
         client.close()
     except:
         with open(f"last_written_value-{db_name}-{coll_name}", "w") as fd:
-            fd.write(str(0))
+            fd.write(str(-1))
         return
 
 

--- a/tests/integration/applications/continuous_write_charm/src/continuous_writes.py
+++ b/tests/integration/applications/continuous_write_charm/src/continuous_writes.py
@@ -20,6 +20,9 @@ def sigterm_handler(_signo, _stack_frame):
     global run
     run = False
 
+def last_written_filename(db_name: str, coll_name: str) -> str:
+    return f"last_written_value-{db_name}-{coll_name}"
+
 
 def continous_writes(
     connection_string: str,
@@ -41,7 +44,7 @@ def continous_writes(
         test_collection.create_index([("number", ASCENDING)], unique=True, sparse=True)
         client.close()
     except:
-        with open(f"last_written_value-{db_name}-{coll_name}", "w") as fd:
+        with open(last_written_filename(db_name, coll_name), "w") as fd:
             fd.write(str(-1))
         return
 
@@ -74,7 +77,7 @@ def continous_writes(
 
         write_value += 1
 
-    with open(f"last_written_value-{db_name}-{coll_name}", "w") as fd:
+    with open(last_written_filename(db_name, coll_name), "w") as fd:
         fd.write(str(write_value - 1))
 
 

--- a/tests/integration/helpers/common.py
+++ b/tests/integration/helpers/common.py
@@ -108,6 +108,8 @@ async def deploy_charm(
     subordinate: bool = False,
     storage: dict[str, str] | None = None,
     series: str | None = None,
+    constraints: dict[str, list[str]] | None = None,
+    bind: dict[str, str] | None = None,
 ):
     if substrate == "microk8s":
         series = series or "noble"
@@ -130,6 +132,8 @@ async def deploy_charm(
             config=config,
             channel=channel,
             storage=storage,
+            constraints=constraints,
+            bind=bind,
         )
 
 
@@ -137,6 +141,8 @@ async def deploy_application(
     ops_test: OpsTest,
     application_path: str,
     app_name: str,
+    constraints: dict[str, list[str]] | None = None,
+    bind: dict[str, str] | None = None,
 ):
     """Deploys the helpers applications with one unit and waits for idle."""
     application_name = await get_app_name(ops_test, app_name)
@@ -147,6 +153,8 @@ async def deploy_application(
         application_name=app_name,
         num_units=1,
         series="noble",
+        constraints=constraints,
+        bind=bind,
     )
     # TODO: remove raise_on_error when we move to juju 3.5 (DPE-4996)
     await ops_test.model.wait_for_idle(

--- a/tests/integration/helpers/ldap.py
+++ b/tests/integration/helpers/ldap.py
@@ -94,7 +94,9 @@ async def deploy_glauth(ops_test: OpsTest, kubernetes_model: Model) -> None:
 
         await kubernetes_model.wait_for_idle([TRAEFIK_CHARM], status="active")
 
-        await kubernetes_model.integrate(LDAP_APP_NAME, POSTGRESQL_K8S)
+        await kubernetes_model.integrate(
+            f"{LDAP_APP_NAME}:pg-database", f"{POSTGRESQL_K8S}:database"
+        )
         await kubernetes_model.integrate(LDAP_APP_NAME, TLS_CERTIFICATES_APP_NAME)
         await kubernetes_model.integrate(LDAP_APP_NAME, LDAP_UTILS_APP_NAME)
 

--- a/tests/integration/mongodb/spaces/conftest.py
+++ b/tests/integration/mongodb/spaces/conftest.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+
+import logging
+import os
+import subprocess
+
+import pytest
+from pytest_operator.plugin import OpsTest
+
+DEFAULT_LXD_NETWORK = "lxdbr0"
+RAW_DNSMASQ = """dhcp-option=3
+dhcp-option=6"""
+
+logger = logging.getLogger(__name__)
+
+
+def _lxd_network(name: str, subnet: str, external: bool = True):
+    try:
+        output = subprocess.run(
+            [
+                "sudo",
+                "lxc",
+                "network",
+                "create",
+                name,
+                "--type=bridge",
+                f"ipv4.address={subnet}",
+                f"ipv4.nat={external}".lower(),
+                "ipv6.address=none",
+                "dns.mode=none",
+            ],
+            capture_output=True,
+            check=True,
+            encoding="utf-8",
+        ).stdout
+        logger.info(f"LXD network created: {output}")
+        output = subprocess.run(
+            ["sudo", "lxc", "network", "show", name],
+            capture_output=True,
+            check=True,
+            encoding="utf-8",
+        ).stdout
+        logger.debug(f"LXD network status: {output}")
+
+        if not external:
+            subprocess.check_output(
+                [
+                    "sudo",
+                    "lxc",
+                    "network",
+                    "set",
+                    name,
+                    "raw.dnsmasq",
+                    RAW_DNSMASQ,
+                ]
+            )
+
+        subprocess.check_output(
+            f"sudo ip link set up dev {name}".split(),
+        )
+    except subprocess.CalledProcessError as e:
+        if "The network already exists" in e.stderr:
+            logger.warning(f"LXD network {name} already created")
+            return
+        logger.error(f"Error creating LXD network {name} with: {e.returncode} {e.stderr}")
+        raise
+
+
+@pytest.fixture(scope="session", autouse=True)
+def lxd():
+    try:
+        # Set all networks' dns.mode=none
+        # We want to avoid check:
+        # https://github.com/canonical/lxd/blob/
+        #     762f7dc5c3dc4dbd0863a796898212d8fbe3f7c3/lxd/device/nic_bridged.go#L403
+        # As described on:
+        # https://discuss.linuxcontainers.org/t/
+        #     error-failed-start-validation-for-device-enp3s0f0-instance
+        #     -dns-name-net17-nicole-munoz-marketing-already-used-on-network/15586/22?page=2
+        subprocess.run(
+            [
+                "sudo",
+                "lxc",
+                "network",
+                "set",
+                DEFAULT_LXD_NETWORK,
+                "dns.mode=none",
+            ],
+            check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        logger.error(
+            f"Error creating LXD network {DEFAULT_LXD_NETWORK} with: {e.returncode} {e.stderr}"
+        )
+        raise
+
+    _lxd_network("client", "10.0.0.1/24", True)
+    _lxd_network("peers", "10.10.10.1/24", False)
+    _lxd_network("isolated", "10.20.20.1/24", False)
+    _lxd_network("sharding", "10.30.0.1/24", True)
+    _lxd_network("cluster", "10.40.0.1/24", True)
+    _lxd_network("config-server", "10.50.0.1/24", True)
+
+
+@pytest.fixture(scope="module")
+async def lxd_spaces(ops_test: OpsTest) -> None:
+    await ops_test.juju("reload-spaces")
+    await ops_test.juju("add-space", "client", "10.0.0.1/24")
+    await ops_test.juju("add-space", "peers", "10.10.10.1/24")
+    await ops_test.juju("add-space", "isolated", "10.20.20.1/24")
+    await ops_test.juju("add-space", "sharding", "10.30.0.1/24")
+    await ops_test.juju("add-space", "cluster", "10.40.0.1/24")
+    await ops_test.juju("add-space", "config-server", "10.50.0.1/24")
+
+
+@pytest.hookimpl()
+def pytest_sessionfinish(session, exitstatus):
+    if os.environ.get("CI", "true").lower() == "true":
+        # Nothing to do, as this is a temp runner only
+        return
+
+    def __exec(cmd):
+        try:
+            subprocess.check_output(cmd.split())
+        except subprocess.CalledProcessError as e:
+            # Log and try to delete the next network
+            logger.warning(f"Error deleting LXD network with: {e.returncode} {e.stderr}")
+
+    for network in ["client", "peers", "isolated", "sharding", "cluster", "config-server"]:
+        __exec(f"sudo lxc network delete {network}")
+
+    __exec(f"sudo lxc network unset {DEFAULT_LXD_NETWORK} dns.mode")

--- a/tests/integration/mongodb/spaces/test_spaced_database.py
+++ b/tests/integration/mongodb/spaces/test_spaced_database.py
@@ -82,11 +82,11 @@ async def test_integrate_with_spaces(ops_test: OpsTest):
         apps=[app_name, CONTINUOUS_WRITE_APPLICATION], status="active"
     )
 
+    unit = ops_test.model.applications[CONTINUOUS_WRITE_APPLICATION].units[0]
+
     # remove default route on client so traffic can't be routed through default interface
     logger.info("Flush default routes on client")
-    await ops_test.juju(
-        f"exec --unit {CONTINUOUS_WRITE_APPLICATION}/0 sudo ip route flush default".split()
-    )
+    await unit.run("sudo ip route flush default")
 
     await start_continous_writes(ops_test, CONTINUOUS_WRITE_APPLICATION)
     sleep(10)
@@ -125,5 +125,4 @@ async def test_integrate_with_isolated_space(ops_test: OpsTest, application_path
     sleep(10)
 
     number_of_writes = await stop_continous_writes(ops_test, ISOLATED_APP_NAME)
-    assert number_of_writes == 0, "network was not isolated enough"
-    await clear_continous_writes(ops_test, ISOLATED_APP_NAME)
+    assert number_of_writes <= 0, "network was not isolated enough"

--- a/tests/integration/mongodb/spaces/test_spaced_database.py
+++ b/tests/integration/mongodb/spaces/test_spaced_database.py
@@ -115,9 +115,11 @@ async def test_integrate_with_isolated_space(ops_test: OpsTest, application_path
 
     await ops_test.model.wait_for_idle(apps=[app_name, ISOLATED_APP_NAME], status="active")
 
+    unit = ops_test.model.applications[ISOLATED_APP_NAME].units[0]
+
     # remove default route on client so traffic can't be routed through default interface
     logger.info("Flush default routes on client")
-    await ops_test.juju(f"exec --unit {ISOLATED_APP_NAME}/0 sudo ip route flush default".split())
+    await unit.run("sudo ip route flush default")
 
     await start_continous_writes(ops_test, ISOLATED_APP_NAME)
     sleep(10)

--- a/tests/integration/mongodb/spaces/test_spaced_database.py
+++ b/tests/integration/mongodb/spaces/test_spaced_database.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+# Copyright 2026 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import logging
+from time import sleep
+
+import pytest
+from pytest_operator.plugin import OpsTest
+
+from tests.integration.conftest import stop_continous_writes
+from tests.integration.helpers.common import (
+    CONTINUOUS_WRITE_APPLICATION,
+    DEPLOYMENT_TIMEOUT,
+    UNIT_IDS,
+    check_or_scale_app,
+    clear_continous_writes,
+    deploy_application,
+    deploy_charm,
+    get_app_name,
+    start_continous_writes,
+)
+from tests.integration.helpers.types import Substrate
+
+logger = logging.getLogger(__name__)
+
+ISOLATED_APP_NAME = "isolated"
+
+
+@pytest.mark.skip_if_substrate("microk8s")
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(
+    ops_test: OpsTest,
+    mongodb_charm: str,
+    substrate: Substrate,
+    mongod_resource: dict[str, str],
+    base_app_name: str,
+    application_path: str,
+    lxd_spaces,
+):
+    """Build and deploy one unit of MongoDB."""
+    # it is possible for users to provide their own cluster for testing. Hence check if there
+    # is a pre-existing cluster.
+    app_name = await get_app_name(ops_test)
+    if app_name:
+        await check_or_scale_app(ops_test, substrate, app_name, len(UNIT_IDS))
+        return
+
+    await deploy_charm(
+        ops_test=ops_test,
+        charm=mongodb_charm,
+        substrate=substrate,
+        mongod_resource=mongod_resource,
+        app_name=base_app_name,
+        num_units=len(UNIT_IDS),
+        constraints={"spaces": ["client", "peers"]},
+        bind={"database-peers": "peers", "database": "client"},
+    )
+
+    await deploy_application(
+        ops_test=ops_test,
+        application_path=application_path,
+        app_name=CONTINUOUS_WRITE_APPLICATION,
+        constraints={"spaces": ["client"]},
+        bind={"database": "client"},
+    )
+
+    await ops_test.model.wait_for_idle(
+        apps=[base_app_name], timeout=DEPLOYMENT_TIMEOUT, status="active"
+    )
+
+
+@pytest.mark.skip_if_substrate("microk8s")
+@pytest.mark.abort_on_fail
+async def test_integrate_with_spaces(ops_test: OpsTest):
+    app_name = await get_app_name(ops_test)
+    await ops_test.model.integrate(
+        f"{app_name}:database", f"{CONTINUOUS_WRITE_APPLICATION}:database"
+    )
+
+    await ops_test.model.wait_for_idle(
+        apps=[app_name, CONTINUOUS_WRITE_APPLICATION], status="active"
+    )
+
+    # remove default route on client so traffic can't be routed through default interface
+    logger.info("Flush default routes on client")
+    await ops_test.juju(
+        f"exec --unit {CONTINUOUS_WRITE_APPLICATION}/0 sudo ip route flush default".split()
+    )
+
+    await start_continous_writes(ops_test, CONTINUOUS_WRITE_APPLICATION)
+    sleep(10)
+    number_of_writes = await stop_continous_writes(ops_test, CONTINUOUS_WRITE_APPLICATION)
+
+    assert number_of_writes > 0, "Show continuous writes failed."
+    await clear_continous_writes(ops_test, CONTINUOUS_WRITE_APPLICATION)
+
+
+@pytest.mark.skip_if_substrate("microk8s")
+@pytest.mark.abort_on_fail
+async def test_integrate_with_isolated_space(ops_test: OpsTest, application_path: str):
+    app_name = await get_app_name(ops_test)
+    await deploy_application(
+        ops_test=ops_test,
+        application_path=application_path,
+        app_name=ISOLATED_APP_NAME,
+        constraints={"spaces": ["isolated"]},
+        bind={"database": "isolated"},
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[ISOLATED_APP_NAME], timeout=DEPLOYMENT_TIMEOUT, status="waiting"
+    )
+
+    await ops_test.model.integrate(f"{app_name}:database", f"{ISOLATED_APP_NAME}:database")
+
+    await ops_test.model.wait_for_idle(apps=[app_name, ISOLATED_APP_NAME], status="active")
+
+    # remove default route on client so traffic can't be routed through default interface
+    logger.info("Flush default routes on client")
+    await ops_test.juju(f"exec --unit {ISOLATED_APP_NAME}/0 sudo ip route flush default".split())
+
+    await start_continous_writes(ops_test, ISOLATED_APP_NAME)
+    sleep(10)
+
+    number_of_writes = await stop_continous_writes(ops_test, ISOLATED_APP_NAME)
+    assert number_of_writes == 0, "network was not isolated enough"
+    await clear_continous_writes(ops_test, ISOLATED_APP_NAME)

--- a/tests/integration/mongodb/spaces/test_spaced_database.py
+++ b/tests/integration/mongodb/spaces/test_spaced_database.py
@@ -17,7 +17,9 @@ from tests.integration.helpers.common import (
     clear_continous_writes,
     deploy_application,
     deploy_charm,
+    get_address_of_unit,
     get_app_name,
+    get_unit_id,
     start_continous_writes,
 )
 from tests.integration.helpers.types import Substrate
@@ -72,7 +74,7 @@ async def test_build_and_deploy(
 
 @pytest.mark.skip_if_substrate("microk8s")
 @pytest.mark.abort_on_fail
-async def test_integrate_with_spaces(ops_test: OpsTest):
+async def test_integrate_with_spaces(ops_test: OpsTest, substrate: Substrate):
     app_name = await get_app_name(ops_test)
     await ops_test.model.integrate(
         f"{app_name}:database", f"{CONTINUOUS_WRITE_APPLICATION}:database"
@@ -87,6 +89,15 @@ async def test_integrate_with_spaces(ops_test: OpsTest):
     # remove default route on client so traffic can't be routed through default interface
     logger.info("Flush default routes on client")
     await unit.run("sudo ip route flush default")
+
+    # Get IP on database interface:
+    unit_address = await get_address_of_unit(
+        ops_test, substrate, get_unit_id(unit.name), CONTINUOUS_WRITE_APPLICATION
+    )
+
+    # Add a route to access all nodes in the replica set
+    logger.info("Add a route to contact all nodes on the replicaset")
+    await unit.run(f"sudo ip route add 10.10.10.0/24 via {unit_address}")
 
     await start_continous_writes(ops_test, CONTINUOUS_WRITE_APPLICATION)
     sleep(10)

--- a/tests/spread/mongodb/lxd/test_spaced_database.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_spaced_database.py/task.yaml
@@ -1,0 +1,10 @@
+summary: test_spaced_database.py
+environment:
+  TEST_MODULE: test_spaced_database.py
+execute: |
+  tox run -e integration -- "tests/integration/mongodb/spaces/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results
+systems:
+  - self-hosted-linux-amd64-noble-medium
+  - self-hosted-linux-arm64-noble-medium

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -91,6 +91,10 @@ def harness(mock_refresh, substrate: Substrate, mongod_base_path: Path) -> Harne
     harness.add_relation("database-peers", "database-peers")
     harness.add_relation("status-peers", "mongodb")
     harness.add_relation("ldap-peers", "ldap-peers")
+
+    # Add network
+    harness.add_network("10.0.0.10")
+
     harness.begin()
 
     if substrate == "microk8s":
@@ -127,6 +131,10 @@ def mongos_harness(mock_refresh, substrate: Substrate, mongos_base_path: Path) -
     harness.add_relation("status-peers", "mongos")
     harness.add_relation("ldap-peers", "ldap-peers")
     harness.add_relation("router-peers", "router-peers")
+
+    # Add network
+    harness.add_network("10.0.0.10")
+
     harness.begin()
     if substrate == "microk8s":
         container = harness.model.unit.get_container("mongos")
@@ -242,12 +250,12 @@ def mock_fs_interactions(mocker, substrate: Substrate) -> None:
 @pytest.fixture
 def mongodb_hostname(substrate: Substrate) -> str:
     if substrate == "lxd":
-        return "10.0.0.10"
+        return "192.0.2.0"
     return "mongodb-k8s-0.mongodb-k8s-endpoints"
 
 
 @pytest.fixture
 def second_hostname(substrate: Substrate) -> str:
     if substrate == "lxd":
-        return "10.0.0.11"
+        return "192.0.2.1"
     return "mongodb-k8s-1.mongodb-k8s-endpoints"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -48,6 +48,13 @@ class _MockRefreshVM:
 
 
 @pytest.fixture(autouse=True)
+def mock_unit_get(mocker):
+    mocker.patch(
+        "single_kernel_mongo.state.charm_state.get_host_public_ip", return_value={"10.0.0.1"}
+    )
+
+
+@pytest.fixture(autouse=True)
 def mock_network_get(mocker):
     mocker.patch(
         "single_kernel_mongo.state.charm_state.network_get",

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -5,6 +5,7 @@ from platform import platform
 import pytest
 import tomllib
 import yaml
+from ops.hookcmds import Network
 from ops.testing import Harness
 
 from single_kernel_mongo.lib.charms.operator_libs_linux.v2.snap import Snap, SnapState
@@ -44,6 +45,28 @@ class _MockRefreshVM:
 
     def unit_status_lower_priority(self, *, workload_is_running=True):
         return None
+
+
+@pytest.fixture(autouse=True)
+def mock_network_get(mocker):
+    mocker.patch(
+        "single_kernel_mongo.state.charm_state.network_get",
+        return_value=Network._from_dict(
+            {
+                "bind-addresses": [
+                    {
+                        "mac-address": "aa:bb",
+                        "interface-name": "eth0",
+                        "addresses": [
+                            {"hostname": "host", "value": "10.0.0.1", "cidr": "10.0.0.1/24"}
+                        ],
+                    }
+                ],
+                "egress-subnets": ["127.0.0.0/24"],
+                "ingress-addresses": ["10.0.0.1"],
+            }
+        ),
+    )
 
 
 @pytest.fixture(autouse=True)
@@ -250,12 +273,12 @@ def mock_fs_interactions(mocker, substrate: Substrate) -> None:
 @pytest.fixture
 def mongodb_hostname(substrate: Substrate) -> str:
     if substrate == "lxd":
-        return "192.0.2.0"
+        return "10.0.0.1"
     return "mongodb-k8s-0.mongodb-k8s-endpoints"
 
 
 @pytest.fixture
 def second_hostname(substrate: Substrate) -> str:
     if substrate == "lxd":
-        return "192.0.2.1"
+        return "10.0.0.2"
     return "mongodb-k8s-1.mongodb-k8s-endpoints"

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -48,13 +48,6 @@ class _MockRefreshVM:
 
 
 @pytest.fixture(autouse=True)
-def mock_unit_get(mocker):
-    mocker.patch(
-        "single_kernel_mongo.state.charm_state.get_host_public_ip", return_value={"10.0.0.1"}
-    )
-
-
-@pytest.fixture(autouse=True)
 def mock_network_get(mocker):
     mocker.patch(
         "single_kernel_mongo.state.charm_state.network_get",

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -637,7 +637,7 @@ def test_on_config_changed_upgrade_in_progress(harness, mocker, mongodb_name):
 
 @pytest.mark.parametrize("role", [MongoDBRoles.CONFIG_SERVER, MongoDBRoles.REPLICATION])
 def test_on_config_changed_valid_system_users_password_is_updated(
-    harness, mocker, mongodb_name, role
+    harness, mocker, mongodb_name, role, mock_fs_interactions
 ):
     set_user_password_mock = mocker.patch(
         "single_kernel_mongo.utils.mongo_connection.MongoConnection.set_user_password"
@@ -667,7 +667,9 @@ def test_on_config_changed_valid_system_users_password_is_updated(
 
 
 @pytest.mark.parametrize("role", [MongoDBRoles.CONFIG_SERVER, MongoDBRoles.REPLICATION])
-def test_on_config_changed_system_users_invalid_passwords(harness, mocker, mongodb_name, role):
+def test_on_config_changed_system_users_invalid_passwords(
+    harness, mocker, mongodb_name, role, mock_fs_interactions
+):
     set_user_password_mock = mocker.patch(
         "single_kernel_mongo.utils.mongo_connection.MongoConnection.set_user_password"
     )
@@ -689,7 +691,7 @@ def test_on_config_changed_system_users_invalid_passwords(harness, mocker, mongo
 
 @pytest.mark.parametrize("role", [MongoDBRoles.CONFIG_SERVER, MongoDBRoles.REPLICATION])
 def test_on_config_changed_system_users_password_did_not_changed(
-    harness, mocker, mongodb_name, role
+    harness, mocker, mongodb_name, role, mock_fs_interactions
 ):
     set_user_password_mock = mocker.patch(
         "single_kernel_mongo.utils.mongo_connection.MongoConnection.set_user_password"
@@ -717,7 +719,9 @@ def test_on_config_changed_system_users_password_did_not_changed(
 
 
 @pytest.mark.parametrize("role", [MongoDBRoles.CONFIG_SERVER, MongoDBRoles.REPLICATION])
-def test_on_config_changed_system_users_one_password_changed(harness, mocker, mongodb_name, role):
+def test_on_config_changed_system_users_one_password_changed(
+    harness, mocker, mongodb_name, role, mock_fs_interactions
+):
     set_user_password_mock = mocker.patch(
         "single_kernel_mongo.utils.mongo_connection.MongoConnection.set_user_password"
     )
@@ -746,7 +750,7 @@ def test_on_config_changed_system_users_one_password_changed(harness, mocker, mo
 
 
 def test_on_config_changed_system_users_do_not_update_passwords_on_shard(
-    harness, mocker, mongodb_name: str
+    harness, mocker, mongodb_name: str, mock_fs_interactions
 ):
     set_user_password_mock = mocker.patch(
         "single_kernel_mongo.utils.mongo_connection.MongoConnection.set_user_password"
@@ -768,7 +772,9 @@ def test_on_config_changed_system_users_do_not_update_passwords_on_shard(
 
 
 @pytest.mark.parametrize("role", [MongoDBRoles.CONFIG_SERVER, MongoDBRoles.REPLICATION])
-def test_on_config_changed_system_users_secret_does_not_exist(harness, mocker, role):
+def test_on_config_changed_system_users_secret_does_not_exist(
+    harness, mocker, role, mock_fs_interactions
+):
     set_user_password_mock = mocker.patch(
         "single_kernel_mongo.utils.mongo_connection.MongoConnection.set_user_password"
     )
@@ -791,7 +797,7 @@ def test_on_config_changed_system_users_secret_does_not_exist(harness, mocker, r
 
 @pytest.mark.parametrize("role", [MongoDBRoles.CONFIG_SERVER, MongoDBRoles.REPLICATION])
 def test_on_config_changed_system_users_fail_to_update_password(
-    harness, mocker, mongodb_name, role
+    harness, mocker, mongodb_name, role, mock_fs_interactions
 ):
     defer = mocker.patch("ops.framework.EventBase.defer")
     set_user_password_mock = mocker.patch(

--- a/tests/unit/test_charm_state.py
+++ b/tests/unit/test_charm_state.py
@@ -26,7 +26,7 @@ def test_app_hosts(
     harness.update_relation_data(rel_id, f"{mongodb_name}/1", PEER_ADDR[substrate])
     resulting_ips = harness.charm.operator.state.app_hosts
     if substrate == "lxd":
-        expected_ips = {"10.0.0.10", "127.4.5.6"}
+        expected_ips = {"10.0.0.1", "127.4.5.6"}
     else:
         expected_ips = {
             "mongodb-k8s-1.mongodb-k8s-endpoints",

--- a/tests/unit/test_charm_state.py
+++ b/tests/unit/test_charm_state.py
@@ -18,24 +18,6 @@ PEER_ADDR = {
 }
 
 
-def test_app_hosts(
-    harness: Harness[MongoTestCharm], mocker, mongodb_name: str, substrate: Substrate
-):
-    rel_id = harness.charm.model.get_relation(PeerRelationNames.PEERS.value).id  # type: ignore
-    harness.add_relation_unit(rel_id, f"{mongodb_name}/1")
-    harness.update_relation_data(rel_id, f"{mongodb_name}/1", PEER_ADDR[substrate])
-    resulting_ips = harness.charm.operator.state.app_hosts
-    if substrate == "lxd":
-        expected_ips = {"10.0.0.1", "127.4.5.6"}
-    else:
-        expected_ips = {
-            "mongodb-k8s-1.mongodb-k8s-endpoints",
-            "mongodb-k8s-0.mongodb-k8s-endpoints",
-        }
-
-    assert expected_ips == resulting_ips
-
-
 def test_config(harness: Harness[MongoTestCharm]):
     config = harness.charm.operator.state.config
     assert config.role == "replication"

--- a/tests/unit/test_cluster_manager.py
+++ b/tests/unit/test_cluster_manager.py
@@ -109,6 +109,7 @@ def test_share_secret_to_mongos(harness: Harness[MongoTestCharm], mocker, mongod
     harness.set_leader(True)
     harness.charm.operator.state.db_initialised = True
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.CONFIG_SERVER
+    harness.charm.operator.state.unit_peer_data.cluster_address = mongodb_hostname
 
     mocked_reconcile = mocker.patch(
         "single_kernel_mongo.managers.mongo.MongoManager.reconcile_mongo_users_and_dbs"
@@ -134,6 +135,7 @@ def test_share_secret_to_mongos_also_shares_ldap_config(
     harness.set_leader(True)
     harness.charm.operator.state.db_initialised = True
     harness.charm.operator.state.app_peer_data.role = MongoDBRoles.CONFIG_SERVER
+    harness.charm.operator.state.unit_peer_data.cluster_address = mongodb_hostname
 
     mocked_reconcile = mocker.patch(
         "single_kernel_mongo.managers.mongo.MongoManager.reconcile_mongo_users_and_dbs"

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -2,6 +2,7 @@ from pathlib import Path
 from typing import Any
 
 import pytest
+from ops.hookcmds import Network
 from ops.model import Relation
 from yaml import safe_dump
 
@@ -46,6 +47,20 @@ def test_mongodb_config_manager(mocker, role: MongoDBRoles, expected_parameter: 
     mock_state.app_peer_data.role = role
     mock_state.tls.peer_enabled = False
     mock_state.tls.client_enabled = False
+    mock_state.peer_network = lambda: Network._from_dict(
+        {
+            "bind-addresses": [
+                {
+                    "mac-address": "aa:bb",
+                    "interface-name": "eth0",
+                    "addresses": [{"hostname": "host", "value": "10.0.0.1", "cidr": "10.0.0.1/24"}],
+                }
+            ],
+            "egress-subnets": ["127.0.0.0/24"],
+            "ingress-addresses": ["10.0.0.1"],
+        }
+    )
+    mock_state.listen_ips = lambda: ["10.0.0.1", "127.0.0.1"]
     workload = VMMongoDBWorkload(VM_MONGOD, None)
     config = MongoDBCharmConfig()
     manager = MongoDBConfigManager(
@@ -63,6 +78,7 @@ def test_mongodb_config_manager(mocker, role: MongoDBRoles, expected_parameter: 
     audit_options = manager.audit_options
     auth_parameter = manager.auth_parameter
     client_tls_parameters = manager.client_tls_parameters
+    cluster_ips = manager.cluster_ips
 
     all_params = manager.build_config()
 
@@ -75,7 +91,7 @@ def test_mongodb_config_manager(mocker, role: MongoDBRoles, expected_parameter: 
             "journal": {"enabled": True},
         }
     }
-    assert binding_ips == {"net": {"bindIpAll": True}}
+    assert binding_ips == {"net": {"bindIp": "10.0.0.1,127.0.0.1"}}
     assert log_options == {
         "setParameter": {"processUmask": "037"},
         "systemLog": {
@@ -102,14 +118,16 @@ def test_mongodb_config_manager(mocker, role: MongoDBRoles, expected_parameter: 
         }
     }
     assert client_tls_parameters == {}
+    assert cluster_ips == {"security": {"clusterIpSourceAllowlist": ["10.0.0.1/24", "127.0.0.1"]}}
 
     assert (
         all_params
         == {
-            "net": {"bindIpAll": True, "port": 27017},
+            "net": {"bindIp": "10.0.0.1,127.0.0.1", "port": 27017},
             "security": {
                 "authorization": "enabled",
                 "clusterAuthMode": "keyFile",
+                "clusterIpSourceAllowlist": ["10.0.0.1/24", "127.0.0.1"],
                 "keyFile": f"{VM_PATH['mongod']['CONF']}/keyFile",
             },
             "setParameter": {"processUmask": "037"},
@@ -194,6 +212,19 @@ def test_mongos_config_manager(mocker):
     mock_state.tls.peer_enabled = False
     mock_state.tls.client_enabled = False
     mock_state.ldap.is_ready = lambda: False
+    mock_state.peer_network = lambda: Network._from_dict(
+        {
+            "bind-addresses": [
+                {
+                    "mac-address": "aa:bb",
+                    "interface-name": "eth0",
+                    "addresses": [{"hostname": "host", "value": "10.0.0.1", "cidr": "10.0.0.1/24"}],
+                }
+            ],
+            "egress-subnets": ["127.0.0.0/24"],
+            "ingress-addresses": ["10.0.0.1"],
+        }
+    )
     workload = VMMongosWorkload(VM_MONGOS, None)
     config = MongosCharmConfig()
     manager = MongosConfigManager(
@@ -209,6 +240,7 @@ def test_mongos_config_manager(mocker):
     auth_parameter = manager.auth_parameter
     client_tls_parameters = manager.client_tls_parameters
     config_server_db_parameter = manager.config_server_db_parameter
+    cluster_ips = manager.cluster_ips
 
     all_params = manager.build_config()
 
@@ -221,6 +253,7 @@ def test_mongos_config_manager(mocker):
             },
         }
     }
+    assert cluster_ips == {}
     assert log_options == {
         "setParameter": {"processUmask": "037"},
         "systemLog": {

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -60,7 +60,7 @@ def test_mongodb_config_manager(mocker, role: MongoDBRoles, expected_parameter: 
             "ingress-addresses": ["10.0.0.1"],
         }
     )
-    mock_state.listen_ips = lambda: ["10.0.0.1", "127.0.0.1"]
+    mock_state.listens_on = lambda: ["10.0.0.1", "127.0.0.1"]
     workload = VMMongoDBWorkload(VM_MONGOD, None)
     config = MongoDBCharmConfig()
     manager = MongoDBConfigManager(

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -3,6 +3,7 @@
 
 
 from single_kernel_mongo.utils.helpers import hostname_from_hostport, mask_sensitive_information
+from single_kernel_mongo.utils.network_helpers import get_cidr_for_ip_list
 
 
 def test_hostname_from_hostport():
@@ -12,3 +13,7 @@ def test_hostname_from_hostport():
 
 def test_mask_cmd():
     assert mask_sensitive_information("hmacSecret=deadbeef") == "hmacSecret=xxx"
+
+
+def test_get_cidr_for_ip_list():
+    assert get_cidr_for_ip_list(["10.0.3.254", "10.0.3.136"]) == "10.0.3.0/24"

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -2,8 +2,10 @@
 # See LICENSE file for licensing details.
 
 
+from ops.hookcmds import Network
+
 from single_kernel_mongo.utils.helpers import hostname_from_hostport, mask_sensitive_information
-from single_kernel_mongo.utils.network_helpers import get_cidr_for_ip_list
+from single_kernel_mongo.utils.network_helpers import cidrs, get_cidr_for_ip_list, ip_addresses
 
 
 def test_hostname_from_hostport():
@@ -17,3 +19,53 @@ def test_mask_cmd():
 
 def test_get_cidr_for_ip_list():
     assert get_cidr_for_ip_list(["10.0.3.254", "10.0.3.136"]) == "10.0.3.0/24"
+    assert get_cidr_for_ip_list(["10.0.3.254"]) == "10.0.3.254/24"
+    assert get_cidr_for_ip_list(["10.1.2.254", "10.1.3.136"]) == "10.1.0.0/16"
+    assert (
+        get_cidr_for_ip_list(["2001:1234:0:1000::", "2001:1234:0:1000:1234::"])
+        == "2001:1234:0:1000::/64"
+    )
+
+
+def test_ip_addresses():
+    network = Network._from_dict(
+        {
+            "bind-addresses": [
+                {
+                    "mac-address": "aa:bb",
+                    "interface-name": "eth0",
+                    "addresses": [{"hostname": "host", "value": "10.0.0.1", "cidr": "10.0.0.1/24"}],
+                },
+                {
+                    "mac-address": "cc:dd",
+                    "interface-name": "enp0s9",
+                    "addresses": [{"hostname": "host", "value": "10.0.1.2", "cidr": "10.0.1.1/24"}],
+                },
+            ],
+            "egress-subnets": ["127.0.0.0/24"],
+            "ingress-addresses": ["10.0.0.1"],
+        }
+    )
+    assert ip_addresses(network.bind_addresses) == ["10.0.0.1", "10.0.1.2"]
+
+
+def test_cidrs():
+    network = Network._from_dict(
+        {
+            "bind-addresses": [
+                {
+                    "mac-address": "aa:bb",
+                    "interface-name": "eth0",
+                    "addresses": [{"hostname": "host", "value": "10.0.0.1", "cidr": "10.0.0.1/24"}],
+                },
+                {
+                    "mac-address": "cc:dd",
+                    "interface-name": "enp0s9",
+                    "addresses": [{"hostname": "host", "value": "10.0.1.2", "cidr": "10.0.1.1/24"}],
+                },
+            ],
+            "egress-subnets": ["127.0.0.0/24"],
+            "ingress-addresses": ["10.0.0.1"],
+        }
+    )
+    assert cidrs(network.bind_addresses) == ["10.0.0.1/24", "10.0.1.1/24"]

--- a/tests/unit/test_mongo_manager.py
+++ b/tests/unit/test_mongo_manager.py
@@ -81,7 +81,10 @@ def test_initialise_user(harness: Harness[MongoTestCharm], mocker, user):
         config.username,
         config.password,
         config.supported_roles,
-        auth_restrictions=[{"clientSource": ["10.0.0.1/24"], "serverAddress": ["127.0.0.1"]}],
+        auth_restrictions=[
+            {"clientSource": ["127.0.0.1"], "serverAddress": ["127.0.0.1"]},
+            {"clientSource": ["10.0.0.1/24"], "serverAddress": ["10.0.0.1/24"]},
+        ],
     )
 
     assert harness.charm.operator.state.app_peer_data.is_user_created(user.username)

--- a/tests/unit/test_mongo_manager.py
+++ b/tests/unit/test_mongo_manager.py
@@ -77,7 +77,12 @@ def test_initialise_user(harness: Harness[MongoTestCharm], mocker, user):
     )
 
     mock_create_role.assert_called_with(role_name=user.mongodb_role, privileges=user.privileges)
-    mock_create_user.assert_called_with(config.username, config.password, config.supported_roles)
+    mock_create_user.assert_called_with(
+        config.username,
+        config.password,
+        config.supported_roles,
+        auth_restrictions=[{"clientSource": ["10.0.0.1/24"], "serverAddress": ["127.0.0.1"]}],
+    )
 
     assert harness.charm.operator.state.app_peer_data.is_user_created(user.username)
 

--- a/tests/unit/test_sharding.py
+++ b/tests/unit/test_sharding.py
@@ -198,7 +198,6 @@ def test_config_server_add_shard(harness: Harness[MongoTestCharm], mocker, subst
     harness.update_relation_data(
         rel_id, "shard0", {"requested-secrets": '["unused"]', "database": "unused"}
     )
-    # harness.update_relation_data(rel_id, "shard0/0", {"private-address": "2.2.2.2"})
     if substrate == "lxd":
         harness.update_relation_data(rel_id, "shard0", {"rs-hosts": '["2.2.2.2"]'})
     else:

--- a/tests/unit/test_sharding.py
+++ b/tests/unit/test_sharding.py
@@ -198,7 +198,13 @@ def test_config_server_add_shard(harness: Harness[MongoTestCharm], mocker, subst
     harness.update_relation_data(
         rel_id, "shard0", {"requested-secrets": '["unused"]', "database": "unused"}
     )
-    harness.update_relation_data(rel_id, "shard0/0", {"private-address": "2.2.2.2"})
+    # harness.update_relation_data(rel_id, "shard0/0", {"private-address": "2.2.2.2"})
+    if substrate == "lxd":
+        harness.update_relation_data(rel_id, "shard0", {"rs-hosts": '["2.2.2.2"]'})
+    else:
+        harness.update_relation_data(
+            rel_id, "shard0", {"rs-hosts": '["shard0-0.shard0-endpoints"]'}
+        )
 
     manager.add_shard(relation)
 

--- a/tests/unit/test_status_handler.py
+++ b/tests/unit/test_status_handler.py
@@ -28,14 +28,14 @@ from tests.charms.mongos_test_charm.src.charm import MongosTestCharm
     ("replset_status", "expected_status"),
     (
         ({}, MaintenanceStatus("Adding member...")),
-        ({"10.0.0.10": "PRIMARY"}, ActiveStatus("Primary.")),
-        ({"10.0.0.10": "SECONDARY"}, ActiveStatus("")),
-        ({"10.0.0.10": "STARTUP"}, MaintenanceStatus("Syncing member...")),
-        ({"10.0.0.10": "STARTUP2"}, MaintenanceStatus("Syncing member...")),
-        ({"10.0.0.10": "ROLLBACK"}, MaintenanceStatus("Syncing member...")),
-        ({"10.0.0.10": "RECOVERING"}, MaintenanceStatus("Syncing member...")),
-        ({"10.0.0.10": "REMOVED"}, MaintenanceStatus("Removing member...")),
-        ({"10.0.0.10": "ERROR"}, BlockedStatus("ERROR")),
+        ({"10.0.0.1": "PRIMARY"}, ActiveStatus("Primary.")),
+        ({"10.0.0.1": "SECONDARY"}, ActiveStatus("")),
+        ({"10.0.0.1": "STARTUP"}, MaintenanceStatus("Syncing member...")),
+        ({"10.0.0.1": "STARTUP2"}, MaintenanceStatus("Syncing member...")),
+        ({"10.0.0.1": "ROLLBACK"}, MaintenanceStatus("Syncing member...")),
+        ({"10.0.0.1": "RECOVERING"}, MaintenanceStatus("Syncing member...")),
+        ({"10.0.0.1": "REMOVED"}, MaintenanceStatus("Removing member...")),
+        ({"10.0.0.1": "ERROR"}, BlockedStatus("ERROR")),
     ),
 )
 def test_mongo_get_status_no_error_lxd(

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -719,7 +719,9 @@ def test_tls_relation_broken_log_upgrade_in_progress(
     mock_defer.assert_called()
 
 
-def test_tls_config_changed(harness: Harness[MongoTestCharm], mocker, mongodb_name):
+def test_tls_config_changed(
+    harness: Harness[MongoTestCharm], mocker, mongodb_name, mock_fs_interactions
+):
     manager = harness.charm.operator.tls_manager
     harness.set_leader(True)
     harness.charm.operator.state.db_initialised = True
@@ -744,7 +746,9 @@ def test_tls_config_changed(harness: Harness[MongoTestCharm], mocker, mongodb_na
     spied.assert_called()
 
 
-def test_tls_config_changed_invalid_key(harness: Harness[MongoTestCharm], mocker, mongodb_name):
+def test_tls_config_changed_invalid_key(
+    harness: Harness[MongoTestCharm], mocker, mongodb_name, mock_fs_interactions
+):
     manager = harness.charm.operator.tls_manager
     harness.set_leader(True)
     harness.charm.operator.state.db_initialised = True
@@ -779,7 +783,9 @@ def test_tls_config_changed_invalid_key(harness: Harness[MongoTestCharm], mocker
     )
 
 
-def test_tls_config_changed_invalid_keys(harness: Harness[MongoTestCharm], mocker, mongodb_name):
+def test_tls_config_changed_invalid_keys(
+    harness: Harness[MongoTestCharm], mocker, mongodb_name, mock_fs_interactions
+):
     manager = harness.charm.operator.tls_manager
     harness.set_leader(True)
     harness.charm.operator.state.db_initialised = True


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷️ Type of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling and CI
- [ ] Dependencies upgrade or change
- [ ] Chores / refactoring

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and feature scope of this PR (what)
  - the motivation behind this change (why)
  - the impacted components (often matches conventional commit scope)
  - explanation/algorithm if required (how)
-->
This PR implements support for juju spaces according to [DA243](https://docs.google.com/document/d/1cQD2fYq4lo81lxfSs8t4d000-SBOrpFsDFllJB1e-sA/edit?usp=sharing).

It contains:
 * Restriction of the IPs the server listens on to specific interfaces
 * Restriction of the CIDRS that can be part of the cluster
 * Restriction of the IPs shared to clients to the specific interfaces
 * User authenticationRestriction in non sharded mode (not possible on sharded mode for a variety of reasons.

## 🧪 Manual testing steps
<!--- Give a list of instructions to manually test your change. -->
<!--- These instructions are meant for reviewers to test the PR -->
<!--- on their development environment. -->

```text
1. sudo lxc network create peers --type=bridge ipv4.address="10.137.180.1/24" ipv4.nat=True ipv6.address=none dns.mode=none
2. sudo lxc network create clients --type=bridge ipv4.address="10.137.181.1/24" ipv4.nat=True ipv6.address=none dns.mode=none
3. sudo lxc network set clients raw.dnsmasq "dhcp-option=3
dhcp-option=6"
4. sudo lxc network set peers raw.dnsmasq "dhcp-option=3
dhcp-option=6"
5. juju reload-spaces
6. juju add-space clients 10.137.181.1/24
7. juju add-space peers 10.137.180.1/24
8. juju deploy ./tests/charms/mongodb_test_charm/mongodb_ubuntu@24.04-amd64.charm --constraints spaces=peers,clients --bind "alpha database-peers=peers database=clients" -n3
9. juju deploy ./tests/integration/applications/client_relations_charm/application_ubuntu@24.04-amd64.charm --bind "alpha first-database=clients"
10. juju integrate mongodb application:first-database
11. The URI should contain IPs in the slash 10.137.181.1/24
```

## 🔬 Automated testing steps
<!--- Describe the unit and integration tests that you added -->
<!--- to ensure that this feature works as expected. Include details -->
<!--- on the positive and negative test cases, as well as any changes -->
<!--- made to the existing tests to ensure they are still relevant. -->
TBD

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have added or updated any relevant documentation.
- [x] I have read the [**CONTRIBUTING**](../blob/8/edge/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
