### PR TITLE
patch(DPE-9525): Shard integration and backups stability

### DIFF
--- a/single_kernel_mongo/managers/sharding.py
+++ b/single_kernel_mongo/managers/sharding.py
@@ -367,6 +367,12 @@ class ConfigServerManager(Object, ManagerStatusProtocol):
                 logger.error(f"Failed to add {shard_name} to cluster")
                 raise e
 
+        # Say to the shard that it has been integrated
+        self.data_interface.update_relation_data(
+            relation.id,
+            {AppShardingComponentKeys.SHARD_INTEGRATED.value: json.dumps(True)},
+        )
+
     def remove_shards(self) -> None:
         """During update-status, remove shards until they are removed completely.
 
@@ -529,8 +535,8 @@ class ShardManager(Object, ManagerStatusProtocol):
 
         # Edge case for DPE-4998
         # TODO: Remove this when https://github.com/canonical/operator/issues/1306 is fixed.
-        if relation.app is None:
-            raise NonDeferrableFailedHookChecksError("Missing app information in event, skipping.")
+        if relation.app is None:  # pyright: ignore[reportUnnecessaryComparison]
+            raise NonDeferrableFailedHookChecksError("Missing app information in event, skipping.")  # pyright: ignore[reportUnreachable]
 
         if is_leaving and not self.state.app_peer_data.mongos_hosts:
             raise NonDeferrableFailedHookChecksError(
@@ -599,6 +605,10 @@ class ShardManager(Object, ManagerStatusProtocol):
         if not self.dependent.mongo_manager.mongod_ready():
             logger.info("MongoDB is not ready")
             raise NotReadyError
+
+        # We restart PBM only when the shard is integrated on the cluster side.
+        if self.state.shard_state.shard_integrated:
+            self.dependent.s3_backup_manager.configure_and_restart()
 
         # By setting the status we ensure that the former statuses of this component are removed.
         self.state.statuses.set(ShardStatuses.ACTIVE_IDLE.value, scope="unit", component=self.name)

--- a/single_kernel_mongo/state/charm_state.py
+++ b/single_kernel_mongo/state/charm_state.py
@@ -660,6 +660,9 @@ class CharmState(Object, StatusesStateProtocol):
         if self.shard_state.external_ca_secret is not None and not self.tls.client_enabled:
             return False
 
+        if not self.shard_state.shard_integrated:
+            return False
+
         try:
             # check our ability to use connect to mongos
             with MongoConnection(self.remote_mongos_config) as mongos:

--- a/single_kernel_mongo/state/config_server_state.py
+++ b/single_kernel_mongo/state/config_server_state.py
@@ -117,12 +117,17 @@ class AppShardingComponentState(AbstractRelationState[Data]):
 
     @property
     def shard_integrated(self) -> bool:
-        """Returns the backup ca secret."""
+        """Returns the shard integrated flag."""
         if not self.relation:
             return False
         return json.loads(
             self.relation_data.get(AppShardingComponentKeys.SHARD_INTEGRATED.value, "false")
         )
+
+    @shard_integrated.setter
+    def shard_integrated(self, value: bool) -> None:
+        """Sets the shard integrated flag."""
+        self.update({AppShardingComponentKeys.SHARD_INTEGRATED.value: json.dumps(value)})
 
 
 class UnitShardingComponentState(AbstractRelationState[Data]):

--- a/single_kernel_mongo/state/config_server_state.py
+++ b/single_kernel_mongo/state/config_server_state.py
@@ -18,17 +18,18 @@ class AppShardingComponentKeys(str, Enum):
     """Config Server State Model for the application."""
 
     DATABASE = "database"
-    OPERATOR_PASSWORD = "charmed-operator-password"
-    BACKUP_PASSWORD = "charmed-backup-password"
+    OPERATOR_PASSWORD = "charmed-operator-password"  # nosec: B105
+    BACKUP_PASSWORD = "charmed-backup-password"  # nosec: B105
     HOST = "host"
     KEY_FILE = "key-file"
-    INT_CA_SECRET = "int-ca-secret"
-    EXT_CA_SECRET = "ext-ca-secret"
-    BACKUP_CA_SECRET = "backup-ca-secret"
+    INT_CA_SECRET = "int-ca-secret"  # nosec: B105
+    EXT_CA_SECRET = "ext-ca-secret"  # nosec: B105
+    BACKUP_CA_SECRET = "backup-ca-secret"  # nosec: B105
+    SHARD_INTEGRATED = "shard-integrated"
 
     # We don't use those except to check if we've received credentials
-    USERNAME = "username"
-    PASSWORD = "password"
+    USERNAME = "username"  # nosec: B105
+    PASSWORD = "password"  # nosec: B105
 
 
 SECRETS_FIELDS = [
@@ -112,6 +113,15 @@ class AppShardingComponentState(AbstractRelationState[Data]):
             return None
         return json.loads(
             self.relation_data.get(AppShardingComponentKeys.BACKUP_CA_SECRET.value, "null")
+        )
+
+    @property
+    def shard_integrated(self) -> bool:
+        """Returns the backup ca secret."""
+        if not self.relation:
+            return False
+        return json.loads(
+            self.relation_data.get(AppShardingComponentKeys.SHARD_INTEGRATED.value, "false")
         )
 
 

--- a/tests/integration/helpers/backups.py
+++ b/tests/integration/helpers/backups.py
@@ -73,7 +73,7 @@ async def count_logical_backups(db_unit: JujuUnit) -> int:
     list_result = list_result.split("\n")
     backups = 0
     for res in list_result:
-        if "logical" in res and "finished" in res:
+        if "logical" in res and "in progress" not in res:
             backups += 1
 
     return backups

--- a/tests/integration/helpers/backups.py
+++ b/tests/integration/helpers/backups.py
@@ -73,7 +73,8 @@ async def count_logical_backups(db_unit: JujuUnit) -> int:
     list_result = list_result.split("\n")
     backups = 0
     for res in list_result:
-        backups += 1 if "logical" in res else 0
+        if "logical" in res and "finished" in res:
+            backups += 1
 
     return backups
 

--- a/tests/integration/helpers/ldap.py
+++ b/tests/integration/helpers/ldap.py
@@ -94,7 +94,9 @@ async def deploy_glauth(ops_test: OpsTest, kubernetes_model: Model) -> None:
 
         await kubernetes_model.wait_for_idle([TRAEFIK_CHARM], status="active")
 
-        await kubernetes_model.integrate(LDAP_APP_NAME, POSTGRESQL_K8S)
+        await kubernetes_model.integrate(
+            f"{LDAP_APP_NAME}:pg-database", f"{POSTGRESQL_K8S}:database"
+        )
         await kubernetes_model.integrate(LDAP_APP_NAME, TLS_CERTIFICATES_APP_NAME)
         await kubernetes_model.integrate(LDAP_APP_NAME, LDAP_UTILS_APP_NAME)
 

--- a/tests/integration/mongodb/backups/test_backups_gcs.py
+++ b/tests/integration/mongodb/backups/test_backups_gcs.py
@@ -158,7 +158,7 @@ async def test_create_and_list_backups(ops_test: OpsTest, cloud_configs: CloudCo
     # backup can take a lot of time so this function returns once the command was successfully
     # sent to pbm. Therefore we should retry listing the backup several times
     try:
-        for attempt in Retrying(stop=stop_after_delay(20), wait=wait_fixed(3)):
+        for attempt in Retrying(stop=stop_after_delay(30), wait=wait_fixed(5)):
             with attempt:
                 backups = await count_logical_backups(leader_unit)
                 assert backups == 1
@@ -184,7 +184,7 @@ async def test_restore(ops_test: OpsTest, add_writes_to_db, substrate: Substrate
 
     # verify that backup was made on the bucket
     try:
-        for attempt in Retrying(stop=stop_after_attempt(10), wait=wait_fixed(5)):
+        for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(5)):
             with attempt:
                 backups = await count_logical_backups(leader_unit)
                 assert backups == prev_backups + 1, "Backup not created."
@@ -218,7 +218,7 @@ async def test_restore(ops_test: OpsTest, add_writes_to_db, substrate: Substrate
 
     # verify all writes are present
     try:
-        for attempt in Retrying(stop=stop_after_attempt(5), wait=wait_fixed(20)):
+        for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(5)):
             with attempt:
                 number_writes_restored = await count_writes(
                     ops_test, substrate, db_app_name, leader_unit

--- a/tests/integration/mongodb/backups/test_backups_gcs_deprecated.py
+++ b/tests/integration/mongodb/backups/test_backups_gcs_deprecated.py
@@ -110,7 +110,7 @@ async def test_create_and_list_backups(ops_test: OpsTest, cloud_configs: CloudCo
     # backup can take a lot of time so this function returns once the command was successfully
     # sent to pbm. Therefore we should retry listing the backup several times
     try:
-        for attempt in Retrying(stop=stop_after_delay(20), wait=wait_fixed(3)):
+        for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(5)):
             with attempt:
                 backups = await count_logical_backups(leader_unit)
                 assert backups == 1
@@ -135,7 +135,7 @@ async def test_restore(ops_test: OpsTest, add_writes_to_db, substrate: Substrate
 
     # verify that backup was made on the bucket
     try:
-        for attempt in Retrying(stop=stop_after_attempt(10), wait=wait_fixed(5)):
+        for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(5)):
             with attempt:
                 backups = await count_logical_backups(leader_unit)
                 assert backups == prev_backups + 1, "Backup not created."

--- a/tests/integration/mongodb/backups/test_backups_s3.py
+++ b/tests/integration/mongodb/backups/test_backups_s3.py
@@ -174,7 +174,7 @@ async def test_create_and_list_backups(ops_test: OpsTest, cloud_configs: CloudCo
     # backup can take a lot of time so this function returns once the command was successfully
     # sent to pbm. Therefore we should retry listing the backup several times
     try:
-        for attempt in Retrying(stop=stop_after_delay(20), wait=wait_fixed(3)):
+        for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(5)):
             with attempt:
                 backups = await count_logical_backups(leader_unit)
                 assert backups == 1
@@ -199,7 +199,7 @@ async def test_restore(ops_test: OpsTest, add_writes_to_db, substrate: Substrate
 
     # verify that backup was made on the bucket
     try:
-        for attempt in Retrying(stop=stop_after_attempt(10), wait=wait_fixed(5)):
+        for attempt in Retrying(stop=stop_after_delay(60), wait=wait_fixed(5)):
             with attempt:
                 backups = await count_logical_backups(leader_unit)
                 assert backups == prev_backups + 1, "Backup not created."

--- a/tests/integration/mongodb/backups/test_sharded_backups_tls.py
+++ b/tests/integration/mongodb/backups/test_sharded_backups_tls.py
@@ -7,8 +7,9 @@ from logging import getLogger
 
 import pytest
 from pytest_operator.plugin import OpsTest
+from tenacity import Retrying, stop_after_delay, wait_fixed
 
-from ...helpers.backups import S3_APP_NAME, S3_ENDPOINT
+from ...helpers.backups import S3_APP_NAME, S3_ENDPOINT, count_logical_backups
 from ...helpers.common import (
     DEPLOYMENT_TIMEOUT,
     TIMEOUT,
@@ -131,6 +132,15 @@ async def test_create_backup(ops_test: OpsTest) -> None:
     first_backup = await action.wait()
     assert first_backup.status == "completed", "First backup not started."
 
+    # verify backup is present in the list of backups
+    # the action `create-backup` only confirms that the command was sent to the `pbm`. Creating a
+    # backup can take a lot of time so this function returns once the command was successfully
+    # sent to pbm. Therefore we should retry listing the backup several times
+    for attempt in Retrying(stop=stop_after_delay(TIMEOUT), wait=wait_fixed(3), reraise=True):
+        with attempt:
+            backups = await count_logical_backups(leader_unit)
+            assert backups == 1
+
 
 @pytest.mark.abort_on_fail
 async def test_backup_restore(ops_test: OpsTest, add_writes_to_shard, substrate: Substrate) -> None:
@@ -161,13 +171,15 @@ async def test_backup_restore(ops_test: OpsTest, add_writes_to_shard, substrate:
     first_backup = await action.wait()
     assert first_backup.status == "completed", "First backup not started."
 
+    for attempt in Retrying(stop=stop_after_delay(TIMEOUT), wait=wait_fixed(3), reraise=True):
+        with attempt:
+            backups = await count_logical_backups(leader_unit)
+            assert backups == 2
+
     action = await leader_unit.run_action(action_name="list-backups")
     list_result = await action.wait()
     list_result = list_result.results["backups"]
     most_recent_backup = list_result.split("\n")[-1]
-
-    # Wait for backup to be finished
-    await ops_test.model.wait_for_idle(apps=[db_app_name], status="active", idle_period=20)
 
     # add writes to be cleared after restoring the backup.
     await add_and_verify_unwanted_writes(ops_test, substrate, leader_unit, cluster_writes)

--- a/tests/integration/mongodb/backups/test_sharding_backups.py
+++ b/tests/integration/mongodb/backups/test_sharding_backups.py
@@ -204,7 +204,7 @@ async def test_rotate_backup_password(ops_test: OpsTest) -> None:
     # the action `create-backup` only confirms that the command was sent to the `pbm`. Creating a
     # backup can take a lot of time so this function returns once the command was successfully
     # sent to pbm. Therefore we should retry listing the backup several times
-    for attempt in Retrying(stop=stop_after_delay(20), wait=wait_fixed(3), reraise=True):
+    for attempt in Retrying(stop=stop_after_delay(TIMEOUT), wait=wait_fixed(3), reraise=True):
         with attempt:
             backups = await count_logical_backups(leader_unit)
             assert backups == 2, "Backup not created after password rotation."
@@ -242,7 +242,7 @@ async def test_restore_backup(ops_test: OpsTest, substrate: Substrate, add_write
     assert first_backup.status == "completed", "First backup not started."
 
     # verify that backup was made on the bucket
-    for attempt in Retrying(stop=stop_after_delay(4), wait=wait_fixed(5), reraise=True):
+    for attempt in Retrying(stop=stop_after_delay(TIMEOUT), wait=wait_fixed(3), reraise=True):
         with attempt:
             backups = await count_logical_backups(leader_unit)
             assert backups == prev_backups + 1, "Backup not created."

--- a/tests/integration/mongodb/test_major_upgrades.py
+++ b/tests/integration/mongodb/test_major_upgrades.py
@@ -7,7 +7,7 @@ from logging import getLogger
 
 import pytest
 from pytest_operator.plugin import OpsTest
-from tenacity import RetryError, Retrying, stop_after_attempt, wait_fixed
+from tenacity import RetryError, Retrying, stop_after_delay, wait_fixed
 
 from tests.integration.helpers.backups import S3_APP_NAME, count_logical_backups
 from tests.integration.helpers.common import (
@@ -106,7 +106,7 @@ async def test_backup_mongodb_6(ops_test: OpsTest, s3_bucket):
 
     # verify that backup was made on the bucket
     try:
-        for attempt in Retrying(stop=stop_after_attempt(10), wait=wait_fixed(5)):
+        for attempt in Retrying(stop=stop_after_delay(TIMEOUT), wait=wait_fixed(5)):
             with attempt:
                 backups = await count_logical_backups(leader_unit)
                 assert backups == 1, "Backup not created."
@@ -194,7 +194,7 @@ async def test_backup_mongodb_7(
 
     # verify that backup was made on the bucket
     try:
-        for attempt in Retrying(stop=stop_after_attempt(10), wait=wait_fixed(5)):
+        for attempt in Retrying(stop=stop_after_delay(TIMEOUT), wait=wait_fixed(5)):
             with attempt:
                 backups = await count_logical_backups(leader_unit)
                 assert backups == 2, "Backup not created."

--- a/tests/integration/mongodb/test_sharding_major_upgrades.py
+++ b/tests/integration/mongodb/test_sharding_major_upgrades.py
@@ -7,7 +7,7 @@ from logging import getLogger
 
 import pytest
 from pytest_operator.plugin import OpsTest
-from tenacity import RetryError, Retrying, stop_after_attempt, wait_fixed
+from tenacity import RetryError, Retrying, stop_after_delay, wait_fixed
 
 from tests.integration.helpers.backups import S3_APP_NAME, count_logical_backups
 from tests.integration.helpers.common import (
@@ -146,7 +146,7 @@ async def test_backup_mongodb_6(ops_test: OpsTest, s3_bucket):
 
     # verify that backup was made on the bucket
     try:
-        for attempt in Retrying(stop=stop_after_attempt(10), wait=wait_fixed(5)):
+        for attempt in Retrying(stop=stop_after_delay(TIMEOUT), wait=wait_fixed(5)):
             with attempt:
                 backups = await count_logical_backups(leader_unit)
                 assert backups == 1, "Backup not created."
@@ -263,7 +263,7 @@ async def test_backup_mongodb_7(
 
     # verify that backup was made on the bucket
     try:
-        for attempt in Retrying(stop=stop_after_attempt(10), wait=wait_fixed(5)):
+        for attempt in Retrying(stop=stop_after_delay(TIMEOUT), wait=wait_fixed(5)):
             with attempt:
                 backups = await count_logical_backups(leader_unit)
                 assert backups == 2, "Backup not created."

--- a/tests/unit/test_charm_state.py
+++ b/tests/unit/test_charm_state.py
@@ -115,3 +115,43 @@ def test_mongodb_status_user(harness: Harness[MongoTestCharm]):
     assert state.stats_config.uri.startswith(
         f"mongodb://charmed-stats:{password}@127.0.0.1:27017/admin?"
     )
+
+
+def test_is_shard_added_to_cluster_fail(
+    harness: Harness[MongoTestCharm], mocker, mongodb_name: str
+):
+    """Tests that the shard cannot be considered added to cluster if shard_integrated is False."""
+    rel = harness.charm.model.get_relation(PeerRelationNames.PEERS.value)
+    harness.add_relation_unit(rel.id, f"{mongodb_name}/1")  # type: ignore
+    harness.add_relation("sharding", "config-server")
+    harness.set_leader(True)
+    mock_get_shard_members = mocker.patch(
+        "single_kernel_mongo.utils.mongo_connection.MongoConnection.get_shard_members"
+    )
+    state = harness.charm.operator.state
+    state.app_peer_data.role = MongoDBRoles.SHARD
+    state.app_peer_data.mongos_hosts = ["a-host", "another-host"]
+    state.shard_state.shard_integrated = False
+
+    assert not state.is_shard_added_to_cluster()
+    mock_get_shard_members.assert_not_called()
+
+
+def test_is_shard_added_to_cluster_success(
+    harness: Harness[MongoTestCharm], mocker, mongodb_name: str
+):
+    """Tests that the shard can be considered added to cluster if shard_integrated is True."""
+    rel = harness.charm.model.get_relation(PeerRelationNames.PEERS.value)
+    harness.add_relation_unit(rel.id, f"{mongodb_name}/1")  # type: ignore
+    harness.add_relation("sharding", "config-server")
+    harness.set_leader(True)
+    mocker.patch(
+        "single_kernel_mongo.utils.mongo_connection.MongoConnection.get_shard_members",
+        return_value=[mongodb_name, "another-replica-set"],
+    )
+    state = harness.charm.operator.state
+    state.app_peer_data.role = MongoDBRoles.SHARD
+    state.app_peer_data.mongos_hosts = ["a-host", "another-host"]
+    state.shard_state.shard_integrated = True
+
+    assert state.is_shard_added_to_cluster()

--- a/tests/unit/test_sharding.py
+++ b/tests/unit/test_sharding.py
@@ -522,6 +522,44 @@ def test_shard_manager_synchronise_cluster_secrets_mongod_not_ready(
         manager.synchronise_cluster_secrets(relation)
 
 
+def test_shard_manager_restart_only_after_shard_integrated(
+    harness: Harness[MongoTestCharm], mocker
+):
+    manager = harness.charm.operator.shard_manager
+
+    harness.set_leader(True)
+
+    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.SHARD
+    harness.charm.operator.state.db_initialised = True
+
+    mocker.patch("single_kernel_mongo.managers.sharding.ShardManager.sync_cluster_passwords")
+    mocker.patch("single_kernel_mongo.managers.sharding.ShardManager.update_member_auth")
+    mocker.patch(
+        "single_kernel_mongo.managers.mongo.MongoManager.mongod_ready",
+        return_value=True,
+    )
+    mock_configure_and_restart = mocker.patch(
+        "single_kernel_mongo.managers.config.BackupConfigManager.configure_and_restart"
+    )
+    rel_id = harness.add_relation(RelationNames.SHARDING.value, "config-server")
+    harness.update_relation_data(
+        rel_id,
+        "config-server",
+        {
+            "key-file": "feeddead",
+            "charmed-operator-password": "test-operator",
+            "charmed-backup-password": "test-backup",
+            "username": "unused",
+            "password": "unused",
+        },
+    )
+
+    relation: Relation = harness.charm.model.get_relation(RelationNames.SHARDING.value, rel_id)  # type: ignore[assignment]
+    manager.synchronise_cluster_secrets(relation)
+
+    mock_configure_and_restart.assert_not_called()
+
+
 def test_shard_manager_sync_cluster_passwords(
     harness: Harness[MongoTestCharm], mocker, mongodb_hostname: str
 ):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷️ Type of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling and CI
- [ ] Dependencies upgrade or change
- [ ] Chores / refactoring

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and feature scope of this PR (what)
  - the motivation behind this change (why)
  - the impacted components (often matches conventional commit scope)
  - explanation/algorithm if required (how)
-->
1. Add a step in the shard integration workflow to signify a shard it has been added. This allows to know when to restart PBM
2. Improve the quality checks of backups test. We now check for backups that are finished so we don't try to restore a backup that is still in progress.

## 🧪 Manual testing steps
<!--- Give a list of instructions to manually test your change. -->
<!--- These instructions are meant for reviewers to test the PR -->
<!--- on their development environment. -->

TBD

## 🔬 Automated testing steps
<!--- Describe the unit and integration tests that you added -->
<!--- to ensure that this feature works as expected. Include details -->
<!--- on the positive and negative test cases, as well as any changes -->
<!--- made to the existing tests to ensure they are still relevant. -->

TBD

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have added or updated any relevant documentation.
- [x] I have read the [**CONTRIBUTING**](../blob/8/edge/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
