### PR TITLE
patch(DPE-9770): Race condition + handle secret events

### DIFF
--- a/single_kernel_mongo/events/cluster.py
+++ b/single_kernel_mongo/events/cluster.py
@@ -9,7 +9,12 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from ops.charm import RelationBrokenEvent, RelationChangedEvent, RelationCreatedEvent
+from ops.charm import (
+    RelationBrokenEvent,
+    RelationChangedEvent,
+    RelationCreatedEvent,
+    SecretChangedEvent,
+)
 from ops.framework import Object
 
 from single_kernel_mongo.config.statuses import MongosStatuses
@@ -17,6 +22,7 @@ from single_kernel_mongo.exceptions import (
     DatabaseRequestedHasNotRunYetError,
     DeferrableError,
     DeferrableFailedHookChecksError,
+    MissingCredentialsError,
     NonDeferrableFailedHookChecksError,
     WaitingForSecretsError,
     WorkloadServiceError,
@@ -136,6 +142,9 @@ class ClusterMongosEventHandler(Object):
         self.framework.observe(
             self.charm.on[self.relation_name.value].relation_broken, self._on_relation_broken
         )
+        self.framework.observe(
+            getattr(self.charm.on, "secret_changed"), self._handle_changed_secrets
+        )
 
     def _on_relation_created(self, event: RelationCreatedEvent) -> None:
         """Relation created event handler."""
@@ -159,6 +168,26 @@ class ClusterMongosEventHandler(Object):
         except (WaitingForSecretsError, NonDeferrableFailedHookChecksError) as e:
             logger.info(f"Skipping {str(type(event))}: {str(e)}")
 
+    def _handle_changed_secrets(self, event: SecretChangedEvent):
+        """SecretChanged event handler, which is used to propagate the updated passwords."""
+        try:
+            self.manager.handle_secret_changed(event.secret.label or "")
+        except (DeferrableError, DeferrableFailedHookChecksError):
+            event.defer()
+        except NonDeferrableFailedHookChecksError as e:
+            logger.info(f"Skipping {str(type(event))}: {str(e)}")
+        except WaitingForSecretsError as e:
+            logger.info(f"Skipping {str(type(event))}: {str(e)}")
+            self.dependent.state.statuses.add(
+                MongosStatuses.WAITING_FOR_SECRETS.value,
+                scope="unit",
+                component=self.charm.name,
+            )
+        except WorkloadServiceError:
+            # Some status was already set and a log was already displayed in
+            # `restart_charm_services`
+            return
+
     def _on_relation_changed(self, event: RelationChangedEvent) -> None:
         """Relation changed event handler.
 
@@ -171,9 +200,9 @@ class ClusterMongosEventHandler(Object):
             DeferrableFailedHookChecksError,
         ) as e:
             defer_event_with_info_log(logger, event, str(type(event)), str(e))
-        except (NonDeferrableFailedHookChecksError, WaitingForSecretsError) as e:
+        except NonDeferrableFailedHookChecksError as e:
             logger.info(f"Skipping {str(type(event))}: {str(e)}")
-        except WaitingForSecretsError as e:
+        except (WaitingForSecretsError, MissingCredentialsError) as e:
             logger.info(f"Skipping {str(type(event))}: {str(e)}")
             self.dependent.state.statuses.add(
                 MongosStatuses.WAITING_FOR_SECRETS.value,

--- a/single_kernel_mongo/managers/cluster.py
+++ b/single_kernel_mongo/managers/cluster.py
@@ -352,6 +352,29 @@ class ClusterRequirer(Object):
 
         self.dependent.share_connection_info()
 
+    def handle_secret_changed(self, secret_label: str | None) -> None:
+        """If the certificates are rotated for example, handle it immediately.
+
+        Changes in secrets do not re-trigger a relation changed event, so it is necessary to listen
+        to secret changes events.
+        """
+        if not secret_label:
+            return
+        if not (relation := self.state.mongos_cluster_relation):
+            return
+        # many secret changed events occur,only listen to the ones related to our interface
+        # with the config server.
+        cluster_extra_secret_label = f"{self.relation_name.value}.{relation.id}.extra.secret"
+        cluster_user_secret_label = f"{self.relation_name.value}.{relation.id}.user.secret"
+        if secret_label not in (cluster_extra_secret_label, cluster_user_secret_label):
+            logger.info(
+                f"Secret unrelated to this sharding relation {relation.id} is changing, ignoring event."
+            )
+            return
+
+        # This will take care of updating everything that needs updating
+        self.update_mongos_and_restart()
+
     def remove_users_and_cleanup_mongo(self, relation: Relation) -> None:
         """Proceeds on relation broken."""
         self.dependent.assert_proceed_on_broken_event(relation)
@@ -382,6 +405,11 @@ class ClusterRequirer(Object):
         # server.
         if self.substrate != Substrates.K8S:
             return
+
+        if not self.state.has_credentials():
+            # This happens if we haven't received yet credentials.
+            logger.info("We haven't received credentials yet, exiting early.")
+            raise DeferrableError("Credentials not received yet, can't reconcile users for mongos.")
 
         # We are a Kubernetes Mongos Charm so we are in charge of our client
         # applications and their users and we proceed to update the users and their DBs.

--- a/single_kernel_mongo/managers/tls.py
+++ b/single_kernel_mongo/managers/tls.py
@@ -195,6 +195,10 @@ class TLSManager(ManagerStatusProtocol):
             logger.error("An exception occurred when starting mongod agent, error: %s.", str(e))
             return
 
+        if self.state.is_role(MongoDBRoles.MONGOS):
+            # After restarting, we update the certificates for all clients.
+            self.dependent.share_connection_info()  # type: ignore[attr-defined]
+
     def delete_certificates_from_workload(self, internal: bool) -> None:
         """Deletes the certificates from the workload."""
         logger.info(

--- a/single_kernel_mongo/state/charm_state.py
+++ b/single_kernel_mongo/state/charm_state.py
@@ -360,6 +360,7 @@ class CharmState(Object, StatusesStateProtocol):
                 ClusterStateKeys.KEYFILE.value,
                 ClusterStateKeys.CONFIG_SERVER_DB.value,
                 ClusterStateKeys.INT_CA_SECRET.value,
+                ClusterStateKeys.EXT_CA_SECRET.value,
             ],
         )
 

--- a/tests/integration/mongos/test_tls_inverted.py
+++ b/tests/integration/mongos/test_tls_inverted.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+import pytest
+from pytest_operator.plugin import OpsTest
+
+from tests.integration.helpers.common import (
+    MONGOS_APP_NAME,
+    TIMEOUT,
+    check_status_detail,
+    wait_for_mongodb_units_blocked,
+)
+from tests.integration.helpers.mongos import (
+    MONGOS_CLUSTER_COMPONENTS,
+    assert_mongos_tls_enabled,
+    build_cluster,
+    deploy_cluster_components,
+)
+from tests.integration.helpers.tls import (
+    TLS_CERTIFICATES_APP_NAME,
+    TLS_CERTIFICATES_BASE,
+    TLS_CERTIFICATES_CHANNEL,
+    integrate_apps_with_tls,
+)
+from tests.integration.helpers.types import Substrate
+
+
+@pytest.mark.abort_on_fail
+async def test_build_and_deploy(
+    ops_test: OpsTest,
+    substrate: Substrate,
+    mongodb_charm: str,
+    mongos_charm: str,
+    mongod_resource: dict[str, str],
+    mongos_resource: dict[str, str],
+    application_path: str,
+) -> None:
+    """Build and deploy a sharded cluster."""
+    await deploy_cluster_components(
+        ops_test,
+        substrate,
+        mongodb_charm,
+        mongos_charm,
+        mongod_resource,
+        mongos_resource,
+        application_path,
+    )
+    await build_cluster(ops_test, substrate, integrate_with_mongos=True, integrate_with_client=True)
+
+    config = {"ca-common-name": "Test CA"}
+    await ops_test.model.deploy(
+        TLS_CERTIFICATES_APP_NAME,
+        channel=TLS_CERTIFICATES_CHANNEL,
+        base=TLS_CERTIFICATES_BASE,
+        config=config,
+    )
+
+    await ops_test.model.wait_for_idle(
+        apps=[TLS_CERTIFICATES_APP_NAME],
+        idle_period=20,
+        raise_on_blocked=False,
+        timeout=TIMEOUT,
+        raise_on_error=False,
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_mongos_tls_enabled_on_cluster(ops_test: OpsTest, substrate: Substrate):
+    """Tests that if we enable on cluster first, we end up in blocked state."""
+    await integrate_apps_with_tls(ops_test, applications=MONGOS_CLUSTER_COMPONENTS)
+
+    await wait_for_mongodb_units_blocked(
+        ops_test,
+        substrate,
+        MONGOS_APP_NAME,
+        status="Missing peer-certificates relation.",
+        timeout=TIMEOUT,
+        subordinate=(substrate == "lxd"),
+    )
+    await check_status_detail(
+        ops_test,
+        MONGOS_APP_NAME,
+        status="blocked",
+        message="Peer TLS must be enabled in mongos, since it is enabled on the config-server in the cluster relation.",
+    )
+
+
+@pytest.mark.abort_on_fail
+async def test_mongos_tls_enabled(ops_test: OpsTest, substrate: Substrate):
+    """Tests that if we then add the TLS integration on mongos it resolves."""
+    assert ops_test.model
+    await integrate_apps_with_tls(ops_test, applications=[MONGOS_APP_NAME])
+    await ops_test.model.wait_for_idle(
+        apps=MONGOS_CLUSTER_COMPONENTS + [MONGOS_APP_NAME],
+        idle_period=20,
+        timeout=TIMEOUT,
+        raise_on_blocked=False,
+        status="active",
+    )
+
+    await assert_mongos_tls_enabled(ops_test, substrate)

--- a/tests/spread/mongos/lxd/test_tls_inverted.py/task.yaml
+++ b/tests/spread/mongos/lxd/test_tls_inverted.py/task.yaml
@@ -1,0 +1,10 @@
+summary: test_tls_inverted.py
+environment:
+  TEST_MODULE: test_tls_inverted.py
+execute: |
+  tox run -e integration -- "tests/integration/mongos/$TEST_MODULE" --substrate lxd --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results
+systems:
+  - ubuntu-22.04
+  - ubuntu-22.04-arm

--- a/tests/spread/mongos/microk8s/test_tls_inverted.py/task.yaml
+++ b/tests/spread/mongos/microk8s/test_tls_inverted.py/task.yaml
@@ -1,0 +1,10 @@
+summary: test_tls_inverted.py
+environment:
+  TEST_MODULE: test_tls_inverted.py
+execute: |
+  tox run -e integration -- "tests/integration/mongos/$TEST_MODULE" --substrate microk8s --model testing --alluredir="$SPREAD_TASK/allure-results"
+artifacts:
+  - allure-results
+systems:
+  - ubuntu-22.04
+  - ubuntu-22.04-arm


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷️ Type of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling and CI
- [ ] Dependencies upgrade or change
- [ ] Chores / refactoring

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and feature scope of this PR (what)
  - the motivation behind this change (why)
  - the impacted components (often matches conventional commit scope)
  - explanation/algorithm if required (how)
-->
Two issues are solved by this PR:
 * Race condition when the Mongos K8S would try to reconcile users while it hasn't received credentials yet
 * Handling of secret changes in the cluster relation. For the TLS it would be seen in the next update-status event but that makes it faster to check. Other updates could be missed (keyfile update if it ever happens).

## 🧪 Manual testing steps
<!--- Give a list of instructions to manually test your change. -->
<!--- These instructions are meant for reviewers to test the PR -->
<!--- on their development environment. -->

The first one is flaky so hard to reproduce and ensure it's fixed, but the root cause was exposed in [this run](https://github.com/canonical/mongo-single-kernel-library/actions/runs/24442954470/job/71413236589?pr=258#step:9:4636)

The second one can be triggered by changing the CA and checking that the CA update is taken into account.
```text
1. juju deploy <my-app>
2. …
```

## 🔬 Automated testing steps
<!--- Describe the unit and integration tests that you added -->
<!--- to ensure that this feature works as expected. Include details -->
<!--- on the positive and negative test cases, as well as any changes -->
<!--- made to the existing tests to ensure they are still relevant. -->
TBD

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have added or updated any relevant documentation.
- [x] I have read the [**CONTRIBUTING**](../blob/8/edge/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
