### PR TITLE
patch(DPE-9772): CI Green

### DIFF
--- a/.github/workflows/ci-quick.yaml
+++ b/.github/workflows/ci-quick.yaml
@@ -14,7 +14,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: Install tox & poetry
@@ -36,6 +36,30 @@ jobs:
       - name: Run pre-commit hooks
         run: |
           poetry run pre-commit run --all-files
+
+  check-pyproject-dynamic-versioning:
+    name: Poetry dynamic versioning check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install deps
+        run: sudo snap install yq
+      - name: Check versioning
+        run: |
+          VERSION=$(yq -p toml -oy '.tool.poetry.version' ./pyproject.toml)
+          DYNAMIC_FIELDS=$(yq -p toml -oc '.project.dynamic'  ./pyproject.toml)
+          if [[ $VERSION != *"0.0.0"* ]]
+          then
+            exit 1
+          fi
+          if [[ $DYNAMIC_FIELDS != *"version"* ]]
+          then
+            exit 1
+          fi
 
   actionlint:
     name: Lint .github/workflows/

--- a/single_kernel_mongo/managers/cluster.py
+++ b/single_kernel_mongo/managers/cluster.py
@@ -16,7 +16,11 @@ from pymongo.errors import PyMongoError
 
 from single_kernel_mongo.config.literals import Scope, Substrates
 from single_kernel_mongo.config.relations import RelationNames
-from single_kernel_mongo.config.statuses import CharmStatuses, MongoDBStatuses, MongosStatuses
+from single_kernel_mongo.config.statuses import (
+    CharmStatuses,
+    MongoDBStatuses,
+    MongosStatuses,
+)
 from single_kernel_mongo.core.structured_config import MongoDBRoles
 from single_kernel_mongo.exceptions import (
     DeferrableError,
@@ -359,6 +363,8 @@ class ClusterRequirer(Object):
 
         self.dependent.share_connection_info()
 
+        self.dependent.ldap_manager.update_hash_status()
+
     def handle_secret_changed(self, secret_label: str | None) -> None:
         """If the certificates are rotated for example, handle it immediately.
 
@@ -389,6 +395,8 @@ class ClusterRequirer(Object):
             self.remove_users_for_k8s_routers(relation)
         except PyMongoError:
             raise DeferrableError("Trouble removing router users")
+
+        self.dependent.ldap_manager.update_hash_status()
 
         self.dependent.stop_charm_services()
         logger.info("Stopped mongos daemon")

--- a/single_kernel_mongo/managers/cluster.py
+++ b/single_kernel_mongo/managers/cluster.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import json
 from logging import getLogger
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, final
 
 from data_platform_helpers.advanced_statuses.models import StatusObject
 from ops.framework import Object
@@ -234,6 +234,7 @@ class ClusterProvider(Object):
             )
 
 
+@final
 class ClusterRequirer(Object):
     """Manage relations between the config server and mongos router on the mongos side."""
 
@@ -272,6 +273,7 @@ class ClusterRequirer(Object):
             raise DeferrableFailedHookChecksError(
                 "Mongos was waiting for config-server to enable TLS. Wait for TLS to be enabled until starting mongos."
             )
+
         if self.dependent.refresh_in_progress:
             logger.warning(
                 "Processing client applications is not supported during an upgrade. The charm may be in a broken, unrecoverable state."
@@ -309,6 +311,11 @@ class ClusterRequirer(Object):
     def update_mongos_and_restart(self) -> None:
         """Start/restarts mongos with config server information."""
         self.assert_pass_hook_checks()
+
+        # Wait for
+        if not self.state.cluster.username or not self.state.cluster.password:
+            raise WaitingForSecretsError("Waiting for username and password.")
+
         key_file_contents = self.state.cluster.keyfile
         config_server_db_uri = self.state.cluster.config_server_uri
 
@@ -493,7 +500,7 @@ class ClusterRequirer(Object):
     def mongos_and_config_server_peer_tls_status(self) -> tuple[bool, bool]:
         """Returns the peer TLS integration status for mongos and config-server."""
         if self.state.mongos_cluster_relation:
-            mongos_has_tls = self.state.peer_tls_relation is not None
+            mongos_has_tls = self.state.tls.peer_enabled
             config_server_has_tls = self.state.cluster.internal_ca_secret is not None
             return mongos_has_tls, config_server_has_tls
 
@@ -502,7 +509,7 @@ class ClusterRequirer(Object):
     def mongos_and_config_server_client_tls_status(self) -> tuple[bool, bool]:
         """Returns the client TLS integration status for mongos and config-server."""
         if self.state.mongos_cluster_relation:
-            mongos_has_tls = self.state.client_tls_relation is not None
+            mongos_has_tls = self.state.tls.client_enabled
             config_server_has_tls = self.state.cluster.external_ca_secret is not None
             return mongos_has_tls, config_server_has_tls
 

--- a/single_kernel_mongo/managers/config.py
+++ b/single_kernel_mongo/managers/config.py
@@ -657,13 +657,9 @@ class MongosConfigManager(MongoConfigManager):
         """The config server DB parameter."""
         # In case we are integrated with a config-server, we need to provide
         # it's URI to mongos so it can configure_and_restart to it.
-        if uri := self.state.cluster.config_server_uri:
+        if uri := self.state.config_server_uri:
             return {"sharding": {"configDB": uri}}
-        return {
-            "sharding": {
-                "configDB": f"{self.state.app_peer_data.replica_set}/{self.state.unit_peer_data.internal_address}:{MongoPorts.MONGODB_PORT.value}"
-            }
-        }
+        return {}
 
     @property
     @override

--- a/single_kernel_mongo/managers/ldap.py
+++ b/single_kernel_mongo/managers/ldap.py
@@ -213,6 +213,11 @@ class LDAPManager(Object, ManagerStatusProtocol):
         """Returns an enum object indicating the state of the LDAP integration."""
         if not self.state.db_initialised:
             return LdapState.EMPTY
+        if (
+            self.state.is_role(MongoDBRoles.MONGOS)
+            and self.state.cluster.ldap_hash != self.get_hash()
+        ):
+            return LdapState.LDAP_SERVERS_MISMATCH
         if self.state.ldap_relation is None and self.state.ldap_cert_relation is None:
             return LdapState.EMPTY
         if self.state.is_role(MongoDBRoles.SHARD):
@@ -221,11 +226,6 @@ class LDAPManager(Object, ManagerStatusProtocol):
             return LdapState.MISSING_CERT_REL
         if self.state.ldap_relation is None:
             return LdapState.MISSING_LDAP_REL
-        if (
-            self.state.is_role(MongoDBRoles.MONGOS)
-            and self.state.cluster.ldap_hash != self.get_hash()
-        ):
-            return LdapState.LDAP_SERVERS_MISMATCH
 
         ldap_relation_status = self.state.ldap.ldap_ready()
         ldap_certificate_integration_status = self.state.ldap.ldap_certs_ready()
@@ -369,3 +369,16 @@ class LDAPManager(Object, ManagerStatusProtocol):
         if not self.state.is_role(MongoDBRoles.CONFIG_SERVER):
             return
         self.dependent.cluster_manager.remove_ldap_hash()  # type: ignore
+
+    def update_hash_status(self) -> None:
+        """Updates the hash incompatibility status."""
+        if not self.state.is_role(MongoDBRoles.MONGOS):
+            return
+        if self.state.cluster.ldap_hash != self.get_hash():
+            self.state.statuses.add(
+                LdapStatuses.LDAP_SERVERS_MISMATCH.value, scope="unit", component=self.name
+            )
+        else:
+            self.state.statuses.delete(
+                LdapStatuses.LDAP_SERVERS_MISMATCH.value, scope="unit", component=self.name
+            )

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -391,7 +391,10 @@ class MongoDBOperator(OperatorProtocol, Object):
             return
 
         manager.set_certificate(credentials)
-        manager.set_config_options(credentials)
+
+        # Only leader should set config options.
+        if self.charm.unit.is_leader():
+            manager.set_config_options(credentials)
 
     @property
     @override

--- a/single_kernel_mongo/state/charm_state.py
+++ b/single_kernel_mongo/state/charm_state.py
@@ -595,6 +595,15 @@ class CharmState(Object, StatusesStateProtocol):
         )
         return None
 
+    @property
+    def config_server_uri(self) -> str | None:
+        """Gets the config-server URI for Mongos."""
+        if self.charm_role.name == CharmKind.MONGOS:
+            return self.cluster.config_server_uri
+        if not self.is_role(MongoDBRoles.CONFIG_SERVER):
+            return None
+        return f"{self.app_peer_data.replica_set}/{self.unit_peer_data.internal_address}:{MongoPorts.MONGODB_PORT.value}"
+
     def get_subject_name(self) -> str:
         """Generate the subject name for CSR."""
         # In sharded MongoDB deployments it is a requirement that all subject names match across

--- a/single_kernel_mongo/state/cluster_state.py
+++ b/single_kernel_mongo/state/cluster_state.py
@@ -27,6 +27,8 @@ class ClusterStateKeys(str, Enum):
     EXT_CA_SECRET = "ext-ca-secret"
     LDAP_USER_TO_DN_MAPPING = "ldap-user-to-dn-mapping"
     LDAP_HASH = "ldap-hash"
+    USERNAME = "username"
+    PASSWORD = "password"
 
 
 class ClusterState(AbstractRelationState[Data]):
@@ -42,6 +44,16 @@ class ClusterState(AbstractRelationState[Data]):
     def config_server_uri(self) -> str:
         """Return config-server URI in the databag."""
         return self.relation_data.get(ClusterStateKeys.CONFIG_SERVER_DB.value, "")
+
+    @property
+    def username(self) -> str:
+        """Return config-server URI in the databag."""
+        return self.relation_data.get(ClusterStateKeys.USERNAME.value, "")
+
+    @property
+    def password(self) -> str:
+        """Return config-server URI in the databag."""
+        return self.relation_data.get(ClusterStateKeys.PASSWORD.value, "")
 
     @property
     def database(self) -> str:

--- a/tests/integration/helpers/vault.py
+++ b/tests/integration/helpers/vault.py
@@ -144,7 +144,11 @@ async def deploy_vault(ops_test: OpsTest, substrate: Substrate, vault_charm_name
     )
     async with ops_test.fast_forward(fast_interval=FAST_INTERVAL):
         await ops_test.model.wait_for_idle(
-            apps=[vault_charm_name], wait_for_at_least_units=1, status="blocked", idle_period=5
+            apps=[vault_charm_name],
+            wait_for_at_least_units=1,
+            status="blocked",
+            idle_period=5,
+            raise_on_error=False,  # TODO: Remove this when CI is more stable.
         )
     await initialize_unseal_authorize_vault(ops_test, substrate, vault_charm_name)
 

--- a/tests/integration/mongos/ldap/test_ldap.py
+++ b/tests/integration/mongos/ldap/test_ldap.py
@@ -138,11 +138,48 @@ async def test_build_and_deploy_mongos(
         subordinate=(substrate == "lxd"),
     )
 
+
+@pytest.mark.abort_on_fail
+async def test_config_server_only_integrated_with_mongos(ops_test: OpsTest, substrate: Substrate):
+    app_name = await get_app_name(ops_test, charm_name="mongos")
+
+    await ops_test.model.integrate(f"{LDAP_OFFER}:ldap", f"{CONFIG_SERVER_APP_NAME}:ldap")
+    await ops_test.model.integrate(
+        f"{LDAP_CERT_OFFER}:send-ca-cert", f"{CONFIG_SERVER_APP_NAME}:ldap-certificate-transfer"
+    )
+    await ops_test.model.wait_for_idle(
+        apps=[CONFIG_SERVER_APP_NAME, SHARD_ONE_APP_NAME, SHARD_TWO_APP_NAME],
+        idle_period=20,
+        status="active",
+    )
+
     # connect sharded cluster to mongos
     await ops_test.model.integrate(
         f"{app_name}:{CLUSTER_REL_NAME}",
         f"{CONFIG_SERVER_APP_NAME}:{CLUSTER_REL_NAME}",
     )
+    await ops_test.model.wait_for_idle(
+        apps=[CONFIG_SERVER_APP_NAME, SHARD_ONE_APP_NAME, SHARD_TWO_APP_NAME],
+        idle_period=20,
+        status="active",
+    )
+    await wait_for_mongodb_units_blocked(
+        ops_test,
+        substrate,
+        app_name,
+        status="mongos and config-server not integrated with the same ldap server.",
+        timeout=300,
+        subordinate=(substrate == "lxd"),
+    )
+
+    # Go back to normal state
+    await ops_test.model.applications[CONFIG_SERVER_APP_NAME].remove_relation(
+        f"{LDAP_OFFER}:ldap", f"{CONFIG_SERVER_APP_NAME}:ldap"
+    )
+    await ops_test.model.applications[CONFIG_SERVER_APP_NAME].remove_relation(
+        f"{LDAP_CERT_OFFER}:send-ca-cert", f"{CONFIG_SERVER_APP_NAME}:ldap-certificate-transfer"
+    )
+
     await ops_test.model.wait_for_idle(
         apps=[CONFIG_SERVER_APP_NAME, SHARD_ONE_APP_NAME, SHARD_TWO_APP_NAME, app_name],
         idle_period=20,

--- a/tests/integration/mongos/ldap/test_ldap.py
+++ b/tests/integration/mongos/ldap/test_ldap.py
@@ -2,7 +2,6 @@
 # Copyright 2025 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-from pathlib import Path
 
 import pytest
 from juju.model import Model
@@ -93,7 +92,11 @@ async def test_build_and_deploy_mongodb_cluster(
 
 @pytest.mark.abort_on_fail
 async def test_build_and_deploy_mongos(
-    ops_test: OpsTest, mongos_charm: Path, substrate: Substrate, mongod_resource, base_app_name
+    ops_test: OpsTest,
+    mongos_charm: str,
+    substrate: Substrate,
+    mongos_resource: dict[str, str],
+    base_app_name: str,
 ) -> None:
     """Deploys mongos and data integrator, and integrates both.
 
@@ -106,7 +109,7 @@ async def test_build_and_deploy_mongos(
             ops_test=ops_test,
             charm=mongos_charm,
             substrate=substrate,
-            mongod_resource=mongod_resource,
+            mongod_resource=mongos_resource,
             app_name=base_app_name,
             num_units=1,
             subordinate=(substrate == "lxd"),
@@ -250,10 +253,10 @@ async def test_teardown(ops_test: OpsTest, kubernetes_model: Model):
     await ops_test.model.applications[app_name].remove_relation(
         f"{LDAP_CERT_OFFER}:send-ca-cert", f"{app_name}:ldap-certificate-transfer"
     )
-    await ops_test.model.applications[app_name].remove_relation(
+    await ops_test.model.applications[CONFIG_SERVER_APP_NAME].remove_relation(
         f"{LDAP_OFFER}:ldap", f"{CONFIG_SERVER_APP_NAME}:ldap"
     )
-    await ops_test.model.applications[app_name].remove_relation(
+    await ops_test.model.applications[CONFIG_SERVER_APP_NAME].remove_relation(
         f"{LDAP_CERT_OFFER}:send-ca-cert", f"{CONFIG_SERVER_APP_NAME}:ldap-certificate-transfer"
     )
 

--- a/tests/spread/mongodb/lxd/test_backups_tls.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_backups_tls.py/task.yaml
@@ -6,5 +6,5 @@ execute: |
 artifacts:
   - allure-results
 systems:
-  - ubuntu-22.04
-  - ubuntu-22.04-arm
+  - self-hosted-linux-amd64-noble-medium
+  - self-hosted-linux-arm64-noble-medium

--- a/tests/spread/mongodb/lxd/test_encryption_invalid_scenario.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_encryption_invalid_scenario.py/task.yaml
@@ -6,6 +6,6 @@ execute: |
 artifacts:
   - allure-results
 systems:
-  - self-hosted-linux-amd64-noble-medium
+  - self-hosted-linux-amd64-noble-large
   # TODO: Enable this when we have a stable arm64 vault charm.
-  #- self-hosted-linux-arm64-noble-medium
+  #- self-hosted-linux-arm64-noble-large

--- a/tests/spread/mongodb/lxd/test_encryption_valid_scenario.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_encryption_valid_scenario.py/task.yaml
@@ -6,6 +6,6 @@ execute: |
 artifacts:
   - allure-results
 systems:
-  - self-hosted-linux-amd64-noble-medium
+  - self-hosted-linux-amd64-noble-large
   # TODO: Enable this when we have a stable arm64 vault charm.
-  #- self-hosted-linux-arm64-noble-medium
+  #- self-hosted-linux-arm64-noble-large

--- a/tests/spread/mongodb/lxd/test_ldap.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_ldap.py/task.yaml
@@ -6,6 +6,6 @@ execute: |
 artifacts:
   - allure-results
 systems:
-  - ubuntu-22.04
+  - self-hosted-linux-amd64-noble-large
   # TODO: Re-enable this when glauth charm supports arm64
-  #- self-hosted-linux-arm64-noble-medium
+  #- self-hosted-linux-arm64-noble-large

--- a/tests/spread/mongodb/lxd/test_major_upgrades.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_major_upgrades.py/task.yaml
@@ -6,4 +6,4 @@ execute: |
 artifacts:
   - allure-results
 systems:
-  - self-hosted-linux-amd64-noble-medium
+  - self-hosted-linux-amd64-noble-large

--- a/tests/spread/mongodb/lxd/test_sharding_ldap.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_sharding_ldap.py/task.yaml
@@ -6,6 +6,6 @@ execute: |
 artifacts:
   - allure-results
 systems:
-  - self-hosted-linux-amd64-noble-medium
+  - self-hosted-linux-amd64-noble-large
   # TODO: Re-enable this when glauth charm supports arm64
-  #- self-hosted-linux-arm64-noble-medium
+  #- self-hosted-linux-arm64-noble-large

--- a/tests/spread/mongodb/lxd/test_sharding_major_upgrades.py/task.yaml
+++ b/tests/spread/mongodb/lxd/test_sharding_major_upgrades.py/task.yaml
@@ -6,4 +6,4 @@ execute: |
 artifacts:
   - allure-results
 systems:
-  - self-hosted-linux-amd64-noble-medium
+  - self-hosted-linux-amd64-noble-large

--- a/tests/spread/mongodb/microk8s/test_backups_tls.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_backups_tls.py/task.yaml
@@ -6,5 +6,5 @@ execute: |
 artifacts:
   - allure-results
 systems:
-  - ubuntu-22.04
-  - ubuntu-22.04-arm
+  - self-hosted-linux-amd64-noble-medium
+  - self-hosted-linux-arm64-noble-medium

--- a/tests/spread/mongodb/microk8s/test_encryption_invalid_scenario.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_encryption_invalid_scenario.py/task.yaml
@@ -6,6 +6,6 @@ execute: |
 artifacts:
   - allure-results
 systems:
-  - self-hosted-linux-amd64-noble-medium
+  - self-hosted-linux-amd64-noble-large
   # TODO: Enable this when we have a stable arm64 vault charm.
-  #- self-hosted-linux-arm64-noble-medium
+  #- self-hosted-linux-arm64-noble-large

--- a/tests/spread/mongodb/microk8s/test_encryption_valid_scenario.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_encryption_valid_scenario.py/task.yaml
@@ -6,6 +6,6 @@ execute: |
 artifacts:
   - allure-results
 systems:
-  - self-hosted-linux-amd64-noble-medium
+  - self-hosted-linux-amd64-noble-large
   # TODO: Enable this when we have a stable arm64 vault charm.
-  #- self-hosted-linux-arm64-noble-medium
+  #- self-hosted-linux-arm64-noble-large

--- a/tests/spread/mongodb/microk8s/test_ldap.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_ldap.py/task.yaml
@@ -6,6 +6,6 @@ execute: |
 artifacts:
   - allure-results
 systems:
-  - ubuntu-22.04
+  - self-hosted-linux-amd64-noble-large
   # TODO: Re-enable this when glauth charm supports arm64
-  #- self-hosted-linux-arm64-noble-medium
+  #- self-hosted-linux-arm64-noble-large

--- a/tests/spread/mongodb/microk8s/test_major_upgrades.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_major_upgrades.py/task.yaml
@@ -6,4 +6,4 @@ execute: |
 artifacts:
   - allure-results
 systems:
-  - self-hosted-linux-amd64-noble-medium
+  - self-hosted-linux-amd64-noble-large

--- a/tests/spread/mongodb/microk8s/test_sharding_ldap.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_sharding_ldap.py/task.yaml
@@ -6,6 +6,6 @@ execute: |
 artifacts:
   - allure-results
 systems:
-  - self-hosted-linux-amd64-noble-medium
+  - self-hosted-linux-amd64-noble-large
   # TODO: Re-enable this when glauth charm supports arm64
-  #- self-hosted-linux-arm64-noble-medium
+  #- self-hosted-linux-arm64-noble-large

--- a/tests/spread/mongodb/microk8s/test_sharding_major_upgrades.py/task.yaml
+++ b/tests/spread/mongodb/microk8s/test_sharding_major_upgrades.py/task.yaml
@@ -6,4 +6,4 @@ execute: |
 artifacts:
   - allure-results
 systems:
-  - self-hosted-linux-amd64-noble-medium
+  - self-hosted-linux-amd64-noble-large

--- a/tests/spread/mongos/lxd/test_ldap.py/task.yaml
+++ b/tests/spread/mongos/lxd/test_ldap.py/task.yaml
@@ -6,6 +6,6 @@ execute: |
 artifacts:
   - allure-results
 systems:
-  - ubuntu-22.04
+  - self-hosted-linux-amd64-noble-large
   # TODO: Re-enable this when glauth charm supports arm64
-  #- self-hosted-linux-arm64-noble-medium
+  #- self-hosted-linux-arm64-noble-large

--- a/tests/spread/mongos/microk8s/test_ldap.py/task.yaml
+++ b/tests/spread/mongos/microk8s/test_ldap.py/task.yaml
@@ -6,6 +6,6 @@ execute: |
 artifacts:
   - allure-results
 systems:
-  - ubuntu-22.04
+  - self-hosted-linux-amd64-noble-large
   # TODO: Re-enable this when glauth charm supports arm64
-  #- self-hosted-linux-arm64-noble-medium
+  #- self-hosted-linux-arm64-noble-large

--- a/tests/unit/test_cluster_manager.py
+++ b/tests/unit/test_cluster_manager.py
@@ -22,7 +22,10 @@ from single_kernel_mongo.exceptions import (
     NonDeferrableFailedHookChecksError,
     WaitingForSecretsError,
 )
-from single_kernel_mongo.state.tls_state import SECRET_CA_LABEL
+from single_kernel_mongo.state.tls_state import (
+    SECRET_CA_LABEL,
+    SECRET_CERT_LABEL,
+)
 from tests.charms.mongodb_test_charm.src.charm import MongoTestCharm
 from tests.charms.mongos_test_charm.src.charm import MongosTestCharm
 from tests.integration.helpers.types import Substrate
@@ -310,8 +313,6 @@ def test_cluster_requirer_update_mongos_and_restart(
 
     mongos_harness.update_relation_data(rel_id_proxy, "test-application", {"database": "test-db"})
 
-    manager.share_credentials_to_clients("charmed-operator", "password")
-
     data = Path("tests/unit/data/mongos.conf").read_text().splitlines()
 
     mocker.patch("single_kernel_mongo.managers.mongo.MongoManager.reconcile_mongo_users_and_dbs")
@@ -328,7 +329,12 @@ def test_cluster_requirer_update_mongos_and_restart(
     mongos_harness.update_relation_data(
         rel_id_cluster,
         "mongodb",
-        {"key-file": "deadbeef", "config-server-db": "mongodb/2.2.2.2:27017"},
+        {
+            "key-file": "deadbeef",
+            "config-server-db": "mongodb/2.2.2.2:27017",
+            "username": "charmed-operator",
+            "password": "password",  # nosec: B105
+        },
     )
 
     statuses = mongos_harness.charm.operator.state.statuses.get(
@@ -382,7 +388,7 @@ def test_cluster_requirer_update_mongos_and_restart_fail_missing_data(
     mongos_harness.update_relation_data(
         rel_id_cluster,
         "mongodb",
-        databag,
+        databag | {"username": "unused", "password": "unused"},
     )
     with pytest.raises(WaitingForSecretsError) as err:
         manager.update_mongos_and_restart()
@@ -418,7 +424,12 @@ def test_cluster_requirer_update_mongos_and_restart_mongos_not_running(
     mongos_harness.update_relation_data(
         rel_id_cluster,
         "mongodb",
-        {"key-file": "deadbeef", "config-server-db": "mongodb/2.2.2.2:27017"},
+        {
+            "key-file": "deadbeef",
+            "config-server-db": "mongodb/2.2.2.2:27017",
+            "username": "unused",
+            "password": "unused",
+        },
     )
 
     # Check that we raise a deferrable error because mongos is not running after restart
@@ -592,6 +603,14 @@ def test_cluster_requirer_tls_status(
         mongos_harness.add_relation(
             ExternalRequirerRelations.CLIENT_TLS.value, "self-signed-certificates"
         )
+        mocker.patch(
+            "single_kernel_mongo.state.tls_state.TLSState.peer_enabled",
+            new_callable=mocker.PropertyMock(return_value=True),
+        )
+        mocker.patch(
+            "single_kernel_mongo.state.tls_state.TLSState.client_enabled",
+            new_callable=mocker.PropertyMock(return_value=True),
+        )
 
     # Ensure some credentials are present
     manager.share_credentials_to_clients("charmed-operator", "password")
@@ -681,9 +700,13 @@ def test_cluster_requirer_get_tls_statuses(
         mongos_harness.add_relation(
             ExternalRequirerRelations.PEER_TLS.value, "self-signed-certificates"
         )
-        # Local certificate
+        # Local CA certificate
         manager.state.tls.set_secret(
             internal=True, label_name=SECRET_CA_LABEL, contents=mongos_peer_ca_secret
+        )
+        # Local cert
+        manager.state.tls.set_secret(
+            internal=True, label_name=SECRET_CERT_LABEL, contents="useless"
         )
     if mongos_client_ca_secret:
         mongos_harness.add_relation(
@@ -691,6 +714,10 @@ def test_cluster_requirer_get_tls_statuses(
         )
         manager.state.tls.set_secret(
             internal=False, label_name=SECRET_CA_LABEL, contents=mongos_client_ca_secret
+        )
+        # Local cert
+        manager.state.tls.set_secret(
+            internal=False, label_name=SECRET_CERT_LABEL, contents="useless"
         )
 
     # Ensure some credentials are present

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -19,7 +19,6 @@ from single_kernel_mongo.managers.config import (
 )
 from single_kernel_mongo.state.app_peer_state import AppPeerReplicaSet
 from single_kernel_mongo.state.charm_state import CharmState
-from single_kernel_mongo.state.cluster_state import ClusterState
 from single_kernel_mongo.state.ldap_state import LdapState
 from single_kernel_mongo.state.tls_state import TLSState
 from single_kernel_mongo.state.vault_state import VaultState
@@ -247,8 +246,7 @@ def test_mongos_config_manager(mocker):
     mock_state.app_peer_data = mocker.MagicMock(AppPeerReplicaSet)
     mock_state.charm_role = ROLES[Substrates.VM][CharmKind.MONGOS]
     mock_state.substrate = Substrates.VM
-    mock_state.cluster = mocker.MagicMock(ClusterState)
-    mock_state.cluster.config_server_uri = "mongodb://config-server-url"
+    mock_state.config_server_uri = "mongodb://config-server-url"
     mock_state.tls = mocker.MagicMock(TLSState)
     mock_state.app_peer_data.external_connectivity = False
     mock_state.tls.peer_enabled = False
@@ -406,12 +404,13 @@ def test_mongodb_config_manager_tls_enabled(mocker):
 
 
 def test_mongos_default_config_server(mocker):
-    mock_state = mocker.MagicMock(CharmState)
-    mock_state.app_peer_data = mocker.MagicMock(AppPeerReplicaSet)
+    mock_state = mocker.create_autospec(CharmState)
+    mock_state.app_peer_data = mocker.Mock(AppPeerReplicaSet)
     mock_state.app_peer_data.replica_set = "deadbeef"
     mock_state.unit_peer_data.internal_address = "127.0.0.1"
-    mock_state.cluster = mocker.MagicMock(ClusterState)
-    mock_state.cluster.config_server_uri = ""
+    mock_state.config_server_uri = (
+        f"{mock_state.app_peer_data.replica_set}/{mock_state.unit_peer_data.internal_address}:27017"
+    )
     mock_state.tls = mocker.MagicMock(TLSState)
     mock_state.app_peer_data.external_connectivity = False
     mock_state.tls.peer_enabled = False


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷️ Type of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tooling and CI
- [ ] Dependencies upgrade or change
- [ ] Chores / refactoring

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and feature scope of this PR (what)
  - the motivation behind this change (why)
  - the impacted components (often matches conventional commit scope)
  - explanation/algorithm if required (how)
-->
 * Poetry dynamic versioning check: We broke releasing once by pushing an invalid pyproject.toml file, let's not reproduce that.
 * Race condition (exposed by release testing):
 	- TLS + Mongos => we were not checking properly if TLS and Mongos had the same CA and if mongos had received certificates. Mongos would start without internal certificate, preventing from building the cluster.
    - We were potentially running some relation-changed events too early.
 * Other bugs 
    -  Generating the config server URI for the local mongos running along with config-server would fail if there are more than 1 mongos integrated. This is fixed by remodelling the way we build the URI, ensuring we don't unnecessarily access the `mongos_cluster_relation` relation object.
    -  Integrating LDAP to Config server and config server to mongos would not show a status for invalid ldap integration because the check for the hashes would never run. This is now fixed by inverting a few instructions and a helper to set the right status on the cluster relation changed events. 
 * CI:
	- Move some tests to large runners
	- Vault is now deployed and waits allowing for errors as it ends up in error state quite often and is out of our control.

## 🧪 Manual testing steps
<!--- Give a list of instructions to manually test your change. -->
<!--- These instructions are meant for reviewers to test the PR -->
<!--- on their development environment. -->

```text
1. Deploy config server + 1 shard + mongos.
2. Integrate config-server and shard.
3. Integrate config-server to tls and shard to tls (at least peer-certs).
4. Integrate mongos to config server and tls integration to mongos at the same time.
5. This should end up quickly.
```

## 🔬 Automated testing steps
<!--- Describe the unit and integration tests that you added -->
<!--- to ensure that this feature works as expected. Include details -->
<!--- on the positive and negative test cases, as well as any changes -->
<!--- made to the existing tests to ensure they are still relevant. -->
TLS race condition test should not be flaky anymore.
New LDAP test with config-server integrated to ldap and mongos, but mongos not integrated to ldap.
Updated UT.

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have added or updated any relevant documentation.
- [x] I have read the [**CONTRIBUTING**](../blob/8/edge/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.