### PR TITLE
patch(DPE-9968): Self healing for LDAP

### DIFF
--- a/single_kernel_mongo/events/ldap.py
+++ b/single_kernel_mongo/events/ldap.py
@@ -20,6 +20,7 @@ from single_kernel_mongo.exceptions import (
     InvalidLdapWithShardError,
     LDAPSNotEnabledError,
     NonDeferrableFailedHookChecksError,
+    UnableToBindError,
     WaitingForLdapDataError,
 )
 from single_kernel_mongo.lib.charms.certificate_transfer_interface.v0.certificate_transfer import (
@@ -62,6 +63,7 @@ class LDAPEventHandler(Object):
             self.manager.certificate_transfer.on.certificate_available,
             self._on_certificate_available,
         )
+        self.framework.observe(self.charm.on.update_status, self._on_update_status)
         self.framework.observe(
             self.manager.certificate_transfer.on.certificate_removed, self._on_certificate_removed
         )
@@ -128,6 +130,22 @@ class LDAPEventHandler(Object):
                 LdapStatuses.on_error_status(err), scope="unit", component=self.manager.name
             )
 
+    def _on_update_status(self, event: CertificateAvailableEvent):
+        try:
+            # Runs the checks and restart if needed.
+            self.manager.restart_when_ready()
+        except (
+            DeferrableFailedHookChecksError,
+            InvalidLdapWithShardError,
+            UnableToBindError,
+            NonDeferrableFailedHookChecksError,
+        ):
+            logger.warning(
+                "Update Status could not reconcile ldap integration. Please investigate."
+            )
+            # Statuses will be updated in the handler for advanced statuses.
+            return
+
     def _on_certificate_removed(self, event: CertificateRemovedEvent) -> None:
         """Handles the ops event that indicates that ldap-certificates relation is unavailable."""
         self.manager.remove_ldap_certificates()
@@ -138,6 +156,13 @@ class LDAPEventHandler(Object):
         try:
             self.manager.restart_when_ready()
         except (DeferrableFailedHookChecksError, DeferrableError) as err:
+            defer_event_with_info_log(logger, event, action, f"{err}")
+        except UnableToBindError as err:
+            self.manager.state.statuses.add(
+                LdapStatuses.UNABLE_TO_BIND.value,
+                scope="unit",
+                component=self.manager.name,
+            )
             defer_event_with_info_log(logger, event, action, f"{err}")
         except InvalidLdapWithShardError:
             self.manager.state.statuses.add(

--- a/single_kernel_mongo/events/ldap.py
+++ b/single_kernel_mongo/events/ldap.py
@@ -131,6 +131,7 @@ class LDAPEventHandler(Object):
             )
 
     def _on_update_status(self, event: CertificateAvailableEvent):
+        """On update-status, check if everything is alright and restart if needed."""
         try:
             # Runs the checks and restart if needed.
             self.manager.restart_when_ready()

--- a/single_kernel_mongo/exceptions.py
+++ b/single_kernel_mongo/exceptions.py
@@ -249,6 +249,10 @@ class InvalidLdapQueryTemplateError(Exception):
     """Raised when the LdapQueryTemplate and LdapUserToDnMapping combination is invalid."""
 
 
+class UnableToBindError(Exception):
+    """Raised when we're unable to bind with GLAuth."""
+
+
 class WaitingForLeaderError(Exception):
     """Raised when we haven't elected a leader yet but we need it."""
 

--- a/single_kernel_mongo/managers/ldap.py
+++ b/single_kernel_mongo/managers/ldap.py
@@ -32,6 +32,7 @@ from single_kernel_mongo.exceptions import (
     InvalidLdapHashError,
     InvalidLdapWithShardError,
     LDAPSNotEnabledError,
+    UnableToBindError,
     WaitingForLdapDataError,
 )
 from single_kernel_mongo.lib.charms.certificate_transfer_interface.v0.certificate_transfer import (
@@ -139,6 +140,10 @@ class LDAPManager(Object, ManagerStatusProtocol):
 
                 if state == LdapState.LDAP_SERVERS_MISMATCH:
                     raise InvalidLdapHashError(
+                        "mongos and config-server not integrated with the same ldap server."
+                    )
+                if state == LdapState.UNABLE_TO_BIND:
+                    raise UnableToBindError(
                         "mongos and config-server not integrated with the same ldap server."
                     )
 

--- a/tests/unit/test_ldap_manager.py
+++ b/tests/unit/test_ldap_manager.py
@@ -12,6 +12,7 @@ from ops.testing import Harness
 from single_kernel_mongo.config.literals import Scope
 from single_kernel_mongo.config.models import LdapState
 from single_kernel_mongo.config.relations import ExternalRequirerRelations, RelationNames
+from single_kernel_mongo.config.statuses import CharmStatuses
 from single_kernel_mongo.core.structured_config import MongoDBRoles
 from single_kernel_mongo.exceptions import (
     DeferrableFailedHookChecksError,
@@ -397,6 +398,69 @@ def test_ldap_full_integration_cycle(
         ldap_parameters["userToDNMapping"]
         == '[{"match": "([^@]+)@([^@\\\\.]+)\\\\.glauth\\\\.com", "substitution": "CN={0},CN=Users,DC={1},DC=glauth,DC=com"}]'
     )
+
+
+def test_ldap_unable_to_bind_defers(
+    harness: Harness[MongoTestCharm], mongodb_name: str, mocker, mock_fs_interactions
+):
+    harness.set_leader()
+    harness.charm.operator.state.app_peer_data.role = MongoDBRoles.REPLICATION
+    harness.charm.operator.state.app_peer_data.db_initialised = True
+    mocker.patch(
+        "single_kernel_mongo.managers.mongodb_operator.MongoDBOperator.restart_charm_services"
+    )
+    mocker.patch(
+        "single_kernel_mongo.managers.ldap.LDAPManager.get_ldap_connection_status",
+        return_value=LdapState.UNABLE_TO_BIND,
+    )
+
+    ldap_relation_id = harness.add_relation(ExternalRequirerRelations.LDAP.value, "glauth-k8s")
+    secret_id = harness.add_model_secret("glauth-k8s", {"password": "password"})
+    harness.grant_secret(secret_id, mongodb_name)
+    harness.update_relation_data(
+        ldap_relation_id,
+        "glauth-k8s",
+        {
+            "base_dn": "dc=glauth,dc=com",
+            "bind_dn": "cn=user,ou=group,dc=glauth,dc=com",
+            "bind_password": "password",
+            "bind_password_id": "secret-id",
+            "bind_password_secret": secret_id,
+            "auth_method": "simple",
+            "starttls": "true",
+            "ldaps_urls": '["ldaps://ldap.glauth.com"]',
+            "urls": '["ldap://ldap.glauth.com"]',
+        },
+    )
+
+    ldap_cert_relation_id = harness.add_relation(
+        ExternalRequirerRelations.LDAP_CERT.value, "glauth-k8s"
+    )
+    harness.add_relation_unit(ldap_cert_relation_id, "glauth-k8s/0")
+
+    defer = mocker.patch("ops.framework.EventBase.defer")
+    harness.update_relation_data(
+        ldap_cert_relation_id,
+        "glauth-k8s/0",
+        {"ca": "deadbeef", "chain": '["feeddead"]', "certificate": "beefdead"},
+    )
+
+    defer.assert_called()
+
+    mocker.patch(
+        "single_kernel_mongo.managers.ldap.LDAPManager.get_ldap_connection_status",
+        return_value=LdapState.ACTIVE,
+    )
+    mocker.patch(
+        "single_kernel_mongo.managers.mongo.MongoManager.get_statuses",
+        return_value=[CharmStatuses.ACTIVE_IDLE.value],
+    )
+
+    harness.charm.on.update_status.emit()
+    harness.evaluate_status()
+
+    # All is good, we are green
+    assert harness.model.unit.status == ActiveStatus("")
 
 
 def test_ldaps_not_enabled(


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷️ Type of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling and CI
- [ ] Dependencies upgrade or change
- [ ] Chores / refactoring

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and feature scope of this PR (what)
  - the motivation behind this change (why)
  - the impacted components (often matches conventional commit scope)
  - explanation/algorithm if required (how)
-->
fixes: #320 
Adds an update-status handler for LDAP recovery (if anything went wrong we can still recover.
Adds a deferral on `restart_if_ready_event` handler because transient communication issue can happen.

Needs: backport on 6/edge and 8-transition/edge

## 🧪 Manual testing steps
<!--- Give a list of instructions to manually test your change. -->
<!--- These instructions are meant for reviewers to test the PR -->
<!--- on their development environment. -->

Hard to reproduce but if you cut network at the right moment between glauth and mongodb you could be ensuring that it gets deferred.

## 🔬 Automated testing steps
<!--- Describe the unit and integration tests that you added -->
<!--- to ensure that this feature works as expected. Include details -->
<!--- on the positive and negative test cases, as well as any changes -->
<!--- made to the existing tests to ensure they are still relevant. -->
* Unit testing added to ensure deferral + resolution when connection works again.

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have added or updated any relevant documentation.
- [x] I have read the [**CONTRIBUTING**](../blob/8/edge/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
