### PR TITLE
ci: set minimum token permissions on automatic-doc-checks

### DIFF
--- a/.github/workflows/automatic-doc-checks.yml
+++ b/.github/workflows/automatic-doc-checks.yml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   documentation-checks:
     uses: canonical/documentation-workflows/.github/workflows/documentation-checks.yaml@main


### PR DESCRIPTION
Sets the minimum-required `GITHUB_TOKEN` scope on `automatic-doc-checks.yml`:

- Workflow-level `permissions:` -> `contents: read`
- No changes to jobs, steps, runners, or triggers
- YAML still parses (`yaml.safe_load` succeeds)

Rationale:

- The automatic doc checks job is read-only; nothing in it needs write access to the repo.
- Without an explicit block, the run inherits whatever default the repository's actions settings happen to be set to. That default has drifted in the past, and forks-of-forks lose track of it.
- the OpenSSF Scorecard Token-Permissions check flags missing per-workflow permissions as a finding.
- After the tj-actions/changed-files supply-chain incident from March 2025, the cost-benefit on explicit minimum scopes is firmly on the side of declaring them.
