### PR TITLE
patch: fix CI permissions in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -104,4 +104,7 @@ jobs:
     with:
       version: ${{ needs.release-part1.outputs.git-tag }}
       base_branch: ${{ github.ref_name }}
+    permissions: # Needed to create PRs in dependent charm repos
+      contents: write
+      pull-requests: write
     secrets: inherit


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷️ Type of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tooling and CI
- [ ] Dependencies upgrade or change
- [ ] Chores / refactoring

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and feature scope of this PR (what)
  - the motivation behind this change (why)
  - the impacted components (often matches conventional commit scope)
  - explanation/algorithm if required (how)
-->

This PR fixes this error on CI release:

[Invalid workflow file: .github/workflows/release.yaml#L97](https://github.com/canonical/mongo-single-kernel-library/actions/runs/26766572683/workflow)
The workflow is not valid. .github/workflows/release.yaml (Line: 97, Col: 3): Error calling workflow 'canonical/mongo-single-kernel-library/.github/workflows/bump_dependent_charms.yaml@615f664f0c26d0615dd33a84f6ce4fb72cdd53d6'. The nested job 'update-dependent-charms' is requesting 'contents: write, pull-requests: write', but is only allowed 'contents: read, pull-requests: none'.

## 🔬 Automated testing steps
<!--- Describe the unit and integration tests that you added -->
<!--- to ensure that this feature works as expected. Include details -->
<!--- on the positive and negative test cases, as well as any changes -->
<!--- made to the existing tests to ensure they are still relevant. -->

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have added or updated any relevant documentation.
- [ ] I have read the [**CONTRIBUTING**](../blob/8/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
