### PR TITLE
patch: fix permission missing in CI release job 

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,6 +16,8 @@ concurrency:
 jobs:
   ci-tests:
     uses: ./.github/workflows/ci.yaml
+    permissions:
+      contents: write # Needed for Allure Report
     secrets: inherit
 
   release-part1:
@@ -94,4 +96,7 @@ jobs:
     with:
       version: ${{ needs.release-part1.outputs.git-tag }}
       base_branch: ${{ github.ref_name }}
+    permissions: # Needed to create PRs in dependent charm repos
+      contents: write
+      pull-requests: write
     secrets: inherit

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,6 +17,7 @@ jobs:
   ci-tests:
     uses: ./.github/workflows/ci.yaml
     permissions:
+      pull-requests: write # Needed for lib-check
       contents: write # Needed for Allure Report
     secrets: inherit
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷️ Type of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tooling and CI
- [ ] Dependencies upgrade or change
- [ ] Chores / refactoring

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and feature scope of this PR (what)
  - the motivation behind this change (why)
  - the impacted components (often matches conventional commit scope)
  - explanation/algorithm if required (how)
-->

This PR fixes this error in the release CI workflow
```
[Invalid workflow file: .github/workflows/release.yaml#L17](https://github.com/canonical/mongo-single-kernel-library/actions/runs/26509737648/workflow)
The workflow is not valid. .github/workflows/release.yaml (Line: 17, Col: 3): Error calling workflow 'canonical/mongo-single-kernel-library/.github/workflows/ci.yaml@3312eb896d2dbe09579ff547014b696edd3a1a8f'. The nested job 'lib-check' is requesting 'pull-requests: write', but is only allowed 'pull-requests: none'. .github/workflows/release.yaml (Line: 17, Col: 3): Error calling workflow 'canonical/mongo-single-kernel-library/.github/workflows/ci.yaml@3312eb896d2dbe09579ff547014b696edd3a1a8f'. The nested job 'integration-test' is requesting 'contents: write', but is only allowed 'contents: read'.
```
https://github.com/canonical/mongo-single-kernel-library/actions/runs/26509737648

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have added or updated any relevant documentation.
- [ ] I have read the [**CONTRIBUTING**](../blob/8/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
