### PR TITLE
patch: fix permission missing in the release CI job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,10 +15,14 @@ concurrency:
 jobs:
   ci-quick-tests:
     uses: ./.github/workflows/ci-quick.yaml
+    permissions:
+      pull-requests: write # Needed for lib-check
     secrets: inherit
 
   ci-tests:
     uses: ./.github/workflows/ci.yaml
+    permissions:
+      contents: write # Needed for Allure Report
     secrets: inherit
 
   release-part1:
@@ -98,4 +102,7 @@ jobs:
     with:
       version: ${{ needs.release-part1.outputs.git-tag }}
       base_branch: ${{ github.ref_name }}
+    permissions: # Needed to create PRs in dependent charm repos
+      contents: write
+      pull-requests: write
     secrets: inherit


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷️ Type of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling and CI
- [ ] Dependencies upgrade or change
- [ ] Chores / refactoring

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and feature scope of this PR (what)
  - the motivation behind this change (why)
  - the impacted components (often matches conventional commit scope)
  - explanation/algorithm if required (how)
-->
This PR fixes 
```
[Invalid workflow file: .github/workflows/release.yaml#L16](https://github.com/canonical/mongo-single-kernel-library/actions/runs/26509724140/workflow)
The workflow is not valid. .github/workflows/release.yaml (Line: 16, Col: 3): Error calling workflow 'canonical/mongo-single-kernel-library/.github/workflows/ci-quick.yaml@b51233a3f7416b55f30ae2d57fb7dd27888d85a6'. The nested job 'lib-check' is requesting 'pull-requests: write', but is only allowed 'pull-requests: none'.
```
https://github.com/canonical/mongo-single-kernel-library/actions/runs/26509724140

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have added or updated any relevant documentation.
- [ ] I have read the [**CONTRIBUTING**](../blob/8/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
