### PR TITLE
patch(DPE-10317): Don't request certs for unix socket

### DIFF
--- a/single_kernel_mongo/managers/cluster.py
+++ b/single_kernel_mongo/managers/cluster.py
@@ -387,6 +387,10 @@ class ClusterRequirer(Object):
             CharmStatuses.ACTIVE_IDLE.value, scope="unit", component=self.dependent.name
         )
         if self.charm.unit.is_leader():
+            # Mongos handles also app statuses
+            self.state.statuses.set(
+                CharmStatuses.ACTIVE_IDLE.value, scope="app", component=self.dependent.name
+            )
             self.state.app_peer_data.db_initialised = True
             # In the K8S case, create the user
             self.update_users_for_k8s_routers()

--- a/single_kernel_mongo/managers/config.py
+++ b/single_kernel_mongo/managers/config.py
@@ -419,7 +419,8 @@ class MongoConfigManager(FileBasedConfigManager, ABC):
                 "net": {
                     "bindIp": f"{self.workload.paths.socket_path}",
                     "unixDomainSocket": {
-                        "filePermissions": "0766",
+                        "enabled": True,
+                        "filePermissions": "0660",
                     },
                 },
             }

--- a/single_kernel_mongo/managers/config.py
+++ b/single_kernel_mongo/managers/config.py
@@ -420,7 +420,7 @@ class MongoConfigManager(FileBasedConfigManager, ABC):
                     "bindIp": f"{self.workload.paths.socket_path}",
                     "unixDomainSocket": {
                         "enabled": True,
-                        "filePermissions": "0660",
+                        "filePermissions": "0666",
                     },
                 },
             }

--- a/single_kernel_mongo/managers/tls.py
+++ b/single_kernel_mongo/managers/tls.py
@@ -119,13 +119,6 @@ class TLSManager(ManagerStatusProtocol):
             if host := self.state.unit_host:
                 sans["sans_ips"].append(host)
 
-        # if (
-        #    self.state.is_role(MongoDBRoles.MONGOS)
-        #    and self.substrate == Substrates.VM
-        #    and not self.state.app_peer_data.external_connectivity
-        # ):
-        #    sans["sans_dns"].append(f"{self.state.paths.socket_path}")
-
         return sans
 
     def get_tls_file_contents(self, internal: bool) -> tuple[str | None, str | None]:

--- a/single_kernel_mongo/managers/tls.py
+++ b/single_kernel_mongo/managers/tls.py
@@ -119,12 +119,12 @@ class TLSManager(ManagerStatusProtocol):
             if host := self.state.unit_host:
                 sans["sans_ips"].append(host)
 
-        if (
-            self.state.is_role(MongoDBRoles.MONGOS)
-            and self.substrate == Substrates.VM
-            and not self.state.app_peer_data.external_connectivity
-        ):
-            sans["sans_dns"].append(f"{self.state.paths.socket_path}")
+        # if (
+        #    self.state.is_role(MongoDBRoles.MONGOS)
+        #    and self.substrate == Substrates.VM
+        #    and not self.state.app_peer_data.external_connectivity
+        # ):
+        #    sans["sans_dns"].append(f"{self.state.paths.socket_path}")
 
         return sans
 

--- a/single_kernel_mongo/utils/mongo_config.py
+++ b/single_kernel_mongo/utils/mongo_config.py
@@ -60,29 +60,34 @@ class MongoConfiguration:
         return self.hosts
 
     @property
-    def formatted_replset(self) -> dict:
+    def formatted_replset(self) -> dict[str, str]:
         """Formatted replicaSet parameter."""
         if self.replset:
             return {"replicaSet": quote_plus(self.replset)}
         return {}
 
     @property
-    def formatted_auth_source(self) -> dict:
+    def formatted_auth_source(self) -> dict[str, str]:
         """Formatted auth source."""
         if self.database != "admin":
             return ADMIN_AUTH_SOURCE
         return {}
 
     @property
-    def tls_config(self) -> dict:
+    def tls_config(self) -> dict[str, str]:
         """TLS Config."""
         if not self.tls_enabled:
             return {}
-        return {
+        config = {
             "tls": "true",
-            "tlsCertificateKeyFile": f"{self.tls_external_keyfile}",
             "tlsCaFile": f"{self.tls_external_ca}",
         }
+        # Edge case: MongoDB TLS with Unix Socket requires disabling client hostname verification.
+        # This is because the reported remote is the unix socket, which is not in the SANS list.
+        if len(self.hosts) == 1 and list(self.hosts)[0].endswith("27018.sock"):
+            config["tlsAllowInvalidHostnames"] = "true"
+
+        return config
 
     def _uri(self, tls: bool):
         if self.port == MongoPorts.MONGOS_PORT and self.replset:

--- a/tests/integration/applications/continuous_write_charm/config.yaml
+++ b/tests/integration/applications/continuous_write_charm/config.yaml
@@ -5,12 +5,17 @@ options:
   mongos-uri:
     type: string
     description: |
-      URI provided to connect to MongoDB cluster via mongos
+      URI provided to connect to MongoDB cluster via mongos.
   tls-ca:
     type: string
     description: |
-      TLS CA certificate to use alongside mongos-uri
+      TLS CA certificate to use alongside mongos-uri.
   database-name:
     type: string
     description: |
       Database name to request.
+  external-connectivity:
+    type: boolean
+    description: |
+      External connectivity for mongos.
+    default: true

--- a/tests/integration/applications/continuous_write_charm/src/charm.py
+++ b/tests/integration/applications/continuous_write_charm/src/charm.py
@@ -67,7 +67,7 @@ class ContinuousWritesApplication(CharmBase):
         # Database related events
         self.database = DatabaseRequires(self, "mongodb", self.database_name)
         # Database related events
-        self.mongos_database = DatabaseRequires(self, "mongos", self.database_name, external_node_connectivity=True)
+        self.mongos_database = DatabaseRequires(self, "mongos", self.database_name, external_node_connectivity=self.config.get("external-connectivity"))
 
         self.framework.observe(self.database.on.database_created, self._on_database_created)
         self.framework.observe(self.mongos_database.on.database_created, self._on_database_created)
@@ -154,17 +154,27 @@ class ContinuousWritesApplication(CharmBase):
     # ==============
 
     def _build_tls_uri(self, uris: str) -> str:
-            parsed_uri = parse_uri(uris)
-            params = parsed_uri["options"]
-            params["tls"] = "true"
-            params["tlsCaFile"] = f"{CA_PATH}"
-            hosts = ",".join(f"{host}:{port}" for host, port in parsed_uri["nodelist"])
-            return (
-                    f"mongodb://{quote_plus(parsed_uri['username'])}:"
-                        f"{quote_plus(parsed_uri['password'])}@"
-                        f"{hosts}/{quote_plus(parsed_uri['database'])}?"
-                        f"{urlencode(params)}"
-                )
+        parsed_uri = parse_uri(uris)
+        params = parsed_uri["options"]
+        params["tls"] = "true"
+        params["tlsCaFile"] = f"{CA_PATH}"
+
+        if any("27018.sock" in host for host, _ in parsed_uri["nodelist"]):
+            params["tlsAllowInvalidHostnames"] = "true"
+
+        nodelist: list[str] = []
+        for host, port in parsed_uri["nodelist"]:
+            if port:
+                nodelist.append(f"{host}:{port}")
+            else:
+                nodelist.append(f"{host}")
+        hosts = ",".join(nodelist)
+        return (
+                f"mongodb://{quote_plus(parsed_uri['username'])}:"
+                    f"{quote_plus(parsed_uri['password'])}@"
+                    f"{hosts}/{quote_plus(parsed_uri['database'])}?"
+                    f"{urlencode(params)}"
+            )
 
     def _start_continuous_writes(
         self, starting_number: int, db_name: str, collection_name: str

--- a/tests/integration/applications/continuous_write_charm/src/charm.py
+++ b/tests/integration/applications/continuous_write_charm/src/charm.py
@@ -15,7 +15,7 @@ import signal
 import subprocess
 import sys
 from pathlib import Path
-from urllib.parse import quote_plus, urlencode
+from urllib.parse import quote_plus, urlencode, quote
 
 from charms.data_platform_libs.v0.data_interfaces import DatabaseRequires, DatabaseCreatedEvent
 from ops.charm import ActionEvent, CharmBase
@@ -167,8 +167,10 @@ class ContinuousWritesApplication(CharmBase):
             if port:
                 nodelist.append(f"{host}:{port}")
             else:
-                nodelist.append(f"{host}")
+                nodelist.append(quote(f"{host}", safe=""))
+
         hosts = ",".join(nodelist)
+
         return (
                 f"mongodb://{quote_plus(parsed_uri['username'])}:"
                     f"{quote_plus(parsed_uri['password'])}@"

--- a/tests/integration/mongos/test_tls_inverted.py
+++ b/tests/integration/mongos/test_tls_inverted.py
@@ -49,7 +49,7 @@ async def test_build_and_deploy(
     )
     if substrate == "lxd":
         await ops_test.model.applications[MONGOS_CLIENT_APPLICATION].set_config(
-            {"external-connectivity": True}
+            {"external-connectivity": "false"}
         )
     await build_cluster(ops_test, substrate, integrate_with_mongos=True, integrate_with_client=True)
 

--- a/tests/integration/mongos/test_tls_inverted.py
+++ b/tests/integration/mongos/test_tls_inverted.py
@@ -12,6 +12,7 @@ from tests.integration.helpers.common import (
     wait_for_mongodb_units_blocked,
 )
 from tests.integration.helpers.mongos import (
+    MONGOS_CLIENT_APPLICATION,
     MONGOS_CLUSTER_COMPONENTS,
     assert_mongos_tls_enabled,
     build_cluster,
@@ -46,6 +47,10 @@ async def test_build_and_deploy(
         mongos_resource,
         application_path,
     )
+    if substrate == "lxd":
+        await ops_test.model.applications[MONGOS_CLIENT_APPLICATION].set_config(
+            {"external-connectivity": True}
+        )
     await build_cluster(ops_test, substrate, integrate_with_mongos=True, integrate_with_client=True)
 
     config = {"ca-common-name": "Test CA"}

--- a/tests/unit/data/mongos.conf
+++ b/tests/unit/data/mongos.conf
@@ -7,7 +7,7 @@ net:
   port: 27018
   unixDomainSocket:
     enabled: true
-    filePermissions: '0660'
+    filePermissions: '0666'
 security:
   clusterAuthMode: keyFile
   keyFile: /var/snap/charmed-mongodb/current/etc/mongod/keyFile

--- a/tests/unit/data/mongos.conf
+++ b/tests/unit/data/mongos.conf
@@ -6,7 +6,8 @@ net:
   bindIp: /var/snap/charmed-mongodb/common/var/mongodb-27018.sock
   port: 27018
   unixDomainSocket:
-    filePermissions: '0766'
+    enabled: true
+    filePermissions: '0660'
 security:
   clusterAuthMode: keyFile
   keyFile: /var/snap/charmed-mongodb/current/etc/mongod/keyFile

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -289,7 +289,8 @@ def test_mongos_config_manager(mocker):
         "net": {
             "bindIp": f"{VM_PATH['mongod']['VAR']}/mongodb-27018.sock",
             "unixDomainSocket": {
-                "filePermissions": "0766",
+                "enabled": True,
+                "filePermissions": "0660",
             },
         }
     }
@@ -324,7 +325,8 @@ def test_mongos_config_manager(mocker):
         "net": {
             "bindIp": f"{VM_PATH['mongod']['VAR']}/mongodb-27018.sock",
             "unixDomainSocket": {
-                "filePermissions": "0766",
+                "enabled": True,
+                "filePermissions": "0660",
             },
             "port": 27018,
         },

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -290,7 +290,7 @@ def test_mongos_config_manager(mocker):
             "bindIp": f"{VM_PATH['mongod']['VAR']}/mongodb-27018.sock",
             "unixDomainSocket": {
                 "enabled": True,
-                "filePermissions": "0660",
+                "filePermissions": "0666",
             },
         }
     }
@@ -326,7 +326,7 @@ def test_mongos_config_manager(mocker):
             "bindIp": f"{VM_PATH['mongod']['VAR']}/mongodb-27018.sock",
             "unixDomainSocket": {
                 "enabled": True,
-                "filePermissions": "0660",
+                "filePermissions": "0666",
             },
             "port": 27018,
         },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷️ Type of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling and CI
- [ ] Dependencies upgrade or change
- [ ] Chores / refactoring

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and feature scope of this PR (what)
  - the motivation behind this change (why)
  - the impacted components (often matches conventional commit scope)
  - explanation/algorithm if required (how)
-->
Mongos charm was requesting a certificate for a local unix socket.
While this was possible with self-signed-certificates operator, is will fail with real life operators.
This PR fixes this, removing the unix socket from the CSR.
It also updates the mongo config to remove the wrongly used mTLS configuration, and adds an exception for pymongo for the unix socket case (remove host validation).

## 🧪 Manual testing steps
<!--- Give a list of instructions to manually test your change. -->
<!--- These instructions are meant for reviewers to test the PR -->
<!--- on their development environment. -->

```text
1. juju deploy config-server
2. juju deploy shard
3. juju deploy mongos
4. juju deploy continuous-writes --config external-connectivity=false
5. juju deploy self-signed certificates
6. juju integrate shard:sharding config-server
7. juju integrate mongos continuous-writes
8. Integrate everything with TLS
9. juju integrate mongos config-server
10. juju run continuous-writes start-continuous-writes
11. juju run continuous-writes stop-continuous-writes
```
The last step should return a valid number of writes.

## 🔬 Automated testing steps
<!--- Describe the unit and integration tests that you added -->
<!--- to ensure that this feature works as expected. Include details -->
<!--- on the positive and negative test cases, as well as any changes -->
<!--- made to the existing tests to ensure they are still relevant. -->
test_tls_inverted.py has been updated to reflect that situation.

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [x] I have added or updated any relevant documentation.
- [x] I have read the [**CONTRIBUTING**](../blob/8/edge/CONTRIBUTING.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
