### PR TITLE
patch: fix failing docs build (8)

### DIFF
--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -14,7 +14,7 @@ Available deployment methods and operations to consider at deploy-time:
 
 Deploy <deploy/index>
 Manage persistent storage <manage-persistent-storage>
-````
+```
 
 ## Operations and maintenance
 
@@ -24,7 +24,7 @@ Essential operations to configure and manage a MongoDB cluster:
 :titlesonly:
 
 Scale replicas and shards <scale-replicas-and-shards>
-Enable cluster-wide rolling operations <enable-cluster-rolling-ops>
+Enable cluster-wide rolling ops <rolling-ops>
 Manage TLS encryption <tls/index>
 ````
 

--- a/docs/how-to/rolling-ops.md
+++ b/docs/how-to/rolling-ops.md
@@ -1,4 +1,4 @@
-(enable-cluster-rolling-ops)=
+(rolling-ops)=
 # Enable cluster-wide rolling operations
 
 By default, Charmed MongoDB coordinates rolling operations only within each application.


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷️ Type of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation update
- [x] Tooling and CI
- [ ] Dependencies upgrade or change
- [ ] Chores / refactoring

## 📝 Description

The Read The Docs build for 8/edge was failing because the new rolling ops guide was included in `how-to/index.md` via its anchor ID (`(enable-cluster-rolling-ops)=` instead of its filename `rollingops`.

I've
* Renamed the file to `rolling-ops.md` to fit our naming convention (hyphens for spaces)
* Renamed the anchor ID from `(enable-cluster-rolling-ops)=` to `(rolling-ops)=` to fit the general pattern of having our title IDs match the filename
* Shortened "operations" to "ops" in the table of contents title to shorten it a bit

## 🧪 Manual testing steps
```shell
cd docs
make clean
make run
```

There should be no Sphinx errors about toctree inclusion.

## 🔬 Automated testing steps

* Documentation checks in this PR should be green
* Read The Docs build should be green: https://app.readthedocs.com/projects/canonical-mongodb-migration/

Link check failures are expected - Juju docs are currently unstable due to known issues. 

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have added or updated any relevant documentation.
- [ ] I have read the [**CONTRIBUTING**](../blob/8/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
