### PR TITLE
patch: fix IP  restriction in rs in different subnets

### DIFF
--- a/single_kernel_mongo/managers/config.py
+++ b/single_kernel_mongo/managers/config.py
@@ -39,7 +39,7 @@ from single_kernel_mongo.utils.mongodb_users import (
     CharmedLogRotateUser,
     CharmedStatsUser,
 )
-from single_kernel_mongo.utils.network_helpers import cidrs
+from single_kernel_mongo.utils.network_helpers import cidrs, get_cidr_for_ip_list, merge_cidrs
 from single_kernel_mongo.workload import (
     get_logrotate_workload_for_substrate,
     get_mongodb_exporter_workload_for_substrate,
@@ -527,6 +527,17 @@ class MongoDBConfigManager(MongoConfigManager):
         """The allowed cluster IPs."""
         # Always include IPs from the local peer relation
         cidrs_list = cidrs(self.state.peer_network().bind_addresses)
+        peer_database_addresses = [
+            unit.database_address for unit in self.state.units if unit.database_address
+        ]
+        if peer_database_addresses:
+            try:
+                cidrs_list.append(get_cidr_for_ip_list(peer_database_addresses))
+            except ValueError:
+                logger.warning(
+                    "Failed to compute peer auth CIDR from peer database addresses: %s",
+                    peer_database_addresses,
+                )
         # The config server should include the CIDR for the shards
         if self.state.is_role(MongoDBRoles.CONFIG_SERVER):
             cidrs_list.extend(cidrs(self.state.config_server_network().bind_addresses))
@@ -541,8 +552,8 @@ class MongoDBConfigManager(MongoConfigManager):
         if self.state.is_cluster_component:
             cidrs_list.extend(cidrs(self.state.cluster_network().bind_addresses))
 
-        # Deduplicate the list
-        return {"security": {"clusterIpSourceAllowlist": sorted(set(cidrs_list))}}
+        # Deduplicate and collapse overlapping networks
+        return {"security": {"clusterIpSourceAllowlist": merge_cidrs(cidrs_list)}}
 
     @property
     def db_path_argument(self) -> dict[str, Any]:

--- a/single_kernel_mongo/managers/mongo.py
+++ b/single_kernel_mongo/managers/mongo.py
@@ -211,6 +211,19 @@ class MongoManager(Object, AbstractManagerStatus[CharmState]):
 
         self.state.app_peer_data.set_user_created(user.username)
 
+    def reconcile_local_auth_restrictions(self) -> None:
+        """Update auth restrictions for internal users that connect locally."""
+        with MongoConnection(self.state.mongo_config) as mongo:
+            for user in (CharmedStatsUser, CharmedBackupUser, CharmedLogRotateUser):
+                if not self.state.app_peer_data.is_user_created(user.username):
+                    continue
+
+                config = self.state.mongodb_config_for_user(
+                    user, auth_restrictions=self.state.local_auth_restrictions
+                )
+                logger.info("Updating auth restrictions for %s user.", user.username)
+                mongo.update_user_auth_restrictions(config)
+
     def reconcile_mongo_users_and_dbs(
         self,
         relation: Relation,

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -927,6 +927,7 @@ class MongoDBOperator(OperatorProtocol, Object):
         try:
             # Adds the newly added/updated units.
             self.mongo_manager.process_added_units()
+            self.mongo_manager.reconcile_local_auth_restrictions()
         except (NotReadyError, PyMongoError) as e:
             logger.error(f"Not reconfiguring: error={e}")
             self.state.statuses.add(

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -903,6 +903,9 @@ class MongoDBOperator(OperatorProtocol, Object):
             # We can use either manager, what matters is the BackupConfigManager below
             self.s3_backup_manager.configure_and_restart()
 
+        if self.state.db_initialised:
+            self.async_restart_charm_services(force=False)
+
         # only leader should configure replica set and we should do it only if
         # the replica set is initialised.
         if not self.charm.unit.is_leader() or not self.state.db_initialised:

--- a/single_kernel_mongo/state/charm_state.py
+++ b/single_kernel_mongo/state/charm_state.py
@@ -88,7 +88,12 @@ from single_kernel_mongo.utils.mongodb_users import (
     MongoDBUser,
     RoleNames,
 )
-from single_kernel_mongo.utils.network_helpers import cidrs, ip_addresses
+from single_kernel_mongo.utils.network_helpers import (
+    cidrs,
+    get_cidr_for_ip_list,
+    ip_addresses,
+    merge_cidrs,
+)
 
 if TYPE_CHECKING:
     from single_kernel_mongo.abstract_charm import AbstractMongoCharm
@@ -703,11 +708,28 @@ class CharmState(Object, AbstractStatusesState):
     @property
     def local_auth_restrictions(self) -> list[AuthRestrictions]:
         """Return auth restrictions for local users."""
+        peer_client_sources = cidrs(self.peer_network().bind_addresses)
+
+        peer_database_addresses = [
+            unit.database_address for unit in self.units if unit.database_address
+        ]
+
+        if peer_database_addresses:
+            try:
+                peer_client_sources.append(get_cidr_for_ip_list(peer_database_addresses))
+            except ValueError:
+                logger.warning(
+                    "Failed to compute peer auth CIDR from peer database addresses: %s",
+                    peer_database_addresses,
+                )
+
+        peer_client_sources = merge_cidrs(peer_client_sources)
+
         return [
             AuthRestrictions(clientSource=[LOCALHOST], serverAddress=[LOCALHOST]),
             AuthRestrictions(
-                clientSource=cidrs(self.peer_network().bind_addresses),
-                serverAddress=cidrs(self.peer_network().bind_addresses),
+                clientSource=peer_client_sources,
+                serverAddress=peer_client_sources,
             ),
         ]
 

--- a/single_kernel_mongo/utils/mongo_connection.py
+++ b/single_kernel_mongo/utils/mongo_connection.py
@@ -179,6 +179,14 @@ class MongoConnection:
             roles=config.supported_roles,
         )
 
+    def update_user_auth_restrictions(self, config: MongoConfiguration):
+        """Update authentication restrictions on database."""
+        self.client.admin.command(
+            "updateUser",
+            value=config.username,
+            authenticationRestrictions=config.auth_restrictions,
+        )
+
     def set_user_password(self, username: str, password: str):
         """Update the password."""
         self.client.admin.command(

--- a/single_kernel_mongo/utils/network_helpers.py
+++ b/single_kernel_mongo/utils/network_helpers.py
@@ -7,7 +7,7 @@
 import os
 import subprocess  # nosec: B404
 from collections.abc import Sequence
-from ipaddress import ip_address, ip_network
+from ipaddress import collapse_addresses, ip_address, ip_network
 
 from ops import Relation
 from ops.hookcmds import BindAddress, Network, network_get
@@ -50,6 +50,19 @@ def get_host_public_ip() -> set[str]:
         return set()
 
     return {output.stdout.strip()}
+
+
+def merge_cidrs(cidr_list: Sequence[str]) -> list[str]:
+    """Collapse overlapping or redundant CIDRs into the minimal set."""
+    if not cidr_list:
+        return []
+
+    networks = [ip_network(cidr, strict=False) for cidr in cidr_list]
+    collapsed_networks = [
+        *collapse_addresses(network for network in networks if network.version == 4),
+        *collapse_addresses(network for network in networks if network.version == 6),
+    ]
+    return [str(network) for network in collapsed_networks]
 
 
 def get_cidr_for_ip_list(ip_list: list[str]) -> str:

--- a/tests/unit/test_charm_state.py
+++ b/tests/unit/test_charm_state.py
@@ -91,6 +91,32 @@ def test_unit_peer_data(
     assert state.unit_peer_data.internal_address == mongodb_hostname
 
 
+def test_local_auth_restrictions_use_peer_database_addresses(
+    harness: Harness[MongoTestCharm], mongodb_name: str, substrate: Substrate
+):
+    if substrate != "lxd":
+        pytest.skip("Auth restrictions are only applied on VMs.")
+
+    rel = harness.charm.model.get_relation(PeerRelationNames.PEERS.value)
+    harness.add_relation_unit(rel.id, f"{mongodb_name}/1")  # type: ignore
+    harness.add_relation_unit(rel.id, f"{mongodb_name}/2")  # type: ignore
+    harness.charm.operator.state.unit_peer_data.database_address = "172.31.15.253"
+    harness.update_relation_data(
+        rel.id,  # type: ignore
+        f"{mongodb_name}/1",
+        {"database-address": "172.31.24.68"},
+    )
+    harness.update_relation_data(
+        rel.id,  # type: ignore
+        f"{mongodb_name}/2",
+        {"database-address": "172.31.47.55"},
+    )
+
+    assert harness.charm.operator.state.local_auth_restrictions[1]["clientSource"] == [
+        "172.31.0.0/16"
+    ]
+
+
 def test_mongodb_status_user(harness: Harness[MongoTestCharm]):
     harness.set_leader(True)
     state = harness.charm.operator.state

--- a/tests/unit/test_charm_state.py
+++ b/tests/unit/test_charm_state.py
@@ -113,7 +113,8 @@ def test_local_auth_restrictions_use_peer_database_addresses(
     )
 
     assert harness.charm.operator.state.local_auth_restrictions[1]["clientSource"] == [
-        "172.31.0.0/16"
+        "10.0.0.0/24",
+        "172.31.0.0/16",
     ]
 
 

--- a/tests/unit/test_charm_state.py
+++ b/tests/unit/test_charm_state.py
@@ -90,13 +90,10 @@ def test_unit_peer_data(
 
     assert state.unit_peer_data.internal_address == mongodb_hostname
 
-
+@pytest.mark.skip_if_substrate("microk8s")
 def test_local_auth_restrictions_use_peer_database_addresses(
     harness: Harness[MongoTestCharm], mongodb_name: str, substrate: Substrate
 ):
-    if substrate != "lxd":
-        pytest.skip("Auth restrictions are only applied on VMs.")
-
     rel = harness.charm.model.get_relation(PeerRelationNames.PEERS.value)
     harness.add_relation_unit(rel.id, f"{mongodb_name}/1")  # type: ignore
     harness.add_relation_unit(rel.id, f"{mongodb_name}/2")  # type: ignore

--- a/tests/unit/test_config_manager.py
+++ b/tests/unit/test_config_manager.py
@@ -119,7 +119,9 @@ def test_mongodb_config_manager(mocker, role: MongoDBRoles, expected_parameter: 
         }
     }
     assert client_tls_parameters == {}
-    assert cluster_ips == {"security": {"clusterIpSourceAllowlist": ["10.0.0.1/24", "127.0.0.1"]}}
+    assert cluster_ips == {
+        "security": {"clusterIpSourceAllowlist": ["10.0.0.0/24", "127.0.0.1/32"]}
+    }
 
     assert (
         all_params
@@ -128,7 +130,7 @@ def test_mongodb_config_manager(mocker, role: MongoDBRoles, expected_parameter: 
             "security": {
                 "authorization": "enabled",
                 "clusterAuthMode": "keyFile",
-                "clusterIpSourceAllowlist": ["10.0.0.1/24", "127.0.0.1"],
+                "clusterIpSourceAllowlist": ["10.0.0.0/24", "127.0.0.1/32"],
                 "keyFile": f"{VM_PATH['mongod']['CONF']}/keyFile",
             },
             "setParameter": {"processUmask": "037"},

--- a/tests/unit/test_helpers.py
+++ b/tests/unit/test_helpers.py
@@ -5,7 +5,12 @@
 from ops.hookcmds import Network
 
 from single_kernel_mongo.utils.helpers import hostname_from_hostport, mask_sensitive_information
-from single_kernel_mongo.utils.network_helpers import cidrs, get_cidr_for_ip_list, ip_addresses
+from single_kernel_mongo.utils.network_helpers import (
+    cidrs,
+    get_cidr_for_ip_list,
+    ip_addresses,
+    merge_cidrs,
+)
 
 
 def test_hostname_from_hostport():
@@ -69,3 +74,15 @@ def test_cidrs():
         }
     )
     assert cidrs(network.bind_addresses) == ["10.0.0.1/24", "10.0.1.1/24"]
+
+
+def test_merge_cidrs_collapses_overlapping_networks():
+    assert merge_cidrs(["172.31.0.0/16", "172.31.0.0/20", "252.0.0.0/12"]) == [
+        "172.31.0.0/16",
+        "252.0.0.0/12",
+    ]
+    assert merge_cidrs(["10.0.0.1/24", "10.0.0.0/24"]) == ["10.0.0.0/24"]
+    assert merge_cidrs(["10.0.0.1/32", "2001:db8::1/128"]) == [
+        "10.0.0.1/32",
+        "2001:db8::1/128",
+    ]

--- a/tests/unit/test_mongo_manager.py
+++ b/tests/unit/test_mongo_manager.py
@@ -10,6 +10,7 @@ from single_kernel_mongo.utils.mongo_connection import NotReadyError
 from single_kernel_mongo.utils.mongodb_users import (
     OPERATOR_ROLE,
     CharmedBackupUser,
+    CharmedLogRotateUser,
     CharmedOperatorUser,
     CharmedStatsUser,
 )
@@ -83,11 +84,29 @@ def test_initialise_user(harness: Harness[MongoTestCharm], mocker, user):
         config.supported_roles,
         auth_restrictions=[
             {"clientSource": ["127.0.0.1"], "serverAddress": ["127.0.0.1"]},
-            {"clientSource": ["10.0.0.1/24"], "serverAddress": ["10.0.0.1/24"]},
+            {"clientSource": ["10.0.0.0/24"], "serverAddress": ["10.0.0.0/24"]},
         ],
     )
 
     assert harness.charm.operator.state.app_peer_data.is_user_created(user.username)
+
+
+def test_reconcile_local_auth_restrictions(harness: Harness[MongoTestCharm], mocker):
+    harness.set_leader(True)
+    state = harness.charm.operator.state
+    for user in (CharmedStatsUser, CharmedBackupUser, CharmedLogRotateUser):
+        state.app_peer_data.set_user_created(user.username)
+
+    mock_update = mocker.patch(
+        "single_kernel_mongo.utils.mongo_connection.MongoConnection.update_user_auth_restrictions",
+    )
+
+    harness.charm.operator.mongo_manager.reconcile_local_auth_restrictions()
+
+    assert mock_update.call_count == 3
+    for call in mock_update.call_args_list:
+        config = call.args[0]
+        assert config.auth_restrictions == state.local_auth_restrictions
 
 
 def test_initialise_operator_user(harness: Harness[MongoTestCharm], mocker, substrate: Substrate):


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷️ Type of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling and CI
- [ ] Dependencies upgrade or change
- [ ] Chores / refactoring

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and feature scope of this PR (what)
  - the motivation behind this change (why)
  - the impacted components (often matches conventional commit scope)
  - explanation/algorithm if required (how)
-->

This PR is a fix for https://github.com/canonical/mongo-single-kernel-library/issues/371

If units of a replica set are in different subnets, secondary RS nodes were marked as `unreachable`. This problem is seen with a simple RS deployment in aws

```
Name   Space ID  Subnets       
alpha  0         172.31.0.0/20 
                 172.31.16.0/20
                 172.31.32.0/20
                 252.0.0.0/12  
                 252.16.0.0/12 
                 252.32.0.0/12
```

This PR:
- Update the content of the `mongod.conf` so that it includes a bigger CIDR
- Update the `authenticationRestrictions` of the `charmed-logrotate`, `charmed-backups` and `charmed-stat` users, to include a bigger CIDR


This changes are quite tricky because the `mongod.conf` is written before the other replica set joins the database-peers relation. So we now request an async rolling restart to update the content of the conf file if it changed, on database-peers relation changed event.

We also trigger the update of the charmed users.

When fixing this issue,  I first updated the conf file and then noticed that PBM was not able to start. That's how I noticed that we needed to update the users. 

## 🧪 Manual testing steps
<!--- Give a list of instructions to manually test your change. -->
<!--- These instructions are meant for reviewers to test the PR -->
<!--- on their development environment. -->

1. Deploy a RS with 3 units in AWS
2. All the units should be active/idle

check the content of `/var/snap/charmed-mongodb/168/etc/mongod/mongod.conf`

```
security:
  authorization: enabled
  clusterAuthMode: keyFile
  clusterIpSourceAllowlist:
  - 172.31.0.0/16
  - 252.0.0.0/12
```

The `clusterIpSourceAllowlist` should contain a CIDR that include the IPs of the other units


Use `juju exec -u rs3/1 -- network-get database-peers --format yaml` to check the addresses

```
bind-addresses:
- mac-address: 06:62:e9:ea:6a:b3
  interface-name: enp39s0
  addresses:
  - hostname: ""
    value: 172.31.11.160
    cidr: 172.31.0.0/20
    address: 172.31.11.160
  macaddress: 06:62:e9:ea:6a:b3
  interfacename: enp39s0
- mac-address: 56:d8:22:68:bd:d8
  interface-name: fan-252
  addresses:
  - hostname: ""
    value: 252.11.160.1
    cidr: 252.0.0.0/12
    address: 252.11.160.1
  macaddress: 56:d8:22:68:bd:d8
  interfacename: fan-252
egress-subnets:
- 172.31.11.160/32
ingress-addresses:
- 172.31.11.160
- 252.11.160.1
```

juju ssh into the unit and get the pbm URI
```
 sudo snap get charmed-mongodb
```
```
pbm-uri      mongodb://charmed-backup:<password>@localhost:27017/?authMechanism=SCRAM-SHA-256&authSource=admin
```

Check the RS and user auth

```
sudo snap run charmed-mongodb.mongosh 'mongodb://charmed-backup:<password>@localhost:27017/?authMechanism=SCRAM-SHA-256&authSource=admin'
```

```
rs3 [direct: secondary] test> use admin
switched to db admin
rs3 [direct: secondary] admin> db.system.users.find({user:"charmed-backup"}).pretty()
[
  {
    _id: 'admin.charmed-backup',
    userId: UUID('5cf1bb4b-d193-430f-91c5-a411d211032e'),
    user: 'charmed-backup',
    db: 'admin',
    credentials: {
      'SCRAM-SHA-256': {
        iterationCount: 15000,
        salt: 'IbZcp1FSHYQp2YbZ+HIcpIspzftoBzjb5eEbMA==',
        storedKey: 'GEdW+1QhgEfXt5f07RtGPcveFbUj2zA/Et8/zldq/M8=',
        serverKey: 'JPgtMRtTa2mHTNOhTeK+XiOxPceFJYauwx0HqID1vm4='
      }
    },
    authenticationRestrictions: [
      { clientSource: [ '127.0.0.1' ], serverAddress: [ '127.0.0.1' ] },
      {
        clientSource: [ '172.31.0.0/16', '252.32.0.0/12' ],
        serverAddress: [ '172.31.0.0/16', '252.32.0.0/12' ]
      }
    ],
    roles: [
      { role: 'readWrite', db: 'admin' },
      { role: 'clusterMonitor', db: 'admin' },
      { role: 'backup', db: 'admin' },
      { role: 'restore', db: 'admin' },
      { role: 'pbmAnyAction', db: 'admin' }
    ]
  }
]
```

## 🔬 Automated testing steps
<!--- Describe the unit and integration tests that you added -->
<!--- to ensure that this feature works as expected. Include details -->
<!--- on the positive and negative test cases, as well as any changes -->
<!--- made to the existing tests to ensure they are still relevant. -->

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] I have added or updated any relevant documentation.
- [ ] I have read the [**CONTRIBUTING**](../blob/8/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
