### PR TITLE
patch: migrate docs domain to canonical.com/data/mongodb/docs (6)

### DIFF
--- a/docs/_static/overwrite_links.js
+++ b/docs/_static/overwrite_links.js
@@ -1,0 +1,38 @@
+ // Replaces oldDomain with newDomain in relevant anchor tags
+ const RtDHostedDomain = 'canonical-mongodb-migration.readthedocs-hosted.com';
+ const newDomain = 'canonical.com/data/mongodb/docs';
+
+ function escapeRegExp(value) {
+     return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+ }
+
+ function overwriteMatchingAnchorUrls(container) {
+     if (!container) return;
+
+     const anchors = container.querySelectorAll('a[href], link[href]');
+     const RtDHostedDomainRegex = new RegExp(escapeRegExp(RtDHostedDomain), 'g');
+
+     anchors.forEach(anchor => {
+         anchor.href = anchor.href.replace(RtDHostedDomainRegex, newDomain);
+     });
+ }
+
+ overwriteMatchingAnchorUrls(document.querySelector('header'));
+
+ // Use a MutationObserver to wait for the RTD flyout element to appear in the DOM
+ const observer = new MutationObserver(function(mutations, obs) {
+
+     const rtdFlyout = document.querySelector('readthedocs-flyout');
+     if (!rtdFlyout) return;
+
+     obs.disconnect();
+
+     rtdFlyout.addEventListener('click', function() {
+         const shadowRoot = rtdFlyout.shadowRoot;
+         if (!shadowRoot) return;
+
+         overwriteMatchingAnchorUrls(shadowRoot);
+     });
+ });
+
+ observer.observe(document.body, { childList: true, subtree: true });

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -44,6 +44,7 @@ copyright = f"{datetime.date.today().year}"
 
 html_title = project + " 6" + " documentation"
 
+version_slug = f"{os.environ.get('READTHEDOCS_VERSION', 'local')}"
 
 # Documentation website URL
 #
@@ -52,8 +53,7 @@ html_title = project + " 6" + " documentation"
 # NOTE: The Open Graph Protocol (OGP) enhances page display in a social graph
 #       and is used by social media platforms; see https://ogp.me/
 
-ogp_site_url = "https://canonical-charmed-mongodb.readthedocs-hosted.com/"
-
+ogp_site_url = f"https://canonical.com/data/mongodb/docs/{version_slug}/"
 
 # Preview name of the documentation website
 #
@@ -178,7 +178,7 @@ html_theme_options = {
 # TODO: If your documentation is hosted on https://docs.ubuntu.com/,
 #       uncomment and update as needed.
 
-# slug = ''
+slug = slug = 'data/mongodb/docs'  # Use the slug pattern from your URL pattern dropdown
 
 #######################
 # Sitemap configuration: https://sphinx-sitemap.readthedocs.io/
@@ -186,7 +186,7 @@ html_theme_options = {
 
 # Use RTD canonical URL to ensure duplicate pages have a specific canonical URL
 
-html_baseurl = os.environ.get("READTHEDOCS_CANONICAL_URL", "/")
+html_baseurl = f"https://canonical.com/data/mongodb/docs/{version_slug}/"
 
 # sphinx-sitemap uses html_baseurl to generate the full URL for each page:
 
@@ -211,7 +211,7 @@ sitemap_excludes = [
 # Template and asset locations #
 ################################
 
-# html_static_path = ["_static"]
+html_static_path = ["_static"]
 templates_path = ["_templates"]
 
 
@@ -317,6 +317,7 @@ html_css_files = [
 
 html_js_files = [
     "https://assets.ubuntu.com/v1/287a5e8f-bundle.js",
+    "js/overwrite_links.js"
 ]
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -317,7 +317,7 @@ html_css_files = [
 
 html_js_files = [
     "https://assets.ubuntu.com/v1/287a5e8f-bundle.js",
-    "js/overwrite_links.js"
+    "overwrite_links.js"
 ]
 
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷️ Type of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tooling and CI
- [ ] Dependencies upgrade or change
- [ ] Chores / refactoring

## 📝 Description

This PR adds the necessary configurations for our internal [Read The Docs proxy](https://documentation.ubuntu.com/rtd-proxy/) to redirect our docs to `canonical.com/data/mongodb/docs`. 

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have added or updated any relevant documentation.
- [x] I have read the [**CONTRIBUTING**](../blob/8/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
