### PR TITLE
patch(DPE-10802): Use json output for backups

### DIFF
--- a/single_kernel_mongo/managers/backups/common.py
+++ b/single_kernel_mongo/managers/backups/common.py
@@ -277,21 +277,22 @@ class CommonBackupManager(Object, BackupConfigManager, AbstractManagerStatus[Cha
         If PMB returen any other error, the function will raise BackupError.
         """
         try:
-            output = self.workload.run_bin_command(
+            output_str = self.workload.run_bin_command(
                 "backup",
+                ["--out", "json"],
                 environment=self.environment,
-            )
-            backup_id_match = re.search(
-                r"Starting backup '(?P<backup_id>\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z)'",
-                output,
-            )
-            return backup_id_match.group("backup_id") if backup_id_match else "N/A"
+            ).strip()
+            output = json.loads(output_str)
+            return output.get("name", "N/A")
         except WorkloadExecError as e:
             error_message = e.stdout
             if "Resync" in error_message:
                 raise ResyncError from e
 
             fail_message = f"Backup failed: {str(e)}"
+            raise BackupError(fail_message)
+        except json.JSONDecodeError:
+            fail_message = f"Backup failed: {output_str}"  # pyright: ignore[reportPossiblyUnboundVariable]
             raise BackupError(fail_message)
 
     def list_backup_action(self) -> str:

--- a/tests/unit/test_backup_manager.py
+++ b/tests/unit/test_backup_manager.py
@@ -265,11 +265,11 @@ def test_create_backup_success(
 
     mocker.patch(
         "single_kernel_mongo.core.vm_workload.VMWorkload.run_bin_command",
-        return_value="Starting backup '2024-11-25T15:05:40Z'",
+        return_value='{"name": "2024-11-25T15:05:40Z", "storagePath": ""}\n',
     )
     mocker.patch(
         "single_kernel_mongo.core.k8s_workload.KubernetesWorkload.run_bin_command",
-        return_value="Starting backup '2024-11-25T15:05:40Z'",
+        return_value='{"name": "2024-11-25T15:05:40Z", "storagePath": ""}\n',
     )
 
     backup_id = backup_manager.create_backup_action()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷️ Type of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling and CI
- [ ] Dependencies upgrade or change
- [ ] Chores / refactoring

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and feature scope of this PR (what)
  - the motivation behind this change (why)
  - the impacted components (often matches conventional commit scope)
  - explanation/algorithm if required (how)
-->
String parsing failed with latest PBM because formatting changed from double quotes to single quotes.
Let's use the json output that is machine readable and does not require fragile regexes.

## 🧪 Manual testing steps
<!--- Give a list of instructions to manually test your change. -->
<!--- These instructions are meant for reviewers to test the PR -->
<!--- on their development environment. -->

Create a backup and ensure the backup id is displayed correctly.

## 🔬 Automated testing steps
<!--- Describe the unit and integration tests that you added -->
<!--- to ensure that this feature works as expected. Include details -->
<!--- on the positive and negative test cases, as well as any changes -->
<!--- made to the existing tests to ensure they are still relevant. -->
Updated UT.

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have added or updated any relevant documentation.
- [ ] I have read the [**CONTRIBUTING**](../blob/8/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
