### PR TITLE
patch: Improve HA test for db_step_down

### DIFF
--- a/tests/integration/helpers/ha.py
+++ b/tests/integration/helpers/ha.py
@@ -662,7 +662,7 @@ async def kill_unit_process(
         )
 
 
-async def db_step_down(
+async def db_step_down(  # noqa: C901
     ops_test: OpsTest, substrate: Substrate, primary_name: str, sigterm_time: float, app_name: str
 ):
     # loop through all units that aren't the old primary
@@ -671,11 +671,13 @@ async def db_step_down(
 
     if substrate == "lxd":
         ls_command_template = "ssh {unit_name} sudo ls {log_path}"
+        election_template = "ssh {unit_name} \"sudo grep 'ELECTION' {log_path}\""
         cat_command_template = (
             "ssh {unit_name} \"sudo grep 'Starting an election due to step up request' {log_path}\""
         )
     else:
         ls_command_template = "ssh  --container mongod {unit_name} ls {log_path}"
+        election_template = "ssh  --container mongod {unit_name} \"grep 'ELECTION' {log_path}\""
         cat_command_template = "ssh  --container mongod {unit_name} \"grep 'Starting an election due to step up request' {log_path}\""
 
     for unit in ops_test.model.applications[app_name].units:
@@ -687,6 +689,14 @@ async def db_step_down(
         if return_code == 2:
             logger.info(f"Missing file {log_path}")
             continue
+
+        # Observability: log all election lines
+        election_file = election_template.format(unit_name=unit.name, log_path=log_path)
+        _, _stdout, _ = await ops_test.juju(*shlex.split(election_file))
+        logger.info("BEGIN: ELECTION lines for %s", unit.name)
+        for line in _stdout.splitlines():
+            logger.info(line)
+        logger.info("END: ELECTION lines for %s", unit.name)
 
         # these log files can get quite large. According to the Juju team the 'run' command
         # cannot be used for more than 16MB of data so it is best to use juju ssh or juju scp.

--- a/tests/integration/helpers/ha.py
+++ b/tests/integration/helpers/ha.py
@@ -6,7 +6,6 @@
 
 import json
 import os
-import shlex
 import string
 import subprocess
 import tarfile
@@ -663,69 +662,61 @@ async def kill_unit_process(
 
 
 async def db_step_down(  # noqa: C901
-    ops_test: OpsTest, substrate: Substrate, primary_name: str, sigterm_time: float, app_name: str
-):
-    # loop through all units that aren't the old primary
-    app_name = await get_app_name(ops_test)
-    log_path = mongodb_log_path(substrate)
+    ops_test: OpsTest,
+    substrate: Substrate,
+    sigterm_time: float,
+    app_name: str,
+) -> bool:
+    """Checks that the DB has stepped down.
 
-    if substrate == "lxd":
-        ls_command_template = "ssh {unit_name} sudo ls {log_path}"
-        election_template = "ssh {unit_name} \"sudo grep 'ELECTION' {log_path}\""
-        cat_command_template = (
-            "ssh {unit_name} \"sudo grep 'Starting an election due to step up request' {log_path}\""
+    We check that by checking the reason of the last election in the metrics.
+    It can be stepUpRequest or stepUpRequestSkipDryRun.
+    We then confirm that it happened after the SIGTERM time.
+    """
+    assert ops_test.model
+
+    password = await get_password(
+        ops_test,
+        username=CHARMED_OPERATOR_USERNAME,
+        app_name=app_name,
+    )
+    replica_set_hosts = [
+        await get_address_of_unit(ops_test, substrate, int(unit.name.split("/")[1]), app_name)
+        for unit in ops_test.model.applications[app_name].units
+    ]
+
+    uri = await generate_mongodb_client(
+        ops_test, substrate, app_name, mongos=False, hosts=replica_set_hosts, password=password
+    )
+
+    result = await execute_on_mongod(ops_test, app_name, substrate, uri, "rs.status()")
+
+    if result.failed:
+        return False
+
+    election_metrics = result.data.get("electionCandidateMetrics", {})
+
+    if not election_metrics:
+        return False
+
+    reason = election_metrics.get("lastElectionReason", "")
+    election_date = election_metrics.get("lastElectionDate", {}).get("$date", None)
+    if not reason.startswith("stepUpRequest"):
+        logger.info(
+            "Reason is %s, should be one of 'stepUpRequest' or 'stepUpRequestSkipDryRun'", reason
         )
-    else:
-        ls_command_template = "ssh  --container mongod {unit_name} ls {log_path}"
-        election_template = "ssh  --container mongod {unit_name} \"grep 'ELECTION' {log_path}\""
-        cat_command_template = "ssh  --container mongod {unit_name} \"grep 'Starting an election due to step up request' {log_path}\""
+        return False
 
-    for unit in ops_test.model.applications[app_name].units:
-        if unit.name == primary_name:
-            continue
-        # verify log file exists on this machine
-        search_file = ls_command_template.format(unit_name=unit.name, log_path=log_path)
-        return_code, _, _ = await ops_test.juju(*search_file.split())
-        if return_code == 2:
-            logger.info(f"Missing file {log_path}")
-            continue
+    if not election_date:
+        logger.info("Missing election date")
+        return False
 
-        # Observability: log all election lines
-        election_file = election_template.format(unit_name=unit.name, log_path=log_path)
-        _, _stdout, _ = await ops_test.juju(*shlex.split(election_file))
-        logger.info("BEGIN: ELECTION lines for %s", unit.name)
-        for line in _stdout.splitlines():
-            logger.info(line)
-        logger.info("END: ELECTION lines for %s", unit.name)
+    election_ts = convert_time(election_date)
 
-        # these log files can get quite large. According to the Juju team the 'run' command
-        # cannot be used for more than 16MB of data so it is best to use juju ssh or juju scp.
-        cat_file = cat_command_template.format(unit_name=unit.name, log_path=log_path)
-        _, stdout, _ = await ops_test.juju(*shlex.split(cat_file))
+    if election_ts >= sigterm_time:
+        return True
 
-        for line in stdout.splitlines():
-            if not len(line):
-                continue
-
-            logger.info(line)
-            try:
-                item = json.loads(line)
-            except json.JSONDecodeError:
-                logger.warning("failed to parse line: %s", line)
-                continue
-
-            step_down_time = convert_time(item["t"]["$date"])
-            if (
-                "Starting an election due to step up request" in item.get("msg", "")
-                and step_down_time >= sigterm_time
-            ):
-                return True
-            if (
-                "Starting an election due to step up request" in line
-                and step_down_time < sigterm_time
-            ):
-                logger.warning(f"Step down: {step_down_time} < {sigterm_time}")
-
+    logger.info("Election time is %s, but sigterm time is %s", election_ts, sigterm_time)
     return False
 
 

--- a/tests/integration/helpers/ha.py
+++ b/tests/integration/helpers/ha.py
@@ -6,6 +6,7 @@
 
 import json
 import os
+import shlex
 import string
 import subprocess
 import tarfile
@@ -670,10 +671,12 @@ async def db_step_down(
 
     if substrate == "lxd":
         ls_command_template = "ssh {unit_name} sudo ls {log_path}"
-        cat_command_template = "ssh {unit_name} sudo cat {log_path}"
+        cat_command_template = (
+            "ssh {unit_name} \"sudo grep 'Starting an election due to step up request' {log_path}\""
+        )
     else:
         ls_command_template = "ssh  --container mongod {unit_name} ls {log_path}"
-        cat_command_template = "ssh  --container mongod {unit_name} cat {log_path}"
+        cat_command_template = "ssh  --container mongod {unit_name} \"grep 'Starting an election due to step up request' {log_path}\""
 
     for unit in ops_test.model.applications[app_name].units:
         if unit.name == primary_name:
@@ -688,17 +691,22 @@ async def db_step_down(
         # these log files can get quite large. According to the Juju team the 'run' command
         # cannot be used for more than 16MB of data so it is best to use juju ssh or juju scp.
         cat_file = cat_command_template.format(unit_name=unit.name, log_path=log_path)
-        _, stdout, _ = await ops_test.juju(*cat_file.split())
+        _, stdout, _ = await ops_test.juju(*shlex.split(cat_file))
 
         for line in stdout.splitlines():
             if not len(line):
                 continue
 
-            item = json.loads(line)
+            logger.info(line)
+            try:
+                item = json.loads(line)
+            except json.JSONDecodeError:
+                logger.warning("failed to parse line: %s", line)
+                continue
 
             step_down_time = convert_time(item["t"]["$date"])
             if (
-                "Starting an election due to step up request" in line
+                "Starting an election due to step up request" in item.get("msg", "")
                 and step_down_time >= sigterm_time
             ):
                 return True

--- a/tests/integration/mongodb/ha/test_ha.py
+++ b/tests/integration/mongodb/ha/test_ha.py
@@ -10,7 +10,7 @@ import pytest
 from juju import tag
 from pymongo import MongoClient
 from pytest_operator.plugin import OpsTest
-from tenacity import RetryError, Retrying, stop_after_delay, wait_fixed
+from tenacity import RetryError, Retrying, stop_after_attempt, stop_after_delay, wait_fixed
 
 from tests.integration.helpers.common import (
     CHARMED_OPERATOR_USERNAME,
@@ -790,9 +790,10 @@ async def test_restart_db_process(ops_test: OpsTest, substrate: Substrate, conti
     ), f"New primary {new_primary.name=} is equal to old primary {primary.name=}"
 
     # verify that a stepdown was performed on restart. SIGTERM should send a graceful restart and
-    # send a replica step down signal. Performed with a retry to give time for the logs to update.
+    # send a replica step down signal.
+    # We check using rs.status metrics information
     try:
-        for attempt in Retrying(stop=stop_after_delay(5 * 60), wait=wait_fixed(2)):
+        for attempt in Retrying(stop=stop_after_attempt(10), wait=wait_fixed(3)):
             with attempt:
                 assert await db_step_down(
                     ops_test, substrate, sig_term_time, app_name

--- a/tests/integration/mongodb/ha/test_ha.py
+++ b/tests/integration/mongodb/ha/test_ha.py
@@ -10,7 +10,7 @@ import pytest
 from juju import tag
 from pymongo import MongoClient
 from pytest_operator.plugin import OpsTest
-from tenacity import RetryError, Retrying, stop_after_attempt, stop_after_delay, wait_fixed
+from tenacity import RetryError, Retrying, stop_after_delay, wait_fixed
 
 from tests.integration.helpers.common import (
     CHARMED_OPERATOR_USERNAME,
@@ -792,10 +792,10 @@ async def test_restart_db_process(ops_test: OpsTest, substrate: Substrate, conti
     # verify that a stepdown was performed on restart. SIGTERM should send a graceful restart and
     # send a replica step down signal. Performed with a retry to give time for the logs to update.
     try:
-        for attempt in Retrying(stop=stop_after_attempt(10), wait=wait_fixed(3)):
+        for attempt in Retrying(stop=stop_after_delay(5 * 60), wait=wait_fixed(2)):
             with attempt:
                 assert await db_step_down(
-                    ops_test, substrate, primary.name, sig_term_time, app_name=app_name
+                    ops_test, substrate, sig_term_time, app_name
                 ), "old primary departed without stepping down."
     except RetryError:
         assert False, "old primary departed without stepping down."

--- a/tests/integration/mongodb/ha/test_ha.py
+++ b/tests/integration/mongodb/ha/test_ha.py
@@ -759,7 +759,9 @@ async def test_restart_db_process(ops_test: OpsTest, substrate: Substrate, conti
     assert other_unit, "No secondary unit found"
 
     # send SIGTERM, we expect `systemd` to restart the process
-    sig_term_time = datetime.now(timezone.utc).timestamp()
+    sig_term_dt = datetime.now(timezone.utc)
+    logger.info("SIGTERM TIME is %s", sig_term_dt)
+    sig_term_time = sig_term_dt.timestamp()
     await kill_unit_process(
         ops_test, substrate, primary.name, kill_code="SIGTERM", app_name=app_name
     )


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷️ Type of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [x] Tooling and CI
- [ ] Dependencies upgrade or change
- [ ] Chores / refactoring

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and feature scope of this PR (what)
  - the motivation behind this change (why)
  - the impacted components (often matches conventional commit scope)
  - explanation/algorithm if required (how)
-->
Microk8S HA tests where incredibly flaky without proper reason.
This PR improves the way we check that the db has stepped down and another unit has stepped up, by using the metrics data available through `rs.status()` instead of trying to parse the logs (which could be outdated, not yet flushed, rotated, etc).


## 🧪 Manual testing steps
<!--- Give a list of instructions to manually test your change. -->
<!--- These instructions are meant for reviewers to test the PR -->
<!--- on their development environment. -->

N/A

## 🔬 Automated testing steps
<!--- Describe the unit and integration tests that you added -->
<!--- to ensure that this feature works as expected. Include details -->
<!--- on the positive and negative test cases, as well as any changes -->
<!--- made to the existing tests to ensure they are still relevant. -->
Fixes automated testing.

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have added or updated any relevant documentation.
- [ ] I have read the [**CONTRIBUTING**](../blob/8/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
