### PR TITLE
patch: MongoDB 8.0.28 and PBM Agent log file

### DIFF
--- a/single_kernel_mongo/managers/backups/common.py
+++ b/single_kernel_mongo/managers/backups/common.py
@@ -231,6 +231,18 @@ class CommonBackupManager(Object, BackupConfigManager, AbstractManagerStatus[Cha
         """Validates that the S3/GCS config is complete."""
         raise NotImplementedError
 
+    def prepare_log_dir(self) -> None:
+        """Prepares the log directory for PBM agent."""
+        if not self.workload.exists(self.workload.paths.pbm_agent_log_dir):
+            self.workload.mkdir(self.workload.paths.pbm_agent_log_dir, make_parents=True)
+            self.workload.exec(
+                [
+                    "chown",
+                    f"{self.workload.users.user}:{self.workload.users.group}",
+                    f"{self.workload.paths.pbm_agent_log_dir}",
+                ]
+            )
+
     def cleanup_certs_and_restart(self, relation: Relation) -> None:
         """On relation broken event, we need to remove the certificate from the trust store."""
         if self.state.is_scaling_down(relation.id):

--- a/single_kernel_mongo/managers/config.py
+++ b/single_kernel_mongo/managers/config.py
@@ -46,6 +46,7 @@ from single_kernel_mongo.workload import (
     get_pbm_workload_for_substrate,
     get_vault_agent_workload_for_substrate,
 )
+from single_kernel_mongo.workload.backup_workload import PBMWorkload
 from single_kernel_mongo.workload.log_rotate_workload import LogRotateWorkload
 from single_kernel_mongo.workload.vault_agent_workload import VaultAgentWorkload
 
@@ -129,9 +130,14 @@ class BackupConfigManager(CommonConfigManager):
         state: CharmState,
         container: Container | None,
     ):
-        self.config = config
-        self.workload = get_pbm_workload_for_substrate(substrate)(role=role, container=container)
-        self.state = state
+        self.config: MongoConfigModel = config
+        self.workload: PBMWorkload = get_pbm_workload_for_substrate(substrate)(
+            role=role, container=container
+        )
+        self.state: CharmState = state
+        self.agent_config: dict[str, dict[str, str | bool]] = {
+            "log": {"path": f"{self.workload.paths.pbm_agent_log_file}", "level": "I", "json": True}
+        }
 
     @override
     def build_parameters(self) -> list[list[str]]:
@@ -140,6 +146,13 @@ class BackupConfigManager(CommonConfigManager):
                 self.state.backup_config.uri,
             ]
         ]
+
+    def write_config_file(self):
+        """Write the configuration for PBM."""
+        if not self.workload.exists(self.workload.paths.pbm_agent_config_path):
+            self.workload.write(
+                path=self.workload.paths.pbm_agent_config_path, content=safe_dump(self.agent_config)
+            )
 
     def configure_and_restart(self, force: bool = False):
         """Sets up PBM with right configuration and restarts it."""
@@ -157,6 +170,9 @@ class BackupConfigManager(CommonConfigManager):
         if not self.state.get_user_password(CharmedBackupUser):
             logger.info("PBM cannot be configured and restarted: No password found.")
             return
+
+        # Write the configuration for PBM
+        self.write_config_file()
 
         if (
             not self.workload.active()

--- a/single_kernel_mongo/managers/mongodb_operator.py
+++ b/single_kernel_mongo/managers/mongodb_operator.py
@@ -1564,11 +1564,16 @@ class MongoDBOperator(OperatorProtocol, Object):
             return MongoDBStatuses.INVALID_MONGOS_REL.value
         return None
 
+    @override
     def _configure_workloads(self) -> None:
         """Handle filesystem interactions for charm configuration."""
         # Configure the workloads
         self.config_manager.set_environment()
         self.mongos_config_manager.set_environment()
+
+        # Write the PBM Agent config file.
+        self.s3_backup_manager.prepare_log_dir()
+        self.s3_backup_manager.write_config_file()
 
         # Instantiate the keyfile
         self.instantiate_keyfile()

--- a/single_kernel_mongo/workload/backup_workload.py
+++ b/single_kernel_mongo/workload/backup_workload.py
@@ -16,12 +16,27 @@ from single_kernel_mongo.exceptions import WorkloadServiceError
 
 
 class PBMPaths(MongoPaths):
-    """PBM Specific paths."""
+    """Vault Agent specific paths."""
 
     @property
     def pbm_config(self) -> Path:
         """PBM Configuration file path."""
         return Path(f"{self.etc_path}/pbm/pbm_config.yaml")
+
+    @property
+    def pbm_agent_config_path(self) -> Path:
+        """PBM Agent configuration file path."""
+        return Path(f"{self.etc_path}/pbm/pbm-agent.yaml")
+
+    @property
+    def pbm_agent_log_dir(self) -> Path:
+        """PBM Agent log dir."""
+        return Path(f"{self.var_path}/log/pbm")
+
+    @property
+    def pbm_agent_log_file(self) -> Path:
+        """PBM Agent log file."""
+        return Path(f"{self.var_path}/log/pbm/pbm-agent.json")
 
 
 class PBMWorkload(WorkloadBase):
@@ -36,7 +51,7 @@ class PBMWorkload(WorkloadBase):
 
     def __init__(self, role: CharmSpec, container: Container | None) -> None:
         super().__init__(role, container)
-        self.paths = PBMPaths(self.role)
+        self.paths: PBMPaths = PBMPaths(self.role)
 
     @property
     @override
@@ -53,7 +68,7 @@ class PBMWorkload(WorkloadBase):
                     self.service: {
                         "override": "replace",
                         "summary": "pbm",
-                        "command": "/usr/bin/pbm-agent",
+                        "command": f"/usr/bin/pbm-agent -f {self.paths.pbm_agent_config_path}",
                         "startup": "enabled",
                         "user": self.users.user,
                         "group": self.users.group,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1235,11 +1235,15 @@ def test_pbm_connect_not_active(harness: Harness[MongoTestCharm], mocker):
     mock_set_env = mocker.patch(
         "single_kernel_mongo.managers.config.BackupConfigManager.set_environment"
     )
+    mock_write_config_file = mocker.patch(
+        "single_kernel_mongo.managers.config.BackupConfigManager.write_config_file"
+    )
 
     harness.charm.operator.s3_backup_manager.configure_and_restart()
     mock_start.assert_called()
     mock_stop.assert_called()
     mock_set_env.assert_called()
+    mock_write_config_file.assert_called()
 
 
 def test_pbm_connect_active_other_password(harness: Harness[MongoTestCharm], mocker):
@@ -1259,6 +1263,9 @@ def test_pbm_connect_active_other_password(harness: Harness[MongoTestCharm], moc
     mock_set_env = mocker.patch(
         "single_kernel_mongo.managers.config.BackupConfigManager.set_environment"
     )
+    mock_write_config_file = mocker.patch(
+        "single_kernel_mongo.managers.config.BackupConfigManager.write_config_file"
+    )
     mocker.patch(
         "single_kernel_mongo.managers.config.BackupConfigManager.get_environment",
         return_value="deadbeef",
@@ -1268,6 +1275,7 @@ def test_pbm_connect_active_other_password(harness: Harness[MongoTestCharm], moc
     mock_start.assert_called()
     mock_stop.assert_called()
     mock_set_env.assert_called()
+    mock_write_config_file.assert_called()
 
 
 def test_relation_joined_non_leader_does_nothing(harness: Harness[MongoTestCharm], mocker):

--- a/tests/unit/test_mongodb_workload.py
+++ b/tests/unit/test_mongodb_workload.py
@@ -111,8 +111,8 @@ def test_pbm_workload_init(monkeypatch):
 
     workload._env = "test"
     assert workload.paths == MongoPaths(ROLES["vm"]["mongod"])
-    assert workload.paths.pbm_config == Path(
-        "/var/snap/charmed-mongodb/current/etc/pbm/pbm_config.yaml"
+    assert workload.paths.pbm_agent_config_path == Path(
+        "/var/snap/charmed-mongodb/current/etc/pbm/pbm-agent.yaml"
     )
     assert workload.env_var == "PBM_MONGODB_URI"
     assert workload.role == ROLES["vm"]["mongod"]
@@ -125,7 +125,7 @@ def test_pbm_workload_init(monkeypatch):
                 "pbm-agent": {
                     "override": "replace",
                     "summary": "pbm",
-                    "command": "/usr/bin/pbm-agent",
+                    "command": "/usr/bin/pbm-agent -f /var/snap/charmed-mongodb/current/etc/pbm/pbm-agent.yaml",
                     "startup": "enabled",
                     "user": VmUser.user,  # type: ignore
                     "group": VmUser.group,  # type: ignore


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- markdownlint-disable MD041 -->

## 🏷️ Type of changes
<!--- What types of changes does your code introduce? -->
<!--- Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Tooling and CI
- [x] Dependencies upgrade or change
- [ ] Chores / refactoring

## 📝 Description
<!--
Describe your changes in detail including:
  - the purpose and feature scope of this PR (what)
  - the motivation behind this change (why)
  - the impacted components (often matches conventional commit scope)
  - explanation/algorithm if required (how)
-->
* PBM 8.0.28
* PBM Agent log file: Configure PBM Agent with a config file to have it logged into a dedicated file.

## 🧪 Manual testing steps
<!--- Give a list of instructions to manually test your change. -->
<!--- These instructions are meant for reviewers to test the PR -->
<!--- on their development environment. -->

```text
1. juju deploy <my-app>
2. …
```

## 🔬 Automated testing steps
<!--- Describe the unit and integration tests that you added -->
<!--- to ensure that this feature works as expected. Include details -->
<!--- on the positive and negative test cases, as well as any changes -->
<!--- made to the existing tests to ensure they are still relevant. -->

## ✅ Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My code follows the code style of this project.
- [ ] I have added or updated any relevant documentation.
- [ ] I have read the [**CONTRIBUTING**](../blob/8/edge/CONTRIBUTING.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
